### PR TITLE
Add missing "-" in usage.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -385,7 +385,7 @@ version: '2'
 tasks:
   print-var:
     cmds:
-      echo "{{.VAR}}"
+      - echo "{{.VAR}}"
     vars:
       VAR: Hello!
 ```


### PR DESCRIPTION
There is a dash missing in front of an echo command. This pull request fixes it.