### PR TITLE
Cancel and restart long running process on file change by using context.WithCancel(..)

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -23,6 +23,7 @@ func (e *Executor) watchTasks(args ...string) error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	for _, a := range args {
+		a := a
 		go func() {
 			if err := e.RunTask(ctx, Call{Task: a}); err != nil && !isCtxErr(err) {
 				e.println(err)
@@ -52,6 +53,7 @@ loop:
 			cancel()
 			ctx, cancel = context.WithCancel(context.Background())
 			for _, a := range args {
+				a := a
 				go func() {
 					if err := e.RunTask(ctx, Call{Task: a}); err != nil && !isCtxErr(err) {
 						e.println(err)

--- a/watch.go
+++ b/watch.go
@@ -15,9 +15,11 @@ func (e *Executor) watchTasks(args ...string) error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	for _, a := range args {
-		if err := e.RunTask(ctx, Call{Task: a}); err != nil {
-			e.println(err)
-		}
+		go func() {
+			if err := e.RunTask(ctx, Call{Task: a}); err != nil {
+				e.println(err)
+			}
+		}()
 	}
 
 	watcher, err := fsnotify.NewWatcher()

--- a/watch.go
+++ b/watch.go
@@ -13,12 +13,18 @@ import (
 func (e *Executor) watchTasks(args ...string) error {
 	e.printfln("task: Started watching for tasks: %s", strings.Join(args, ", "))
 
-	// run tasks on init
+	taskCancellers := map[string]context.CancelFunc{}
+
 	for _, a := range args {
-		if err := e.RunTask(context.Background(), Call{Task: a}); err != nil {
-			e.println(err)
-			break
-		}
+		// Use of goroutines means task order is not guaranteed.
+		// Not sure if task order is a requirement. (jackmordaunt)
+		go func(a string) {
+			ctx, cancel := context.WithCancel(context.Background())
+			taskCancellers[a] = cancel
+			if err := e.RunTask(ctx, Call{Task: a}); err != nil {
+				e.println(err)
+			}
+		}(a)
 	}
 
 	watcher, err := fsnotify.NewWatcher()
@@ -41,10 +47,20 @@ loop:
 		select {
 		case <-watcher.Events:
 			for _, a := range args {
-				if err := e.RunTask(context.Background(), Call{Task: a}); err != nil {
-					e.println(err)
-					continue loop
+				if cancel, ok := taskCancellers[a]; ok {
+					cancel()
 				}
+			}
+			for _, a := range args {
+				// Use of goroutines means task order is not guaranteed.
+				// Not sure if task order is a requirement. (jackmordaunt)
+				go func(a string) {
+					ctx, cancel := context.WithCancel(context.Background())
+					taskCancellers[a] = cancel
+					if err := e.RunTask(ctx, Call{Task: a}); err != nil {
+						e.println(err)
+					}
+				}(a)
 			}
 		case err := <-watcher.Errors:
 			e.println(err)

--- a/watch.go
+++ b/watch.go
@@ -44,13 +44,11 @@ loop:
 			cancel()
 			ctx, cancel = context.WithCancel(context.Background())
 			for _, a := range args {
-				// Use of goroutines means task order is not guaranteed.
-				// Not sure if task order is a requirement. (jackmordaunt)
-				go func(a string) {
+				go func() {
 					if err := e.RunTask(ctx, Call{Task: a}); err != nil {
 						e.println(err)
 					}
-				}(a)
+				}()
 			}
 		case err := <-watcher.Errors:
 			e.println(err)

--- a/watch.go
+++ b/watch.go
@@ -46,7 +46,6 @@ func (e *Executor) watchTasks(args ...string) error {
 		}
 	}()
 
-loop:
 	for {
 		select {
 		case <-watcher.Events:
@@ -62,7 +61,6 @@ loop:
 			}
 		case err := <-watcher.Errors:
 			e.println(err)
-			continue loop
 		}
 	}
 }


### PR DESCRIPTION
Tasks are now called in a goroutine meaning the order of completion is *not* guaranteed. 
I'm not sure if task order is a requirement.

The reason they have to be called in a `goroutine` is because long running tasks would block `watchTasks(..)`, such that it doesn't read-in file change events.

The `goroutines` don't leak because the `context.CancelFunc` cancels the currently executing Task, causing `Executor.RunTask(..)` to return, thus exiting the `goroutine`.

I tested it locally and it appears to work correctly: long running processes are cancelled and re-started when a file change event occurs.

Resolves #60 