### PR TITLE
Fix the zsh completion with sub-tasks

### DIFF
--- a/completion/zsh/_task
+++ b/completion/zsh/_task
@@ -5,7 +5,7 @@ function __list() {
     local -a scripts
 
     if [ -f Taskfile.yml ]; then
-		scripts=($(task -l | sed '1d' | sed 's/^\* //' | awk '{ print $1 }' | sed 's/:$//' | sed 's/:/\\:/'))
+        scripts=($(task -l | sed '1d' | sed 's/^\* //' | awk '{ print $1 }' | sed 's/:$//' | sed 's/:/\\:/'))
         _describe 'script' scripts
     fi
 }

--- a/completion/zsh/_task
+++ b/completion/zsh/_task
@@ -5,7 +5,7 @@ function __list() {
     local -a scripts
 
     if [ -f Taskfile.yml ]; then
-        scripts=($(task -l | sed '1d' | sed 's/://' | awk '{ print $2 }'))
+        scripts=($(task -l | sed '1d' | sed 's/^* //' | sed 's/\:\s.*//' | sed 's/\(\w\):\(\w\)/\1\\\:\2/'))
         _describe 'script' scripts
     fi
 }

--- a/completion/zsh/_task
+++ b/completion/zsh/_task
@@ -5,7 +5,7 @@ function __list() {
     local -a scripts
 
     if [ -f Taskfile.yml ]; then
-        scripts=($(task -l | sed '1d' | sed 's/^* //' | sed 's/\:\s.*//' | sed 's/\(\w\):\(\w\)/\1\\\:\2/'))
+		scripts=($(task -l | sed '1d' | sed 's/^\* //' | awk '{ print $1 }' | sed 's/:$//' | sed 's/:/\\:/'))
         _describe 'script' scripts
     fi
 }
@@ -23,3 +23,4 @@ _arguments \
     '(-w --watch)'{-w,--watch} \
     '(- *)'{-h,--help} \
     '*: :__list' \
+


### PR DESCRIPTION
When the taskfile has sub-tasks (eg: `task foo:bar`), the completion does not work correctly. That PR fixes that.