### PR TITLE
allow skipping dependencies

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -18,7 +18,7 @@ var (
 	version = "master"
 )
 
-const usage = `Usage: task [-ilfwvsd] [--init] [--list] [--force] [--watch] [--verbose] [--silent] [--dir] [--taskfile] [--dry] [--summary] [task...]
+const usage = `Usage: task [-ilfwvsd] [--init] [--list] [--force] [--watch] [--verbose] [--silent] [--dir] [--taskfile] [--dry] [--summary] [--skip-deps] [task...]
 
 Runs the specified task(s). Falls back to the "default" task if no task name
 was specified, or lists all tasks if an unknown task name was specified.

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -58,6 +58,7 @@ func main() {
 		silent      bool
 		dry         bool
 		summary     bool
+		skipDeps    bool
 		dir         string
 		entrypoint  string
 		output      string
@@ -73,6 +74,7 @@ func main() {
 	pflag.BoolVarP(&silent, "silent", "s", false, "disables echoing")
 	pflag.BoolVar(&dry, "dry", false, "compiles and prints tasks in the order that they would be run, without executing them")
 	pflag.BoolVar(&summary, "summary", false, "show summary about a task")
+	pflag.BoolVar(&skipDeps, "skip-deps", false, "skip task dependencies")
 	pflag.StringVarP(&dir, "dir", "d", "", "sets directory of execution")
 	pflag.StringVarP(&entrypoint, "taskfile", "t", "", `choose which Taskfile to run. Defaults to "Taskfile.yml"`)
 	pflag.StringVarP(&output, "output", "o", "", "sets output style: [interleaved|group|prefixed]")
@@ -113,6 +115,7 @@ func main() {
 		Dir:        dir,
 		Dry:        dry,
 		Entrypoint: entrypoint,
+		SkipDeps:   skipDeps,
 		Summary:    summary,
 
 		Stdin:  os.Stdin,

--- a/task.go
+++ b/task.go
@@ -40,6 +40,7 @@ type Executor struct {
 	Verbose    bool
 	Silent     bool
 	Dry        bool
+	SkipDeps   bool
 	Summary    bool
 
 	Stdin  io.Reader
@@ -273,6 +274,11 @@ func (e *Executor) mkdir(t *taskfile.Task) error {
 }
 
 func (e *Executor) runDeps(ctx context.Context, t *taskfile.Task) error {
+
+	if e.SkipDeps {
+		return nil
+	}
+
 	g, ctx := errgroup.WithContext(ctx)
 
 	for _, d := range t.Deps {


### PR DESCRIPTION
In some special cases within our CI/CD pipelines we have to run a task but not its dependencies. Therefore I added a option to skip them using `task blabla --skip-deps`.