### PR TITLE
#209 When "dir:" attribute points to a non-existing dir, create it

### DIFF
--- a/internal/taskfile/task.go
+++ b/internal/taskfile/task.go
@@ -1,5 +1,8 @@
 package taskfile
 
+import "os"
+import "sync"
+
 // Tasks represents a group of tasks
 type Tasks map[string]*Task
 
@@ -14,10 +17,30 @@ type Task struct {
 	Generates   []string
 	Status      []string
 	Dir         string
+	mkdirMutex  sync.Mutex
 	Vars        Vars
 	Env         Vars
 	Silent      bool
 	Method      string
 	Prefix      string
 	IgnoreError bool `yaml:"ignore_error"`
+}
+
+// Mkdir creates the directory Task.Dir.
+// Safe to be called concurrently.
+func (t *Task) Mkdir() error {
+	if t.Dir == "" {
+		// No "dir:" attribute, so we do nothing.
+		return nil
+	}
+
+	t.mkdirMutex.Lock()
+	defer t.mkdirMutex.Unlock()
+
+	if _, err := os.Stat(t.Dir); os.IsNotExist(err) {
+		if err := os.MkdirAll(t.Dir, 0755); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/task.go
+++ b/task.go
@@ -200,12 +200,14 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 		}
 	}
 
-	// When using the dir: attribute it can happen that the directory doesn't exist.
+	// When using the "dir:" attribute it can happen that the directory doesn't exist.
 	// If so, we create it.
-	if _, err := os.Stat(t.Dir); os.IsNotExist(err) {
-		if err := os.MkdirAll(t.Dir, 0755); err != nil {
-			e.Logger.Errf("cannot make directory %v: %v", t.Dir, err)
-			return err
+	if t.Dir != "" {
+		if _, err := os.Stat(t.Dir); os.IsNotExist(err) {
+			if err := os.MkdirAll(t.Dir, 0755); err != nil {
+				e.Logger.Errf("task: cannot make directory %q: %v", t.Dir, err)
+				return err
+			}
 		}
 	}
 

--- a/task.go
+++ b/task.go
@@ -202,13 +202,8 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 
 	// When using the "dir:" attribute it can happen that the directory doesn't exist.
 	// If so, we create it.
-	if t.Dir != "" {
-		if _, err := os.Stat(t.Dir); os.IsNotExist(err) {
-			if err := os.MkdirAll(t.Dir, 0755); err != nil {
-				e.Logger.Errf("task: cannot make directory %q: %v", t.Dir, err)
-				return err
-			}
-		}
+	if err := t.Mkdir(); err != nil {
+		e.Logger.Errf("task: cannot make directory %q: %v", t.Dir, err)
 	}
 
 	for i := range t.Cmds {

--- a/task.go
+++ b/task.go
@@ -200,6 +200,15 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 		}
 	}
 
+	// When using the dir: attribute it can happen that the directory doesn't exist.
+	// If so, we create it.
+	if _, err := os.Stat(t.Dir); os.IsNotExist(err) {
+		if err := os.MkdirAll(t.Dir, 0755); err != nil {
+			e.Logger.Errf("cannot make directory %v: %v", t.Dir, err)
+			return err
+		}
+	}
+
 	for i := range t.Cmds {
 		if err := e.runCommand(ctx, t, call, i); err != nil {
 			if err2 := e.statusOnError(t); err2 != nil {

--- a/task_test.go
+++ b/task_test.go
@@ -236,7 +236,7 @@ func TestDeps(t *testing.T) {
 	for _, f := range files {
 		f = filepath.Join(dir, f)
 		if _, err := os.Stat(f); err != nil {
-			t.Errorf("File %s should exists", f)
+			t.Errorf("File %s should exist", f)
 		}
 	}
 }
@@ -248,7 +248,7 @@ func TestStatus(t *testing.T) {
 	_ = os.Remove(file)
 
 	if _, err := os.Stat(file); err == nil {
-		t.Errorf("File should not exists: %v", err)
+		t.Errorf("File should not exist: %v", err)
 	}
 
 	var buff bytes.Buffer
@@ -262,7 +262,7 @@ func TestStatus(t *testing.T) {
 	assert.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "gen-foo"}))
 
 	if _, err := os.Stat(file); err != nil {
-		t.Errorf("File should exists: %v", err)
+		t.Errorf("File should exist: %v", err)
 	}
 
 	e.Silent = false
@@ -290,7 +290,7 @@ func TestGenerates(t *testing.T) {
 		path := filepath.Join(dir, task)
 		_ = os.Remove(path)
 		if _, err := os.Stat(path); err == nil {
-			t.Errorf("File should not exists: %v", err)
+			t.Errorf("File should not exist: %v", err)
 		}
 	}
 
@@ -311,10 +311,10 @@ func TestGenerates(t *testing.T) {
 		assert.NoError(t, e.Run(context.Background(), taskfile.Call{Task: theTask}))
 
 		if _, err := os.Stat(srcFile); err != nil {
-			t.Errorf("File should exists: %v", err)
+			t.Errorf("File should exist: %v", err)
 		}
 		if _, err := os.Stat(destFile); err != nil {
-			t.Errorf("File should exists: %v", err)
+			t.Errorf("File should exist: %v", err)
 		}
 		// Ensure task was not incorrectly found to be up-to-date on first run.
 		if buff.String() == upToDate {
@@ -371,7 +371,7 @@ func TestInit(t *testing.T) {
 
 	_ = os.Remove(file)
 	if _, err := os.Stat(file); err == nil {
-		t.Errorf("Taskfile.yml should not exists")
+		t.Errorf("Taskfile.yml should not exist")
 	}
 
 	if err := task.InitTaskfile(ioutil.Discard, dir); err != nil {
@@ -379,7 +379,7 @@ func TestInit(t *testing.T) {
 	}
 
 	if _, err := os.Stat(file); err != nil {
-		t.Errorf("Taskfile.yml should exists")
+		t.Errorf("Taskfile.yml should exist")
 	}
 }
 

--- a/task_test.go
+++ b/task_test.go
@@ -594,3 +594,20 @@ func TestWhenNoDirAttributeItRunsInSameDirAsTaskfile(t *testing.T) {
 	assert.Equal(t, expected, got, "Mismatch in the working directory")
 }
 
+func TestWhenDirAttributeAndDirExistsItRunsInThatDir(t *testing.T) {
+	const expected = "exists"
+	const dir = "testdata/dir/explicit_exists"
+	var out bytes.Buffer
+	e := &task.Executor{
+		Dir:    dir,
+		Stdout: &out,
+		Stderr: &out,
+	}
+
+	assert.NoError(t, e.Setup())
+	assert.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "whereami"}))
+
+	got := strings.TrimSuffix(filepath.Base(out.String()), "\n")
+	assert.Equal(t, expected, got, "Mismatch in the working directory")
+}
+

--- a/task_test.go
+++ b/task_test.go
@@ -575,3 +575,22 @@ func readTestFixture(t *testing.T, dir string, file string) string {
 	assert.NoError(t, err, "error reading text fixture")
 	return string(b)
 }
+
+func TestWhenNoDirAttributeItRunsInSameDirAsTaskfile(t *testing.T) {
+	const expected = "dir"
+	const dir = "testdata/" + expected
+	var out bytes.Buffer
+	e := &task.Executor{
+		Dir:    dir,
+		Stdout: &out,
+		Stderr: &out,
+	}
+
+	assert.NoError(t, e.Setup())
+	assert.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "whereami"}))
+
+	// got should be the "dir" part of "testdata/dir"
+	got := strings.TrimSuffix(filepath.Base(out.String()), "\n")
+	assert.Equal(t, expected, got, "Mismatch in the working directory")
+}
+

--- a/testdata/dir/Taskfile.yml
+++ b/testdata/dir/Taskfile.yml
@@ -1,0 +1,7 @@
+version: '2'
+
+tasks:
+  whereami:
+    cmds:
+      - pwd
+    silent: true

--- a/testdata/dir/explicit_doesnt_exist/Taskfile.yml
+++ b/testdata/dir/explicit_doesnt_exist/Taskfile.yml
@@ -1,0 +1,8 @@
+version: '2'
+
+tasks:
+  whereami:
+    dir: createme
+    cmds:
+      - pwd
+    silent: true

--- a/testdata/dir/explicit_exists/Taskfile.yml
+++ b/testdata/dir/explicit_exists/Taskfile.yml
@@ -1,0 +1,8 @@
+version: '2'
+
+tasks:
+  whereami:
+    dir: exists
+    cmds:
+      - pwd
+    silent: true


### PR DESCRIPTION
Also:

* Task directory: test when "dir:" attribute points to an existing dir
* Task directory: test default case (no "dir:" attribute)
* FIx spelling

Closes #209
