### PR TITLE
Fixes some bugs relatated to commands output handling

### DIFF
--- a/internal/output/group.go
+++ b/internal/output/group.go
@@ -7,7 +7,7 @@ import (
 
 type Group struct{}
 
-func (Group) WrapWriter(w io.Writer, _ string) io.WriteCloser {
+func (Group) WrapWriter(w io.Writer, _ string) io.Writer {
 	return &groupWriter{writer: w}
 }
 

--- a/internal/output/interleaved.go
+++ b/internal/output/interleaved.go
@@ -6,18 +6,6 @@ import (
 
 type Interleaved struct{}
 
-func (Interleaved) WrapWriter(w io.Writer, _ string) io.WriteCloser {
-	return nopWriterCloser{w: w}
-}
-
-type nopWriterCloser struct {
-	w io.Writer
-}
-
-func (wc nopWriterCloser) Write(p []byte) (int, error) {
-	return wc.w.Write(p)
-}
-
-func (wc nopWriterCloser) Close() error {
-	return nil
+func (Interleaved) WrapWriter(w io.Writer, _ string) io.Writer {
+	return w
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -5,5 +5,5 @@ import (
 )
 
 type Output interface {
-	WrapWriter(w io.Writer, prefix string) io.WriteCloser
+	WrapWriter(w io.Writer, prefix string) io.Writer
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -3,6 +3,7 @@ package output_test
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/go-task/task/v2/internal/output"
@@ -24,7 +25,7 @@ func TestInterleaved(t *testing.T) {
 func TestGroup(t *testing.T) {
 	var b bytes.Buffer
 	var o output.Output = output.Group{}
-	var w = o.WrapWriter(&b, "")
+	var w = o.WrapWriter(&b, "").(io.WriteCloser)
 
 	fmt.Fprintln(w, "foo\nbar")
 	assert.Equal(t, "", b.String())
@@ -37,7 +38,7 @@ func TestGroup(t *testing.T) {
 func TestPrefixed(t *testing.T) {
 	var b bytes.Buffer
 	var o output.Output = output.Prefixed{}
-	var w = o.WrapWriter(&b, "prefix")
+	var w = o.WrapWriter(&b, "prefix").(io.WriteCloser)
 
 	t.Run("simple use cases", func(t *testing.T) {
 		b.Reset()

--- a/internal/output/prefixed.go
+++ b/internal/output/prefixed.go
@@ -9,7 +9,7 @@ import (
 
 type Prefixed struct{}
 
-func (Prefixed) WrapWriter(w io.Writer, prefix string) io.WriteCloser {
+func (Prefixed) WrapWriter(w io.Writer, prefix string) io.Writer {
 	return &prefixWriter{writer: w, prefix: prefix}
 }
 

--- a/task.go
+++ b/task.go
@@ -248,8 +248,18 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 
 		stdOut := e.Output.WrapWriter(e.Stdout, t.Prefix)
 		stdErr := e.Output.WrapWriter(e.Stderr, t.Prefix)
-		defer stdOut.Close()
-		defer stdErr.Close()
+		defer func() {
+			if _, ok := stdOut.(*os.File); !ok {
+				if closer, ok := stdOut.(io.Closer); ok {
+					closer.Close()
+				}
+			}
+			if _, ok := stdErr.(*os.File); !ok {
+				if closer, ok := stdErr.(io.Closer); ok {
+					closer.Close()
+				}
+			}
+		}()
 
 		err := execext.RunCommand(ctx, &execext.RunCommandOptions{
 			Command: cmd.Cmd,


### PR DESCRIPTION
This seems to fix some of the bugs reported by issues like #114 and #190.

Seems that the standard library's os/exec package has some black magic to detect if a writer is an actual *os.File, and some stuff are handled differently, then.

Fixes #114
Fixes #190