### PR TITLE
Use latest patch releases of Go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - '1.9'
-  - '1.10'
+  - 1.9.x
+  - 1.10.x
 
 addons:
   apt:


### PR DESCRIPTION
`1.9` really installs 1.9(.0)