### PR TITLE
better error output for dynamic variables in Taskvars.yml

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -52,3 +52,12 @@ type cantWatchNoSourcesError struct {
 func (err *cantWatchNoSourcesError) Error() string {
 	return fmt.Sprintf(`task: Can't watch task "%s" because it has no specified sources`, err.taskName)
 }
+
+type dynamicVarError struct {
+	cause error
+	cmd   string
+}
+
+func (err *dynamicVarError) Error() string {
+	return fmt.Sprintf(`task: Command "%s" in taskvars file failed: %s`, err.cmd, err.cause)
+}

--- a/variable_handling.go
+++ b/variable_handling.go
@@ -41,7 +41,7 @@ func (e *Executor) handleDynamicVariableContent(value string) (string, error) {
 		Stderr:  e.Stderr,
 	}
 	if err := execext.RunCommand(opts); err != nil {
-		return "", err
+		return "", &dynamicVarError{cause: err, cmd: opts.Command}
 	}
 
 	result := buff.String()


### PR DESCRIPTION
If you have errors in Taskvars.yml file it can get difficult to debug.

Without this pull request you got the error:

```bash
$ task build-web
exit status 127
```

With this pull request:

```bash
$ task build-web
task: Command "gite show -s --pretty=format:%cI" in taskvars file failed: exit status 127
```