### PR TITLE
Implemented dry run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,11 @@ tasks:
       - echo "This will print nothing" > /dev/null
 ```
 
+## Dry Run Mode
+
+Dry run mode (`--dry-run`) compiles and steps through each task, printing the commands
+that would be run without executing them. This is useful for debugging your Taskfiles.
+
 ## Output syntax
 
 By default, Task just redirect the STDOUT and STDERR of the running commands

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -17,7 +17,7 @@ var (
 	version = "master"
 )
 
-const usage = `Usage: task [-ilfwvsd] [--init] [--list] [--force] [--watch] [--verbose] [--silent] [--dir] [task...]
+const usage = `Usage: task [-ilfwvsd] [--init] [--list] [--force] [--watch] [--verbose] [--silent] [--dir] [--dry-run] [task...]
 
 Runs the specified task(s). Falls back to the "default" task if no task name
 was specified, or lists all tasks if an unknown task name was specified.
@@ -55,6 +55,7 @@ func main() {
 		watch       bool
 		verbose     bool
 		silent      bool
+		dryRun      bool
 		dir         string
 	)
 
@@ -66,6 +67,7 @@ func main() {
 	pflag.BoolVarP(&watch, "watch", "w", false, "enables watch of the given task")
 	pflag.BoolVarP(&verbose, "verbose", "v", false, "enables verbose mode")
 	pflag.BoolVarP(&silent, "silent", "s", false, "disables echoing")
+	pflag.BoolVar(&dryRun, "dry-run", false, "compiles and prints tasks in the order that they would be run, without executing them")
 	pflag.StringVarP(&dir, "dir", "d", "", "sets directory of execution")
 	pflag.Parse()
 
@@ -91,6 +93,7 @@ func main() {
 		Verbose: verbose,
 		Silent:  silent,
 		Dir:     dir,
+		DryRun:  dryRun,
 
 		Context: getSignalContext(),
 

--- a/completion/zsh/_task
+++ b/completion/zsh/_task
@@ -12,6 +12,7 @@ function __list() {
 
 _arguments \
     '(-d --dir)'{-d,--dir}': :_files' \
+    '(--dry-run)'--dry-run \
     '(-f --force)'{-f,--force} \
     '(-i --init)'{-i,--init} \
     '(-l --list)'{-l,--list} \

--- a/task.go
+++ b/task.go
@@ -35,6 +35,7 @@ type Executor struct {
 	Watch    bool
 	Verbose  bool
 	Silent   bool
+	DryRun   bool
 
 	Context context.Context
 
@@ -209,6 +210,10 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 	case cmd.Cmd != "":
 		if e.Verbose || (!cmd.Silent && !t.Silent && !e.Silent) {
 			e.Logger.Errf(cmd.Cmd)
+		}
+
+		if e.DryRun {
+			return nil
 		}
 
 		stdOut := e.Output.WrapWriter(e.Stdout, t.Prefix)


### PR DESCRIPTION
Added a --dry-run flag that compiles and steps through each task, but does not execute them. The commands that would have been run are printed. See #125.