### PR TITLE
Re-run the task if generated files do not exist

### DIFF
--- a/internal/status/checksum.go
+++ b/internal/status/checksum.go
@@ -34,7 +34,10 @@ func (c *Checksum) IsUpToDate() (bool, error) {
 	}
 
 	generates, err := glob(c.Dir, c.Generates)
-	if err != nil || len(generates) == 0 {
+	if err != nil {
+		return false, err
+	}
+	if len(generates) == 0 {
 		return false, err
 	}
 	for _, generate := range generates {

--- a/internal/status/checksum.go
+++ b/internal/status/checksum.go
@@ -28,7 +28,7 @@ func (c *Checksum) IsUpToDate() (bool, error) {
 	data, _ := ioutil.ReadFile(checksumFile)
 	oldMd5 := strings.TrimSpace(string(data))
 
-	sources, err := glob(c.Dir, c.Sources)
+	sources, err := globs(c.Dir, c.Sources)
 	if err != nil {
 		return false, err
 	}

--- a/internal/status/checksum.go
+++ b/internal/status/checksum.go
@@ -14,10 +14,11 @@ import (
 // Checksum validades if a task is up to date by calculating its source
 // files checksum
 type Checksum struct {
-	Dir     string
-	Task    string
-	Sources []string
-	Dry     bool
+	Dir       string
+	Task      string
+	Sources   []string
+	Generates []string
+	Dry       bool
 }
 
 // IsUpToDate implements the Checker interface
@@ -30,6 +31,16 @@ func (c *Checksum) IsUpToDate() (bool, error) {
 	sources, err := glob(c.Dir, c.Sources)
 	if err != nil {
 		return false, err
+	}
+
+	generates, err := glob(c.Dir, c.Generates)
+	if err != nil || len(generates) == 0 {
+		return false, err
+	}
+	for _, generate := range generates {
+		if _, err := os.Stat(generate); err != nil {
+			return false, nil
+		}
 	}
 
 	newMd5, err := c.checksum(sources...)

--- a/internal/status/checksum.go
+++ b/internal/status/checksum.go
@@ -30,8 +30,9 @@ func (c *Checksum) IsUpToDate() (bool, error) {
 
 	sources, err := globs(c.Dir, c.Sources)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
+
 	newMd5, err := c.checksum(sources...)
 	if err != nil {
 		return false, nil

--- a/internal/status/checksum.go
+++ b/internal/status/checksum.go
@@ -64,19 +64,12 @@ func (c *Checksum) checksum(files ...string) (string, error) {
 	h := md5.New()
 
 	for _, f := range files {
+		// also sum the filename, so checksum changes for renaming a file
+		if _, err := io.Copy(h, strings.NewReader(filepath.Base(f))); err != nil {
+			return "", err
+		}
 		f, err := os.Open(f)
 		if err != nil {
-			return "", err
-		}
-		info, err := f.Stat()
-		if err != nil {
-			return "", err
-		}
-		if info.IsDir() {
-			continue
-		}
-		// also sum the filename, so checksum changes for renaming a file
-		if _, err = io.Copy(h, strings.NewReader(info.Name())); err != nil {
 			return "", err
 		}
 		if _, err = io.Copy(h, f); err != nil {

--- a/internal/status/checksum.go
+++ b/internal/status/checksum.go
@@ -30,22 +30,8 @@ func (c *Checksum) IsUpToDate() (bool, error) {
 
 	sources, err := globs(c.Dir, c.Sources)
 	if err != nil {
-		return false, err
+		return false, nil
 	}
-
-	generates, err := glob(c.Dir, c.Generates)
-	if err != nil {
-		return false, err
-	}
-	if len(generates) == 0 {
-		return false, err
-	}
-	for _, generate := range generates {
-		if _, err := os.Stat(generate); err != nil {
-			return false, nil
-		}
-	}
-
 	newMd5, err := c.checksum(sources...)
 	if err != nil {
 		return false, nil
@@ -57,6 +43,20 @@ func (c *Checksum) IsUpToDate() (bool, error) {
 			return false, err
 		}
 	}
+
+	if len(c.Generates) != 0 {
+		// For each specified 'generates' field, check whether the files actually exist.
+		for _, g := range c.Generates {
+			generates, err := glob(c.Dir, g)
+			if err != nil {
+				return false, nil
+			}
+			if len(generates) == 0 {
+				return false, nil
+			}
+		}
+	}
+
 	return oldMd5 == newMd5, nil
 }
 

--- a/internal/status/timestamp.go
+++ b/internal/status/timestamp.go
@@ -19,11 +19,11 @@ func (t *Timestamp) IsUpToDate() (bool, error) {
 		return false, nil
 	}
 
-	sources, err := glob(t.Dir, t.Sources)
+	sources, err := globs(t.Dir, t.Sources)
 	if err != nil {
 		return false, nil
 	}
-	generates, err := glob(t.Dir, t.Generates)
+	generates, err := globs(t.Dir, t.Generates)
 	if err != nil {
 		return false, nil
 	}

--- a/status.go
+++ b/status.go
@@ -58,10 +58,11 @@ func (e *Executor) getStatusChecker(t *taskfile.Task) (status.Checker, error) {
 		}, nil
 	case "checksum":
 		return &status.Checksum{
-			Dir:     t.Dir,
-			Task:    t.Task,
-			Sources: t.Sources,
-			Dry:     e.Dry,
+			Dir:       t.Dir,
+			Task:      t.Task,
+			Sources:   t.Sources,
+			Generates: t.Generates,
+			Dry:       e.Dry,
 		}, nil
 	case "none":
 		return status.None{}, nil


### PR DESCRIPTION
When using `method: checksum`, I was surprised to find out that even when files specified by `generates` do not exist the task won't get triggered as long as the source files are not modified. IMHO this behavior is unintuitive, especially considering how Makefile works. This PR adds a logic to re-run the task when files specified in generates do not exist.