### PR TITLE
Added suport for multiline variables from sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ write-file:
 The above syntax is also supported in `deps`.
 
 > NOTE: It's also possible to call a task without any param prefixing it
-with `^`, but this syntax is deprecaded:
+with `^`, but this syntax is deprecated:
 
 ```yml
 a-task:
@@ -314,8 +314,9 @@ set-message:
 
 #### Dynamic variables
 
-The below syntax (`sh:` prop in a variable) is considered a dynamic
-variable. The value will be treated as a command and the output assigned.
+The below syntax (`sh:` prop in a variable) is considered a dynamic variable.
+The value will be treated as a command and the output assigned. If there is one
+or more trailing newlines, the last newline will be trimmed.
 
 ```yml
 build:
@@ -345,7 +346,7 @@ GIT_COMMIT: $git log -n 1 --format=%h
 ### Go's template engine
 
 Task parse commands as [Go's template engine][gotemplate] before executing
-them. Variables are acessible through dot syntax (`.VARNAME`).
+them. Variables are accessible through dot syntax (`.VARNAME`).
 
 All functions by the Go's [sprig lib](http://masterminds.github.io/sprig/)
 are available. The following example gets the current date in a given format:
@@ -362,11 +363,13 @@ Task also adds the following functions:
   "darwin" (macOS) and "freebsd".
 - `ARCH`: return the architecture Task was compiled to: "386", "amd64", "arm"
   or "s390x".
-- `ToSlash`: Does nothing on Unix, but on Windows converts a string from `\`
+- `splitLines`: Splits Unix (\n) and Windows (\r\n) styled newlines.
+- `catLines`: Replaces Unix (\n) and Windows (\r\n) styled newlines with a space.
+- `toSlash`: Does nothing on Unix, but on Windows converts a string from `\`
   path format to `/`.
-- `FromSlash`: Oposite of `ToSlash`. Does nothing on Unix, but on Windows
+- `fromSlash`: Oposite of `toSlash`. Does nothing on Unix, but on Windows
   converts a string from `\` path format to `/`.
-- `ExeExt`: Returns the right executable extension for the current OS
+- `exeExt`: Returns the right executable extension for the current OS
   (`".exe"` for Windows, `""` for others).
 
 Example:
@@ -377,8 +380,22 @@ print-os:
     - echo '{{OS}} {{ARCH}}'
     - echo '{{if eq OS "windows"}}windows-command{{else}}unix-command{{end}}'
     # This will be path/to/file on Unix but path\to\file on Windows
-    - echo '{{FromSlash "path/to/file"}}'
+    - echo '{{fromSlash "path/to/file"}}'
+enumerated-file:
+  vars:
+    CONTENT: |
+      foo
+      bar
+  cmds:
+    - |
+      cat << EOF > output.txt
+      {{range $i, $line := .CONTENT | splitLines -}}
+      {{printf "%3d" $i}}: {{$line}}
+      {{end}}EOF
 ```
+
+> NOTE: There are some deprecated function names still available: `ToSlash`,
+`FromSlash` and `ExeExt`. These where changed for consistency with sprig lib.
 
 ### Help
 
@@ -458,7 +475,7 @@ echo:
 
 * Or globally with `--silent` or `-s` flag
 
-If you want to supress stdout instead, just redirect a command to `/dev/null`:
+If you want to suppress stdout instead, just redirect a command to `/dev/null`:
 
 ```yml
 echo:

--- a/task.go
+++ b/task.go
@@ -121,8 +121,8 @@ func (e *Executor) RunTask(ctx context.Context, call Call) error {
 		return err
 	}
 
-	// FIXME: doing again, since a var may have been overriden using the
-	// `set:` attribute of a dependecy.  Remove this when `set` (that is
+	// FIXME: doing again, since a var may have been overridden using the
+	// `set:` attribute of a dependency.  Remove this when `set` (that is
 	// deprecated) be removed.
 	t, err = e.CompiledTask(call)
 	if err != nil {

--- a/task_test.go
+++ b/task_test.go
@@ -103,6 +103,26 @@ func TestVars(t *testing.T) {
 	tt.Target = "hello"
 	tt.Run(t)
 }
+func TestMultilineVars(t *testing.T) {
+	tt := fileContentTest{
+		Dir:       "testdata/vars/multiline",
+		Target:    "default",
+		TrimSpace: false,
+		Files: map[string]string{
+			// Note:
+			// - task does not strip a trailing newline from var entries
+			// - task strips one trailing newline from shell output
+			// - the cat command adds a trailing newline
+			"echo_foobar.txt":      "foo\nbar\n",
+			"echo_n_foobar.txt":    "foo\nbar\n",
+			"echo_n_multiline.txt": "\n\nfoo\n  bar\nfoobar\n\nbaz\n\n",
+			"var_multiline.txt":    "\n\nfoo\n  bar\nfoobar\n\nbaz\n\n\n",
+			"var_catlines.txt":     "  foo   bar foobar  baz  \n",
+			"var_enumfile.txt":     "0:\n1:\n2:foo\n3:  bar\n4:foobar\n5:\n6:baz\n7:\n8:\n",
+		},
+	}
+	tt.Run(t)
+}
 
 func TestVarsInvalidTmpl(t *testing.T) {
 	const (

--- a/testdata/vars/multiline/Taskfile.yml
+++ b/testdata/vars/multiline/Taskfile.yml
@@ -1,0 +1,43 @@
+default:
+  vars:
+    MULTILINE: "\n\nfoo\n  bar\nfoobar\n\nbaz\n\n"
+  cmds:
+    - task: file
+      vars:
+        CONTENT:
+          sh: "echo 'foo\nbar'"
+        FILE: "echo_foobar.txt"
+    - task: file
+      vars:
+        CONTENT:
+          sh: "echo -n 'foo\nbar'"
+        FILE: "echo_n_foobar.txt"
+    - task: file
+      vars:
+        CONTENT:
+          sh: echo -n "{{.MULTILINE}}"
+        FILE: "echo_n_multiline.txt"
+    - task: file
+      vars:
+        CONTENT: "{{.MULTILINE}}"
+        FILE: "var_multiline.txt"
+    - task: file
+      vars:
+        CONTENT: "{{.MULTILINE | catLines}}"
+        FILE: "var_catlines.txt"
+    - task: enumfile
+      vars:
+        LINES: "{{.MULTILINE}}"
+        FILE: "var_enumfile.txt"
+file:
+  cmds:
+    - |
+      cat << EOF > '{{.FILE}}'
+      {{.CONTENT}}
+      EOF
+enumfile:
+  cmds:
+    - |
+      cat << EOF > '{{.FILE}}'
+      {{range $i, $line := .LINES| splitLines}}{{$i}}:{{$line}}
+      {{end}}EOF


### PR DESCRIPTION
Fixes #63.

~Instead of giving an error on multiline results from sh, the results are now concatenated to one line by default, separated by a single space. Trailing and leading white space are stripped like before.~
    
~In adition, some flags have been added for advanced use cases to turn off line concationaton and/or trimming off leading/trailing white-space.~

Multiline results are now allowed, while the last newline is stripped to allow the output of most commands to work better as variable values. Some helper functions are added to make it easier to deal with multi-line variables in various ways.