### PR TITLE
Add flag to allow tasks provided on the command line to be run in parallel

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -58,6 +58,7 @@ func main() {
 		silent      bool
 		dry         bool
 		summary     bool
+		parallel    bool
 		dir         string
 		entrypoint  string
 		output      string
@@ -71,6 +72,7 @@ func main() {
 	pflag.BoolVarP(&watch, "watch", "w", false, "enables watch of the given task")
 	pflag.BoolVarP(&verbose, "verbose", "v", false, "enables verbose mode")
 	pflag.BoolVarP(&silent, "silent", "s", false, "disables echoing")
+	pflag.BoolVarP(&parallel, "parallel", "p", false, "executes tasks provided on command line in parallel")
 	pflag.BoolVar(&dry, "dry", false, "compiles and prints tasks in the order that they would be run, without executing them")
 	pflag.BoolVar(&summary, "summary", false, "show summary about a task")
 	pflag.StringVarP(&dir, "dir", "d", "", "sets directory of execution")
@@ -114,6 +116,7 @@ func main() {
 		Dry:        dry,
 		Entrypoint: entrypoint,
 		Summary:    summary,
+		Parallel:   parallel,
 
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,


### PR DESCRIPTION
I have a Taskfile with many different targets and the targets I want to run vary often enough I cannot just put them under another task's `dep`. I'm looking for when I run I supply the list of targets via the command line they will execute in parallel rather than sequentially.

Example of what I looking to
```
$ time task -p sleep1 sleep2
sleep 10
sleep 10
echo sleep 1
echo sleep 2
sleep 1
sleep 2

real	0m10.986s
user	0m0.755s
sys	0m0.530s
```

```yaml
version: '2'

tasks:
  default:
    deps:
      - task: sleep1
      - task: sleep2
      - task: sleep3
  sleep1:
    cmds:
      - sleep 10
      - echo sleep 1
  sleep2:
    cmds:
      - sleep 10
      - echo sleep 2
  sleep3:
    cmds:
      - sleep 10
      - echo sleep 3
```