### PR TITLE
Add Preconditions to Tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dist/
 
 # intellij idea/goland
 .idea/
+
+# exuberant ctags
+tags

--- a/docs/taskfile_versions.md
+++ b/docs/taskfile_versions.md
@@ -141,9 +141,9 @@ includes:
   docker: ./DockerTasks.yml
 ```
 
-## Version 2.3
+## Version 2.6
 
-Version 2.3 comes with `preconditions` stanza in tasks.
+Version 2.6 comes with `preconditions` stanza in tasks.
 
 ```yaml
 version: '2'

--- a/docs/taskfile_versions.md
+++ b/docs/taskfile_versions.md
@@ -141,6 +141,21 @@ includes:
   docker: ./DockerTasks.yml
 ```
 
+## Version 2.3
+
+Version 2.3 comes with `preconditions` stanza in tasks.
+
+```yaml
+version: '2'
+
+tasks:
+  upload_environment:
+    preconditions:
+      - test -f .env
+    cmds:
+      - aws s3 cp .env s3://myenvironment
+```
+
 Please check the [documentation][includes]
 
 [output]: usage.md#output-syntax

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -346,7 +346,7 @@ the tasks are not up-to-date.
 
 If you need a certain set of conditions to be _true_ you can use the
 `preconditions` stanza.  `preconditions` are very similar to `status`
-lines except they support `sh` expansion and they SHOULD all return 0
+lines except they support `sh` expansion and they SHOULD all return 0.
 
 ```yaml
 version: '2'
@@ -373,7 +373,7 @@ executed with a failing precondition will not run unless `--force` is
 given.
 
 Unlike `status` which will skip a task if it is up to date, and continue
-executing tasks that depenend on it a `precondition` will fail a task, along
+executing tasks that depend on it, a `precondition` will fail a task, along
 with any other tasks that depend on it.
 
 ```yaml
@@ -384,13 +384,13 @@ tasks:
       - sh: "exit 1"
 
   task_will_also_fail:
-  deps:
-    - task_will_fail
+    deps:
+      - task_will_fail
 
   task_will_still_fail:
-  cmds:
-    - task: task_will_fail
-    - echo "I will not run"
+    cmds:
+      - task: task_will_fail
+      - echo "I will not run"
 ```
 
 ## Variables

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -365,13 +365,16 @@ tasks:
 ```
 
 Preconditions can set specific failure messages that can tell
-a user what to do using the `msg` field.
+a user what steps to take using the `msg` field.
 
 If a task has a dependency on a sub-task with a precondition, and that
-precondition is not met - the calling task will fail.  Adding `ignore_errors`
-to the precondition will cause parent tasks to execute even if the sub task
-can not run.  Note that a task executed directly with a failing precondition
-will not run unless `--force` is given.
+precondition is not met - the calling task will fail.  Note that a task
+executed with a failing precondition will not run unless `--force` is
+given.
+
+Unlike `status` which will skip a task if it is up to date, and continue
+executing tasks that depenend on it a `precondition` will fail a task, along
+with any other tasks that depend on it.
 
 ```yaml
 version: '2'
@@ -379,16 +382,15 @@ tasks:
   task_will_fail:
     preconditions:
       - sh: "exit 1"
-        ignore_errors: true
 
-  task_will_succeed:
+  task_will_also_fail:
   deps:
     - task_will_fail
 
-  task_will_succeed:
+  task_will_still_fail:
   cmds:
     - task: task_will_fail
-    - echo "I will run"
+    - echo "I will not run"
 ```
 
 ## Variables

--- a/internal/taskfile/precondition.go
+++ b/internal/taskfile/precondition.go
@@ -1,0 +1,51 @@
+package taskfile
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrCantUnmarshalPrecondition is returned for invalid precond YAML.
+	ErrCantUnmarshalPrecondition = errors.New("task: can't unmarshal precondition value")
+)
+
+// Precondition represents a precondition necessary for a task to run
+type Precondition struct {
+	Sh          string
+	Msg         string
+	IgnoreError bool
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler interface.
+func (p *Precondition) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var cmd string
+
+	if err := unmarshal(&cmd); err == nil {
+		p.Sh = cmd
+		p.Msg = fmt.Sprintf("`%s` failed", cmd)
+		p.IgnoreError = false
+		return nil
+	}
+
+	var sh struct {
+		Sh          string
+		Msg         string
+		IgnoreError bool `yaml:"ignore_error"`
+	}
+
+	err := unmarshal(&sh)
+
+	if err == nil {
+		p.Sh = sh.Sh
+		p.Msg = sh.Msg
+		if p.Msg == "" {
+			p.Msg = fmt.Sprintf("%s failed", sh.Sh)
+		}
+
+		p.IgnoreError = sh.IgnoreError
+		return nil
+	}
+
+	return err
+}

--- a/internal/taskfile/precondition.go
+++ b/internal/taskfile/precondition.go
@@ -12,9 +12,8 @@ var (
 
 // Precondition represents a precondition necessary for a task to run
 type Precondition struct {
-	Sh          string
-	Msg         string
-	IgnoreError bool
+	Sh  string
+	Msg string
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler interface.
@@ -24,28 +23,23 @@ func (p *Precondition) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal(&cmd); err == nil {
 		p.Sh = cmd
 		p.Msg = fmt.Sprintf("`%s` failed", cmd)
-		p.IgnoreError = false
 		return nil
 	}
 
 	var sh struct {
-		Sh          string
-		Msg         string
-		IgnoreError bool `yaml:"ignore_error"`
+		Sh  string
+		Msg string
 	}
 
-	err := unmarshal(&sh)
-
-	if err == nil {
-		p.Sh = sh.Sh
-		p.Msg = sh.Msg
-		if p.Msg == "" {
-			p.Msg = fmt.Sprintf("%s failed", sh.Sh)
-		}
-
-		p.IgnoreError = sh.IgnoreError
-		return nil
+	if err := unmarshal(&sh); err != nil {
+		return err
 	}
 
-	return err
+	p.Sh = sh.Sh
+	p.Msg = sh.Msg
+	if p.Msg == "" {
+		p.Msg = fmt.Sprintf("%s failed", sh.Sh)
+	}
+
+	return nil
 }

--- a/internal/taskfile/precondition.go
+++ b/internal/taskfile/precondition.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// ErrCantUnmarshalPrecondition is returned for invalid precond YAML.
-	ErrCantUnmarshalPrecondition = errors.New("task: can't unmarshal precondition value")
+	ErrCantUnmarshalPrecondition = errors.New("task: Can't unmarshal precondition value")
 )
 
 // Precondition represents a precondition necessary for a task to run

--- a/internal/taskfile/precondition_test.go
+++ b/internal/taskfile/precondition_test.go
@@ -1,0 +1,49 @@
+package taskfile_test
+
+import (
+	"testing"
+
+	"github.com/go-task/task/v2/internal/taskfile"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func TestPreconditionParse(t *testing.T) {
+	tests := []struct {
+		content  string
+		v        interface{}
+		expected interface{}
+	}{
+		{
+			"test -f foo.txt",
+			&taskfile.Precondition{},
+			&taskfile.Precondition{Sh: `test -f foo.txt`, Msg: "`test -f foo.txt` failed", IgnoreError: false},
+		},
+		{
+			"sh: '[ 1 = 0 ]'",
+			&taskfile.Precondition{},
+			&taskfile.Precondition{Sh: "[ 1 = 0 ]", Msg: "[ 1 = 0 ] failed", IgnoreError: false},
+		},
+		{`
+sh: "[ 1 = 2 ]"
+msg: "1 is not 2"
+`,
+			&taskfile.Precondition{},
+			&taskfile.Precondition{Sh: "[ 1 = 2 ]", Msg: "1 is not 2", IgnoreError: false},
+		},
+		{`
+sh: "[ 1 = 2 ]"
+msg: "1 is not 2"
+ignore_error: true
+`,
+			&taskfile.Precondition{},
+			&taskfile.Precondition{Sh: "[ 1 = 2 ]", Msg: "1 is not 2", IgnoreError: true},
+		},
+	}
+	for _, test := range tests {
+		err := yaml.Unmarshal([]byte(test.content), test.v)
+		assert.NoError(t, err)
+		assert.Equal(t, test.expected, test.v)
+	}
+}

--- a/internal/taskfile/precondition_test.go
+++ b/internal/taskfile/precondition_test.go
@@ -18,27 +18,26 @@ func TestPreconditionParse(t *testing.T) {
 		{
 			"test -f foo.txt",
 			&taskfile.Precondition{},
-			&taskfile.Precondition{Sh: `test -f foo.txt`, Msg: "`test -f foo.txt` failed", IgnoreError: false},
+			&taskfile.Precondition{Sh: `test -f foo.txt`, Msg: "`test -f foo.txt` failed"},
 		},
 		{
 			"sh: '[ 1 = 0 ]'",
 			&taskfile.Precondition{},
-			&taskfile.Precondition{Sh: "[ 1 = 0 ]", Msg: "[ 1 = 0 ] failed", IgnoreError: false},
+			&taskfile.Precondition{Sh: "[ 1 = 0 ]", Msg: "[ 1 = 0 ] failed"},
 		},
 		{`
 sh: "[ 1 = 2 ]"
 msg: "1 is not 2"
 `,
 			&taskfile.Precondition{},
-			&taskfile.Precondition{Sh: "[ 1 = 2 ]", Msg: "1 is not 2", IgnoreError: false},
+			&taskfile.Precondition{Sh: "[ 1 = 2 ]", Msg: "1 is not 2"},
 		},
 		{`
 sh: "[ 1 = 2 ]"
 msg: "1 is not 2"
-ignore_error: true
 `,
 			&taskfile.Precondition{},
-			&taskfile.Precondition{Sh: "[ 1 = 2 ]", Msg: "1 is not 2", IgnoreError: true},
+			&taskfile.Precondition{Sh: "[ 1 = 2 ]", Msg: "1 is not 2"},
 		},
 	}
 	for _, test := range tests {

--- a/internal/taskfile/task.go
+++ b/internal/taskfile/task.go
@@ -13,7 +13,7 @@ type Task struct {
 	Sources      []string
 	Generates    []string
 	Status       []string
-	Precondition []*Precondition
+	Preconditions []*Precondition
 	Dir          string
 	Vars         Vars
 	Env          Vars

--- a/internal/taskfile/task.go
+++ b/internal/taskfile/task.go
@@ -5,19 +5,20 @@ type Tasks map[string]*Task
 
 // Task represents a task
 type Task struct {
-	Task        string
-	Cmds        []*Cmd
-	Deps        []*Dep
-	Desc        string
-	Summary     string
-	Sources     []string
-	Generates   []string
-	Status      []string
-	Dir         string
-	Vars        Vars
-	Env         Vars
-	Silent      bool
-	Method      string
-	Prefix      string
-	IgnoreError bool `yaml:"ignore_error"`
+	Task         string
+	Cmds         []*Cmd
+	Deps         []*Dep
+	Desc         string
+	Summary      string
+	Sources      []string
+	Generates    []string
+	Status       []string
+	Precondition []*Precondition
+	Dir          string
+	Vars         Vars
+	Env          Vars
+	Silent       bool
+	Method       string
+	Prefix       string
+	IgnoreError  bool `yaml:"ignore_error"`
 }

--- a/internal/taskfile/version/version.go
+++ b/internal/taskfile/version/version.go
@@ -10,6 +10,8 @@ var (
 	v21 = mustVersion("2.1")
 	v22 = mustVersion("2.2")
 	v23 = mustVersion("2.3")
+	v24 = mustVersion("2.4")
+	v25 = mustVersion("2.5")
 )
 
 // IsV1 returns if is a given Taskfile version is version 1
@@ -35,6 +37,16 @@ func IsV22(v *semver.Constraints) bool {
 // IsV23 returns if is a given Taskfile version is at least version 2.3
 func IsV23(v *semver.Constraints) bool {
 	return v.Check(v23)
+}
+
+// IsV24 returns if is a given Taskfile version is at least version 2.4
+func IsV24(v *semver.Constraints) bool {
+	return v.Check(v24)
+}
+
+// IsV25 returns if is a given Taskfile version is at least version 2.5
+func IsV25(v *semver.Constraints) bool {
+	return v.Check(v25)
 }
 
 func mustVersion(s string) *semver.Version {

--- a/precondition.go
+++ b/precondition.go
@@ -22,7 +22,7 @@ func (e *Executor) areTaskPreconditionsMet(ctx context.Context, t *taskfile.Task
 		})
 
 		if err != nil {
-			e.Logger.Outf("task: %s", p.Msg)
+			e.Logger.Errf("task: %s", p.Msg)
 			return false, ErrPreconditionFailed
 		}
 	}

--- a/precondition.go
+++ b/precondition.go
@@ -1,4 +1,3 @@
-// Package task provides ...
 package task
 
 import (
@@ -23,7 +22,7 @@ func (e *Executor) areTaskPreconditionsMet(ctx context.Context, t *taskfile.Task
 		})
 
 		if err != nil {
-			e.Logger.Outf(p.Msg)
+			e.Logger.Outf("task: %s", p.Msg)
 			return false, ErrPreconditionFailed
 		}
 	}

--- a/precondition.go
+++ b/precondition.go
@@ -10,16 +10,12 @@ import (
 )
 
 var (
-	// ErrNecessaryPreconditionFailed is returned when a precondition fails
-	ErrNecessaryPreconditionFailed = errors.New("task: precondition not met")
-	// ErrOptionalPreconditionFailed is returned when a precondition fails
-	// that has ignore_error set to true
-	ErrOptionalPreconditionFailed = errors.New("task: optional precondition not met")
+	// ErrPreconditionFailed is returned when a precondition fails
+	ErrPreconditionFailed = errors.New("task: precondition not met")
 )
 
 func (e *Executor) areTaskPreconditionsMet(ctx context.Context, t *taskfile.Task) (bool, error) {
-	var optionalPreconditionFailed bool
-	for _, p := range t.Precondition {
+	for _, p := range t.Preconditions {
 		err := execext.RunCommand(ctx, &execext.RunCommandOptions{
 			Command: p.Sh,
 			Dir:     t.Dir,
@@ -28,16 +24,8 @@ func (e *Executor) areTaskPreconditionsMet(ctx context.Context, t *taskfile.Task
 
 		if err != nil {
 			e.Logger.Outf(p.Msg)
-			if p.IgnoreError == true {
-				optionalPreconditionFailed = true
-			} else {
-				return false, ErrNecessaryPreconditionFailed
-			}
+			return false, ErrPreconditionFailed
 		}
-	}
-
-	if optionalPreconditionFailed == true {
-		return true, ErrOptionalPreconditionFailed
 	}
 
 	return true, nil

--- a/precondition.go
+++ b/precondition.go
@@ -1,0 +1,44 @@
+// Package task provides ...
+package task
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-task/task/v2/internal/execext"
+	"github.com/go-task/task/v2/internal/taskfile"
+)
+
+var (
+	// ErrNecessaryPreconditionFailed is returned when a precondition fails
+	ErrNecessaryPreconditionFailed = errors.New("task: precondition not met")
+	// ErrOptionalPreconditionFailed is returned when a precondition fails
+	// that has ignore_error set to true
+	ErrOptionalPreconditionFailed = errors.New("task: optional precondition not met")
+)
+
+func (e *Executor) areTaskPreconditionsMet(ctx context.Context, t *taskfile.Task) (bool, error) {
+	var optionalPreconditionFailed bool
+	for _, p := range t.Precondition {
+		err := execext.RunCommand(ctx, &execext.RunCommandOptions{
+			Command: p.Sh,
+			Dir:     t.Dir,
+			Env:     getEnviron(t),
+		})
+
+		if err != nil {
+			e.Logger.Outf(p.Msg)
+			if p.IgnoreError == true {
+				optionalPreconditionFailed = true
+			} else {
+				return false, ErrNecessaryPreconditionFailed
+			}
+		}
+	}
+
+	if optionalPreconditionFailed == true {
+		return true, ErrOptionalPreconditionFailed
+	}
+
+	return true, nil
+}

--- a/status.go
+++ b/status.go
@@ -78,8 +78,10 @@ func (e *Executor) isTaskUpToDateStatus(ctx context.Context, t *taskfile.Task) (
 			Env:     getEnviron(t),
 		})
 		if err != nil {
+			e.Logger.VerboseOutf("task: status command %s exited non-zero: %s", s, err)
 			return false, nil
 		}
+		e.Logger.VerboseOutf("task: status command %s exited zero", s)
 	}
 	return true, nil
 }

--- a/task.go
+++ b/task.go
@@ -189,12 +189,12 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 	}
 
 	if !e.Force {
-		upToDate, err := e.isTaskUpToDate(ctx, t)
+		preCondMet, err := e.areTaskPreconditionsMet(ctx, t)
 		if err != nil {
 			return err
 		}
 
-		preCondMet, err := e.areTaskPreconditionsMet(ctx, t)
+		upToDate, err := e.isTaskUpToDate(ctx, t)
 		if err != nil {
 			return err
 		}
@@ -233,11 +233,8 @@ func (e *Executor) runDeps(ctx context.Context, t *taskfile.Task) error {
 		g.Go(func() error {
 			err := e.RunTask(ctx, taskfile.Call{Task: d.Task, Vars: d.Vars})
 			if err != nil {
-				if err == ErrOptionalPreconditionFailed {
-					e.Logger.Errf("%s", err)
-				} else {
-					return err
-				}
+				e.Logger.Errf("%s", err)
+				return err
 			}
 			return nil
 		})
@@ -253,11 +250,8 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 	case cmd.Task != "":
 		err := e.RunTask(ctx, taskfile.Call{Task: cmd.Task, Vars: cmd.Vars})
 		if err != nil {
-			if err == ErrOptionalPreconditionFailed {
-				e.Logger.Errf("%s", err)
-			} else {
-				return err
-			}
+			e.Logger.Errf("%s", err)
+			return err
 		}
 		return nil
 	case cmd.Cmd != "":

--- a/task.go
+++ b/task.go
@@ -233,7 +233,6 @@ func (e *Executor) runDeps(ctx context.Context, t *taskfile.Task) error {
 		g.Go(func() error {
 			err := e.RunTask(ctx, taskfile.Call{Task: d.Task, Vars: d.Vars})
 			if err != nil {
-				e.Logger.Errf("%s", err)
 				return err
 			}
 			return nil
@@ -250,7 +249,6 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 	case cmd.Task != "":
 		err := e.RunTask(ctx, taskfile.Call{Task: cmd.Task, Vars: cmd.Vars})
 		if err != nil {
-			e.Logger.Errf("%s", err)
 			return err
 		}
 		return nil

--- a/task_test.go
+++ b/task_test.go
@@ -293,7 +293,7 @@ func TestPrecondition(t *testing.T) {
 	// A precondition that was not met
 	assert.Error(t, e.Run(context.Background(), taskfile.Call{Task: "impossible"}))
 
-	if buff.String() != "1 != 0\n" {
+	if buff.String() != "task: 1 != 0 obviously!\n" {
 		t.Errorf("Wrong output message: %s", buff.String())
 	}
 	buff.Reset()
@@ -301,14 +301,14 @@ func TestPrecondition(t *testing.T) {
 	// Calling a task with a precondition in a dependency fails the task
 	assert.Error(t, e.Run(context.Background(), taskfile.Call{Task: "depends_on_imposssible"}))
 
-	if buff.String() != "1 != 0\ntask: precondition not met\n" {
+	if buff.String() != "task: 1 != 0 obviously!\n" {
 		t.Errorf("Wrong output message: %s", buff.String())
 	}
 	buff.Reset()
 
 	// Calling a task with a precondition in a cmd fails the task
 	assert.Error(t, e.Run(context.Background(), taskfile.Call{Task: "executes_failing_task_as_cmd"}))
-	if buff.String() != "1 != 0\ntask: precondition not met\n" {
+	if buff.String() != "task: 1 != 0 obviously!\n" {
 		t.Errorf("Wrong output message: %s", buff.String())
 	}
 	buff.Reset()

--- a/task_test.go
+++ b/task_test.go
@@ -301,38 +301,18 @@ func TestPrecondition(t *testing.T) {
 
 	// Calling a task with a precondition in a dependency fails the task
 	assert.Error(t, e.Run(context.Background(), taskfile.Call{Task: "depends_on_imposssible"}))
-	if buff.String() != "1 != 0\n" {
+
+	if buff.String() != "1 != 0\ntask: precondition not met\n" {
 		t.Errorf("Wrong output message: %s", buff.String())
 	}
 	buff.Reset()
 
 	// Calling a task with a precondition in a cmd fails the task
 	assert.Error(t, e.Run(context.Background(), taskfile.Call{Task: "executes_failing_task_as_cmd"}))
-	if buff.String() != "1 != 0\n" {
+	if buff.String() != "1 != 0\ntask: precondition not met\n" {
 		t.Errorf("Wrong output message: %s", buff.String())
 	}
 	buff.Reset()
-
-	// A task with a failing precondition and ignore_errors on still fails
-	assert.Error(t, e.Run(context.Background(), taskfile.Call{Task: "impossible_but_i_dont_care"}))
-	if buff.String() != "2 != 1\n" {
-		t.Errorf("Wrong output message: %s", buff.String())
-	}
-	buff.Reset()
-
-	// If a precondition has ignore errors, then it will allow _dependent_ tasks to execute
-	assert.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "depends_on_failure_of_impossible"}))
-	if buff.String() != "2 != 1\ntask: optional precondition not met\n" {
-		t.Errorf("Wrong output message: %s", buff.String())
-	}
-	buff.Reset()
-
-	// If a precondition has ignore errors, then it will allow tasks calling it to execute
-	assert.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "executes_failing_task_as_cmd_but_succeeds"}))
-	if buff.String() != "2 != 1\ntask: optional precondition not met\n" {
-		t.Errorf("Wrong output message: %s", buff.String())
-	}
-
 }
 
 func TestGenerates(t *testing.T) {

--- a/task_test.go
+++ b/task_test.go
@@ -281,7 +281,6 @@ func TestPrecondition(t *testing.T) {
 		Dir:    dir,
 		Stdout: &buff,
 		Stderr: &buff,
-		Silent: false,
 	}
 
 	// A precondition that has been met

--- a/testdata/precondition/Taskfile.yml
+++ b/testdata/precondition/Taskfile.yml
@@ -1,0 +1,34 @@
+version: '2'
+
+tasks:
+  foo:
+    precondition:
+      - test -f foo.txt
+
+  impossible:
+    precondition:
+      - sh: "[ 1 = 0 ]"
+        msg: "1 != 0"
+
+  impossible_but_i_dont_care:
+    precondition:
+      - sh: "[ 2 = 1 ]"
+        msg: "2 != 1"
+        ignore_error: true
+
+  depends_on_imposssible:
+    deps:
+      - impossible
+
+  executes_failing_task_as_cmd:
+    cmds:
+      - task: impossible
+
+  depends_on_failure_of_impossible:
+    deps:
+      - impossible_but_i_dont_care
+
+  executes_failing_task_as_cmd_but_succeeds:
+    cmds:
+      - task: impossible_but_i_dont_care
+

--- a/testdata/precondition/Taskfile.yml
+++ b/testdata/precondition/Taskfile.yml
@@ -8,7 +8,7 @@ tasks:
   impossible:
     preconditions:
       - sh: "[ 1 = 0 ]"
-        msg: "1 != 0"
+        msg: "1 != 0 obviously!"
 
   depends_on_imposssible:
     deps:
@@ -17,7 +17,3 @@ tasks:
   executes_failing_task_as_cmd:
     cmds:
       - task: impossible
-
-  depends_on_failure_of_impossible:
-    deps:
-      - impossible_but_i_dont_care

--- a/testdata/precondition/Taskfile.yml
+++ b/testdata/precondition/Taskfile.yml
@@ -2,19 +2,13 @@ version: '2'
 
 tasks:
   foo:
-    precondition:
+    preconditions:
       - test -f foo.txt
 
   impossible:
-    precondition:
+    preconditions:
       - sh: "[ 1 = 0 ]"
         msg: "1 != 0"
-
-  impossible_but_i_dont_care:
-    precondition:
-      - sh: "[ 2 = 1 ]"
-        msg: "2 != 1"
-        ignore_error: true
 
   depends_on_imposssible:
     deps:
@@ -27,8 +21,3 @@ tasks:
   depends_on_failure_of_impossible:
     deps:
       - impossible_but_i_dont_care
-
-  executes_failing_task_as_cmd_but_succeeds:
-    cmds:
-      - task: impossible_but_i_dont_care
-

--- a/variables.go
+++ b/variables.go
@@ -73,6 +73,7 @@ func (e *Executor) CompiledTask(call taskfile.Call) (*taskfile.Task, error) {
 				IgnoreError: cmd.IgnoreError,
 			}
 		}
+
 	}
 	if len(origTask.Deps) > 0 {
 		new.Deps = make([]*taskfile.Dep, len(origTask.Deps))
@@ -80,6 +81,16 @@ func (e *Executor) CompiledTask(call taskfile.Call) (*taskfile.Task, error) {
 			new.Deps[i] = &taskfile.Dep{
 				Task: r.Replace(dep.Task),
 				Vars: r.ReplaceVars(dep.Vars),
+			}
+		}
+	}
+	if len(origTask.Precondition) > 0 {
+		new.Precondition = make([]*taskfile.Precondition, len(origTask.Precondition))
+		for i, precond := range origTask.Precondition {
+			new.Precondition[i] = &taskfile.Precondition{
+				Sh:          r.Replace(precond.Sh),
+				Msg:         r.Replace(precond.Msg),
+				IgnoreError: precond.IgnoreError,
 			}
 		}
 	}

--- a/variables.go
+++ b/variables.go
@@ -83,13 +83,13 @@ func (e *Executor) CompiledTask(call taskfile.Call) (*taskfile.Task, error) {
 			}
 		}
 	}
-	if len(origTask.Precondition) > 0 {
-		new.Precondition = make([]*taskfile.Precondition, len(origTask.Precondition))
-		for i, precond := range origTask.Precondition {
-			new.Precondition[i] = &taskfile.Precondition{
-				Sh:          r.Replace(precond.Sh),
-				Msg:         r.Replace(precond.Msg),
-				IgnoreError: precond.IgnoreError,
+
+	if len(origTask.Preconditions) > 0 {
+		new.Preconditions = make([]*taskfile.Precondition, len(origTask.Preconditions))
+		for i, precond := range origTask.Preconditions {
+			new.Preconditions[i] = &taskfile.Precondition{
+				Sh:  r.Replace(precond.Sh),
+				Msg: r.Replace(precond.Msg),
 			}
 		}
 	}

--- a/variables.go
+++ b/variables.go
@@ -73,7 +73,6 @@ func (e *Executor) CompiledTask(call taskfile.Call) (*taskfile.Task, error) {
 				IgnoreError: cmd.IgnoreError,
 			}
 		}
-
 	}
 	if len(origTask.Deps) > 0 {
 		new.Deps = make([]*taskfile.Dep, len(origTask.Deps))


### PR DESCRIPTION
## What changes does this PR introduce?

This adds a `preconditions` stanza to the `task` stanza.  A precondition is _basically_ the inverse of a `status` in that it's a condition that _must_ succeed before the task can run.

## Any background context you want to provide?

Preconditions on file statuses doesn't make much sense, so preconditions are limited to `sh` interpreter invocations.  Furthermore - preconditions often require the user to do something in order to proceed, so they have a `msg` field that can be used to report next steps to the user.

I've added an "ignore_error" feature to preconditions, which will ignore errors in preconditions if the task is being executed as either a dependency or as a sub-task.  I'm not 100% this isn't a misfeature, but it was requested by our team, so it's there.   Normally a failure in a precondition will fail the task that it's on, and thus any "upstream" tasks as well.

## Where should the reviewer start?

`TestPrecondition` enumerates all of the situations I could think of that encounter a conditional - it's a pretty good place to see how to use `preconditions` - they are executed in the same context as `status` commands in `areTaskPreconditionsMet`

## Has this been manually tested? How?

We run our own fork of go-task with this feature for our automation.  So far it's working well.

