### PR TITLE
Passing tests on Windows (GitBash)

### DIFF
--- a/internal/status/glob.go
+++ b/internal/status/glob.go
@@ -14,7 +14,7 @@ func glob(dir string, globs []string) (files []string, err error) {
 		if !filepath.IsAbs(g) {
 			g = filepath.Join(dir, g)
 		}
-		g, err = execext.Expand(g)
+		g, err = execext.Expand(filepath.ToSlash(g))
 		if err != nil {
 			return nil, err
 		}

--- a/testdata/expand/Taskfile_windows.yml
+++ b/testdata/expand/Taskfile_windows.yml
@@ -1,0 +1,8 @@
+version: '2'
+
+tasks:
+  pwd:
+    cmds:
+      - pwd
+    dir: '$USERPROFILE'
+    silent: true

--- a/variables.go
+++ b/variables.go
@@ -36,7 +36,7 @@ func (e *Executor) CompiledTask(call taskfile.Call) (*taskfile.Task, error) {
 		Prefix:      r.Replace(origTask.Prefix),
 		IgnoreError: origTask.IgnoreError,
 	}
-	new.Dir, err = execext.Expand(new.Dir)
+	new.Dir, err = execext.Expand(filepath.ToSlash(new.Dir))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR is trying to fix two failing tests when running from GitBash on Windows.

1. **TestGenerates**: I believe backslashes must be replaced prior to call [execext.Expand()](https://github.com/mikynov/task/blob/468ff1824380169690441183cd392c51a479f003/internal/execext/exec.go#L74). Otherwise they are just removed what makes wrong filename (path) on Windows (```C:\Users``` becomes ```C:Users```). Windows are fine with slashes in filenames, thus this shouldn't break anything.
    This was an issue on Windows where generated files were not detected correctly and always regenerated (```sources``` and ```generates``` in  [status.IsUpToDate()](https://github.com/mikynov/task/blob/468ff1824380169690441183cd392c51a479f003/internal/status/timestamp.go#L17) were empty).

2. **TestExpand**: Tilda is not expanded properly on Windows. OS-specific Taskfile with ```USERPROFILE``` env. variable make a test to pass.
