### PR TITLE
Added TASKFILE_DIR template variable

### DIFF
--- a/internal/templater/funcs.go
+++ b/internal/templater/funcs.go
@@ -1,6 +1,7 @@
 package templater
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -17,6 +18,12 @@ func init() {
 	taskFuncs := template.FuncMap{
 		"OS":   func() string { return runtime.GOOS },
 		"ARCH": func() string { return runtime.GOARCH },
+		"TASKFILE_DIR": func() string {
+			if wd, err := os.Getwd(); err == nil {
+				return wd
+			}
+			return ""
+		},
 		"catLines": func(s string) string {
 			s = strings.Replace(s, "\r\n", " ", -1)
 			return strings.Replace(s, "\n", " ", -1)


### PR DESCRIPTION
Added TASKFILE_DIR template variable to access the directory where the task file is located.

### example:
```
version: '2'

tasks:
    build: 
        cmds:
            - echo '{{TASKFILE_DIR}}'
```

### output 
```
$ task build
echo '/Users/coda/go/src/github.com/go-task/task/cmd/task'
/Users/coda/go/src/github.com/go-task/task/cmd/task
```
closes #215 