### PR TITLE
An example covering passing values in the environment and value quoting

### DIFF
--- a/example/cgo_envvars/Taskfile.yml
+++ b/example/cgo_envvars/Taskfile.yml
@@ -1,0 +1,24 @@
+# This applies generaly to environment variables passed in this way, not just
+# CGO_ xxx
+#
+right:
+  # Notice the quotes guarding the variable references on the second line of
+  # the cmds.
+  cmds:
+    - |
+      CGO_LDFLAGS="-L/some/path -laaa -lbbb -lccc"
+      CGO_LDFLAGS="$CGO_LDFLAGS" ./showenv.sh "$CGO_LDFLAGS"
+wrong:
+  # In this instance the quotes are missing, the output will be:
+  #
+  # CGO_LDFLAGS=-L/some/path-laaa-lbbb-lccc
+  # $@=-L/some/path-laaa-lbbb-lccc
+  cmds:
+    - |
+      CGO_LDFLAGS="-L/some/path -laaa -lbbb -lccc"
+      CGO_LDFLAGS=$CGO_LDFLAGS ./showenv.sh $CGO_LDFLAGS
+
+# showenv:
+# #!/bin/bash
+# echo "CGO_LDFLAGS=$CGO_LDFLAGS"
+# echo "\$@=$@"

--- a/example/cgo_envvars/Taskfile.yml
+++ b/example/cgo_envvars/Taskfile.yml
@@ -17,8 +17,3 @@ wrong:
     - |
       CGO_LDFLAGS="-L/some/path -laaa -lbbb -lccc"
       CGO_LDFLAGS=$CGO_LDFLAGS ./showenv.sh $CGO_LDFLAGS
-
-# showenv:
-# #!/bin/bash
-# echo "CGO_LDFLAGS=$CGO_LDFLAGS"
-# echo "\$@=$@"

--- a/example/cgo_envvars/showenv.sh
+++ b/example/cgo_envvars/showenv.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "CGO_LDFLAGS=$CGO_LDFLAGS"
+echo "\$@=$@"


### PR DESCRIPTION
The behavior when constructing and passing variables to processes invoked in cmds tripped me up. This example might save someone else some time.

I'm not entirely sure I have chosen a good location for the example in the repo, but I thought this would be clearer as a PR rather than an issue which isn't a bug.