### PR TITLE
 Add "output" option to Taskfile to control how stuff are printed to stdout/stderr

### DIFF
--- a/internal/output/group.go
+++ b/internal/output/group.go
@@ -1,0 +1,26 @@
+package output
+
+import (
+	"bytes"
+	"io"
+)
+
+type Group struct{}
+
+func (Group) WrapWriter(w io.Writer) io.WriteCloser {
+	return &groupWriter{writer: w}
+}
+
+type groupWriter struct {
+	writer io.Writer
+	buff   bytes.Buffer
+}
+
+func (gw *groupWriter) Write(p []byte) (int, error) {
+	return gw.buff.Write(p)
+}
+
+func (gw *groupWriter) Close() error {
+	_, err := io.Copy(gw.writer, &gw.buff)
+	return err
+}

--- a/internal/output/interleaved.go
+++ b/internal/output/interleaved.go
@@ -1,0 +1,23 @@
+package output
+
+import (
+	"io"
+)
+
+type Interleaved struct{}
+
+func (Interleaved) WrapWriter(w io.Writer) io.WriteCloser {
+	return nopWriterCloser{w: w}
+}
+
+type nopWriterCloser struct {
+	w io.Writer
+}
+
+func (wc nopWriterCloser) Write(p []byte) (int, error) {
+	return wc.w.Write(p)
+}
+
+func (wc nopWriterCloser) Close() error {
+	return nil
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1,0 +1,9 @@
+package output
+
+import (
+	"io"
+)
+
+type Output interface {
+	WrapWriter(io.Writer) io.WriteCloser
+}

--- a/internal/taskfile/taskfile.go
+++ b/internal/taskfile/taskfile.go
@@ -4,6 +4,7 @@ package taskfile
 type Taskfile struct {
 	Version    string
 	Expansions int
+	Output     string
 	Vars       Vars
 	Tasks      Tasks
 }
@@ -18,6 +19,7 @@ func (tf *Taskfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var taskfile struct {
 		Version    string
 		Expansions int
+		Output     string
 		Vars       Vars
 		Tasks      Tasks
 	}
@@ -26,6 +28,7 @@ func (tf *Taskfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	tf.Version = taskfile.Version
 	tf.Expansions = taskfile.Expansions
+	tf.Output = taskfile.Output
 	tf.Vars = taskfile.Vars
 	tf.Tasks = taskfile.Tasks
 	if tf.Expansions <= 0 {

--- a/internal/taskfile/version/version.go
+++ b/internal/taskfile/version/version.go
@@ -5,27 +5,30 @@ import (
 )
 
 var (
-	v1 = mustVersion("1")
-	v2 = mustVersion("2")
-
-	isV1  = mustConstraint("= 1")
-	isV2  = mustConstraint(">= 2")
-	isV21 = mustConstraint(">= 2.1")
+	v1  = mustVersion("1")
+	v2  = mustVersion("2")
+	v21 = mustVersion("2.1")
+	v22 = mustVersion("2.2")
 )
 
 // IsV1 returns if is a given Taskfile version is version 1
-func IsV1(v *semver.Version) bool {
-	return isV1.Check(v)
+func IsV1(v *semver.Constraints) bool {
+	return v.Check(v1)
 }
 
 // IsV2 returns if is a given Taskfile version is at least version 2
-func IsV2(v *semver.Version) bool {
-	return isV2.Check(v)
+func IsV2(v *semver.Constraints) bool {
+	return v.Check(v2)
 }
 
-// IsV21 returns if is a given Taskfile version is at least version 2
-func IsV21(v *semver.Version) bool {
-	return isV21.Check(v)
+// IsV21 returns if is a given Taskfile version is at least version 2.1
+func IsV21(v *semver.Constraints) bool {
+	return v.Check(v21)
+}
+
+// IsV22 returns if is a given Taskfile version is at least version 2.2
+func IsV22(v *semver.Constraints) bool {
+	return v.Check(v22)
 }
 
 func mustVersion(s string) *semver.Version {
@@ -34,12 +37,4 @@ func mustVersion(s string) *semver.Version {
 		panic(err)
 	}
 	return v
-}
-
-func mustConstraint(s string) *semver.Constraints {
-	c, err := semver.NewConstraint(s)
-	if err != nil {
-		panic(err)
-	}
-	return c
 }


### PR DESCRIPTION
PR for this feature request: #104 

TODO:

- [x] Implement `group`, along with `interleaved` (default)
- [ ] Implement `prefixed`
- [ ] Write tests

Example Taskfile (comment the `output: group` line to see the difference while running it):

```yml
version: '2'

output: group

tasks:
  default:
    deps:
      - task: print
        vars: {TEXT: ABC, SLEEP: 3}
      - task: print
        vars: {TEXT: QWERTY, SLEEP: 5}
      - task: print
        vars: {TEXT: JKL, SLEEP: 3}
      - task: print
        vars: {TEXT: '1234', SLEEP: 4}

  print:
    cmds:
      - |
        sleep {{.SLEEP}}
        echo "{{.TEXT}}"
        sleep {{.SLEEP}}
        echo "{{.TEXT}}"
        sleep {{.SLEEP}}
        echo "{{.TEXT}}"
    silent: true
```

---

/cc @smyrman @brad-jones @ianwalter

Testing and feedback are welcome here. Does this work how you expect?

And about the prefixed variation, what exactly should be the prefix? `[command] Output` don't seems OK to me, because the command can be really big, and also multi-line.