### PR TITLE
Resolve issues with template- and dynamic variable resolution order and improve testing

### DIFF
--- a/testdata/params/Taskfile.yml
+++ b/testdata/params/Taskfile.yml
@@ -1,7 +1,8 @@
 default:
   vars:
     SPANISH: ¡Holla mundo!
-    PORTUGUESE: "{{.PORTUGUESE}}"
+    PORTUGUESE: "{{.PORTUGUESE_HELLO_WORLD}}"
+    GERMAN: "Welt!"
   deps:
     - task: write-file
       vars: {CONTENT: Dependence1, FILE: dep1.txt}
@@ -20,7 +21,17 @@ default:
       vars: {CONTENT: "{{.SPANISH}}", FILE: spanish.txt}
     - task: write-file
       vars: {CONTENT: "{{.PORTUGUESE}}", FILE: portuguese.txt}
+    - task: write-file
+      vars: {CONTENT: "{{.GERMAN}}", FILE: german.txt}
+    - task: non-default
 
 write-file:
   cmds:
     - echo {{.CONTENT}} > {{.FILE}}
+
+non-default:
+  vars:
+    PORTUGUESE: "{{.PORTUGUESE_HELLO_WORLD}}"
+  cmds:
+    - task: write-file
+      vars: {CONTENT: "{{.PORTUGUESE}}", FILE: portuguese2.txt}

--- a/testdata/params/Taskvars.yml
+++ b/testdata/params/Taskvars.yml
@@ -1,1 +1,2 @@
-PORTUGUESE: Olá, mundo!
+PORTUGUESE_HELLO_WORLD: Olá, mundo!
+GERMAN: "Hello"

--- a/testdata/vars/Taskfile.yml
+++ b/testdata/vars/Taskfile.yml
@@ -7,17 +7,49 @@ hello:
     - echo {{.FOO}} > foo.txt
     - echo {{.BAR}} > bar.txt
     - echo {{.BAZ}} > baz.txt
+    - echo '{{.TMPL_FOO}}' > tmpl_foo.txt
+    - echo '{{.TMPL_BAR}}' > tmpl_bar.txt
+    - echo '{{.TMPL_FOO2}}' > tmpl_foo2.txt
+    - echo '{{.TMPL_BAR2}}' > tmpl_bar2.txt
+    - echo '{{.SHTMPL_FOO}}' > shtmpl_foo.txt
+    - echo '{{.SHTMPL_FOO2}}' > shtmpl_foo2.txt
+    - echo '{{.NESTEDTMPL_FOO}}' > nestedtmpl_foo.txt
+    - echo '{{.NESTEDTMPL_FOO2}}' > nestedtmpl_foo2.txt
     - echo {{.FOO2}} > foo2.txt
     - echo {{.BAR2}} > bar2.txt
     - echo {{.BAZ2}} > baz2.txt
+    - echo '{{.TMPL2_FOO}}' > tmpl2_foo.txt
+    - echo '{{.TMPL2_BAR}}' > tmpl2_bar.txt
+    - echo '{{.TMPL2_FOO2}}' > tmpl2_foo2.txt
+    - echo '{{.TMPL2_BAR2}}' > tmpl2_bar2.txt
+    - echo '{{.SHTMPL2_FOO}}' > shtmpl2_foo.txt
+    - echo '{{.SHTMPL2_FOO2}}' > shtmpl2_foo2.txt
+    - echo '{{.NESTEDTMPL2_FOO2}}' > nestedtmpl2_foo2.txt
     - echo {{.EQUAL}} > equal.txt
+    - echo {{.OVERRIDE}} > override.txt
   vars:
     FOO: foo
     BAR: $echo bar
     BAZ:
       sh: echo baz
+    TMPL_FOO: "{{.FOO}}"
+    TMPL_BAR: "{{.BAR}}"
+    TMPL_FOO2: "{{.FOO2}}"
+    TMPL_BAR2: "{{.BAR2}}"
+    SHTMPL_FOO:
+      sh: "echo '{{.FOO}}'"
+    SHTMPL_FOO2:
+      sh: "echo '{{.FOO2}}'"
+    NESTEDTMPL_FOO: "{{.TMPL_FOO}}"
+    NESTEDTMPL_FOO2: "{{.TMPL2_FOO2}}"
+    OVERRIDE: "bar"
 
 set-equal:
   set: EQUAL
   cmds:
     - echo foo=bar
+
+invalid-var-tmpl:
+  vars:
+    CHARS: "abcd"
+    INVALID: "{{range .CHARS}}no end"

--- a/testdata/vars/Taskvars.yml
+++ b/testdata/vars/Taskvars.yml
@@ -2,3 +2,11 @@ FOO2: foo2
 BAR2: $echo bar2
 BAZ2:
   sh: echo baz2
+TMPL2_FOO: "{{.FOO}}"
+TMPL2_BAR: "{{.BAR}}"
+TMPL2_FOO2: "{{.FOO2}}"
+TMPL2_BAR2: "{{.BAR2}}"
+SHTMPL2_FOO2:
+  sh: "echo '{{.FOO2}}'"
+NESTEDTMPL2_FOO2: "{{.TMPL2_FOO2}}"
+OVERRIDE: "foo"


### PR DESCRIPTION
UPDATE: This PR now ensures:
- Template evaluation finds placed _before_ copying the task for execution
- Template evaluation finds place _before_ dynamic variables are resolved
- Variable _priority order_ is in line with the documentation (also for default/named task)
- Template evaluation gets access to the following variables:
   - Taskvars.yml: uncompiled static Taskvars.yml overwritten by environment variables.
   - Task variables: resolved Taskvars.yml overwritten by uncompiled static task variables, environment variables and fully _resolved_ call parameters.
   - Everything _inside_ a task: fully resolved variables for the task.

PS! This is now possible:
```yaml
task:
   vars:
       A: "no templating or sh:"
       B: "{{.A}}"
```

These changes should finally resolve issue #40, and ensure it keeps working.