### PR TITLE
Bash autocompletion for task

### DIFF
--- a/completion/bash/task.bash
+++ b/completion/bash/task.bash
@@ -3,7 +3,7 @@ _task_completion()
   local scripts;
   local curr_arg;
 
-  # Remove colon from work breaks
+  # Remove colon from word breaks
   COMP_WORDBREAKS=${COMP_WORDBREAKS//:}
 
   scripts=$(task -l | sed '1d' | sed 's/^\* //' | awk '{ print $1 }');

--- a/completion/task.bash
+++ b/completion/task.bash
@@ -1,0 +1,21 @@
+_task_completion()
+{
+  local scripts;
+  local curr_arg;
+
+  # Remove colon from work breaks
+  COMP_WORDBREAKS=${COMP_WORDBREAKS//:}
+
+  scripts=$(task -l | sed '1d' | sed 's/^\* //' | awk '{ print $1 }');
+
+  curr_arg="${COMP_WORDS[COMP_CWORD]:-"."}"
+
+  # Do not accept more than 1 argument
+  if [ "${#COMP_WORDS[@]}" != "2" ]; then
+    return
+  fi
+
+  COMPREPLY=($(compgen -c | echo "$scripts" | grep $curr_arg));
+}
+
+complete -F _task_completion task


### PR DESCRIPTION
Adds the bash autocomplete script into the repo (#103)

How to test it in Mac OS:

First make sure `bash-completion` is installed in your machine:

```shell
$ brew install bash-completion
```

It'll create `/usr/local/etc/bash_completion.d/` folder and add autocomplete files for your existing CLI tools.

For it to work, add this to your `~/.bashrc`:
```shell
[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion
```

Now we're ready to add `task` autocomplete script:

Copy the bash autocomplete script and put it to `/usr/local/etc/bash_completion.d/task`. Start a new shell and it should work!

It's open to the feedback. I think we should add more documentation about autocompletion setup, as some users may not even know it exists for task.
