### PR TITLE
Allow template evaluation when calling a task with vars

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -30,13 +30,15 @@ hello:
   generates:
     - output.txt
 '''
+
+Options:
 `
 
 func main() {
 	log.SetFlags(0)
 
 	pflag.Usage = func() {
-		fmt.Println(usage)
+		fmt.Print(usage)
 		pflag.PrintDefaults()
 	}
 

--- a/task.go
+++ b/task.go
@@ -237,7 +237,15 @@ func (e *Executor) runCommand(ctx context.Context, task string, i int, vars Vars
 	cmd := t.Cmds[i]
 
 	if cmd.Cmd == "" {
-		return e.RunTask(ctx, cmd.Task, cmd.Vars)
+		cmdVars := make(Vars, len(cmd.Vars))
+		for k, v := range cmd.Vars {
+			v, err := e.ReplaceVariables(v, task, vars)
+			if err != nil {
+				return err
+			}
+			cmdVars[k] = v
+		}
+		return e.RunTask(ctx, cmd.Task, cmdVars)
 	}
 
 	c, err := e.ReplaceVariables(cmd.Cmd, task, vars)

--- a/task_test.go
+++ b/task_test.go
@@ -178,6 +178,7 @@ func TestParams(t *testing.T) {
 		{"exclamation.txt", "!\n"},
 		{"dep1.txt", "Dependence1\n"},
 		{"dep2.txt", "Dependence2\n"},
+		{"spanish.txt", "¡Holla mundo!\n"},
 	}
 
 	for _, f := range files {

--- a/testdata/params/Taskfile.yml
+++ b/testdata/params/Taskfile.yml
@@ -1,4 +1,6 @@
 default:
+  vars:
+    SPANISH: ¡Holla mundo!
   deps:
     - task: write-file
       vars: {CONTENT: Dependence1, FILE: dep1.txt}
@@ -11,6 +13,8 @@ default:
       vars: {CONTENT: "$echo 'World'", FILE: world.txt}
     - task: write-file
       vars: {CONTENT: "!", FILE: exclamation.txt}
+    - task: write-file
+      vars: {CONTENT: "{{.SPANISH}}", FILE: spanish.txt}
 
 write-file:
   cmds:


### PR DESCRIPTION
Fixes issue #38 by allowing for template evaluation when calling a task with override variables:

```yaml
echo:
  cmds:
    - "echo {{.MYVAR}}"
default:
  vars:
    PLEASE: "awesome"
  cmds:
    - task: echo
      vars: {MYVAR: "{{.PLEASE}}"}
```