### PR TITLE
Add execute output style options

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -57,6 +57,7 @@ func main() {
 		silent      bool
 		dry         bool
 		dir         string
+		output      string
 	)
 
 	pflag.BoolVar(&versionFlag, "version", false, "show Task version")
@@ -69,6 +70,7 @@ func main() {
 	pflag.BoolVarP(&silent, "silent", "s", false, "disables echoing")
 	pflag.BoolVar(&dry, "dry", false, "compiles and prints tasks in the order that they would be run, without executing them")
 	pflag.StringVarP(&dir, "dir", "d", "", "sets directory of execution")
+	pflag.StringVarP(&output, "output", "o", "", "sets output style: [interleaved|group|prefixed]")
 	pflag.Parse()
 
 	if versionFlag {
@@ -105,6 +107,8 @@ func main() {
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
+
+		OutputStyle: output,
 	}
 	if err := e.Setup(); err != nil {
 		log.Fatal(err)

--- a/task.go
+++ b/task.go
@@ -46,6 +46,7 @@ type Executor struct {
 	Logger   *logger.Logger
 	Compiler compiler.Compiler
 	Output   output.Output
+	OutputStyle string
 
 	taskvars taskfile.Vars
 
@@ -133,6 +134,9 @@ func (e *Executor) Setup() error {
 	}
 	if !version.IsV22(v) && len(e.Taskfile.Includes) > 0 {
 		return fmt.Errorf(`task: Including Taskfiles is only available starting on Taskfile version v2.2`)
+	}
+	if e.OutputStyle != "" {
+		e.Taskfile.Output = e.OutputStyle
 	}
 	switch e.Taskfile.Output {
 	case "", "interleaved":


### PR DESCRIPTION
Add command line option.

``` sh
$ task --help
..
Options:
  ..
  -o, --output string   sets output style: [interleaved|group|prefixed]
  ..
```

Taskfile.yml

``` yaml
version: '2'
tasks:
  test:
    cmds:
      - echo 'test'
```

Execute

``` sh
$ task -s test
test
$ task -s -o prefixed test
[test] test
```