### PR TITLE
Bugfix: allow templating when calling deps

### DIFF
--- a/task.go
+++ b/task.go
@@ -165,8 +165,16 @@ func (e *Executor) runDeps(ctx context.Context, call Call) error {
 			if err != nil {
 				return err
 			}
+			depVars := make(Vars, len(d.Vars))
+			for k, v := range d.Vars {
+				v, err := e.ReplaceVariables(v, call)
+				if err != nil {
+					return err
+				}
+				depVars[k] = v
+			}
 
-			return e.RunTask(ctx, Call{Task: dep, Vars: d.Vars})
+			return e.RunTask(ctx, Call{Task: dep, Vars: depVars})
 		})
 	}
 

--- a/task_test.go
+++ b/task_test.go
@@ -179,6 +179,7 @@ func TestParams(t *testing.T) {
 		{"dep1.txt", "Dependence1\n"},
 		{"dep2.txt", "Dependence2\n"},
 		{"spanish.txt", "¡Holla mundo!\n"},
+		{"spanish-dep.txt", "¡Holla dependencia!\n"},
 	}
 
 	for _, f := range files {

--- a/testdata/params/Taskfile.yml
+++ b/testdata/params/Taskfile.yml
@@ -6,6 +6,8 @@ default:
       vars: {CONTENT: Dependence1, FILE: dep1.txt}
     - task: write-file
       vars: {CONTENT: Dependence2, FILE: dep2.txt}
+    - task: write-file
+      vars: {CONTENT: "{{.SPANISH|replace \"mundo\" \"dependencia\"}}", FILE: spanish-dep.txt}
   cmds:
     - task: write-file
       vars: {CONTENT: Hello, FILE: hello.txt}


### PR DESCRIPTION
Fixes issue #42 by allowing for template evaluatation on task override
variables when the task is launched as dependency.