### PR TITLE
Print on set

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -14,14 +14,14 @@ var (
 	version = "master"
 )
 
-func main() {
-	log.SetFlags(0)
+const usage = `Usage: task [-ifw] [--init] [--force] [--watch] [task...]
 
-	pflag.Usage = func() {
-		fmt.Println(`task [target1 target2 ...]: Runs commands under targets like make.
+Runs the specified task(s). Falls back to the "default" task if no task name
+was specified, or lists all tasks if an unknown task name was specified.
 
-Example: 'task hello' with the following 'Taskfile.yml' file will generate
-an 'output.txt' file.
+Example: 'task hello' with the following 'Taskfile.yml' file will generate an
+'output.txt' file with the content "hello".
+
 '''
 hello:
   cmds:
@@ -30,7 +30,13 @@ hello:
   generates:
     - output.txt
 '''
-`)
+`
+
+func main() {
+	log.SetFlags(0)
+
+	pflag.Usage = func() {
+		fmt.Println(usage)
 		pflag.PrintDefaults()
 	}
 

--- a/task.go
+++ b/task.go
@@ -249,8 +249,8 @@ func (e *Executor) runCommand(ctx context.Context, task string, i int) error {
 		Stderr:  e.Stderr,
 	}
 
+	e.println(c)
 	if t.Set == "" {
-		e.println(c)
 		opts.Stdout = e.Stdout
 		if err = execext.RunCommand(opts); err != nil {
 			return err


### PR DESCRIPTION
Enables printing of the run command, even when "set" is specified. I don't know if this is what we want, but it felt more consistent. I would have raised an issue first, but since the change was so small, I thought I would skip directly to the PR instead.

This PR also updates the help text to follow standard conventions. I renamed "target" in the help text to "task", since "target" often refers to the "target output file name".

Feel free to reject or request changes.