### PR TITLE
Compile tasks before printing help or summary

### DIFF
--- a/help.go
+++ b/help.go
@@ -29,6 +29,10 @@ func (e *Executor) tasksWithDesc() (tasks []*taskfile.Task) {
 	tasks = make([]*taskfile.Task, 0, len(e.Taskfile.Tasks))
 	for _, task := range e.Taskfile.Tasks {
 		if task.Desc != "" {
+			compiledTask, err := e.CompiledTask(taskfile.Call{Task: task.Task})
+			if err == nil {
+				task = compiledTask
+			}
 			tasks = append(tasks, task)
 		}
 	}

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -9,12 +9,12 @@ import (
 
 func PrintTasks(l *logger.Logger, t *taskfile.Taskfile, c []taskfile.Call) {
 	for i, call := range c {
-		printSpaceBetweenSummaries(l, i)
+		PrintSpaceBetweenSummaries(l, i)
 		PrintTask(l, t.Tasks[call.Task])
 	}
 }
 
-func printSpaceBetweenSummaries(l *logger.Logger, i int) {
+func PrintSpaceBetweenSummaries(l *logger.Logger, i int) {
 	spaceRequired := i > 0
 	if !spaceRequired {
 		return

--- a/task.go
+++ b/task.go
@@ -70,7 +70,14 @@ func (e *Executor) Run(ctx context.Context, calls ...taskfile.Call) error {
 	}
 
 	if e.Summary {
-		summary.PrintTasks(e.Logger, e.Taskfile, calls)
+		for i, c := range calls {
+			compiledTask, err := e.CompiledTask(c)
+			if err != nil {
+				return nil
+			}
+			summary.PrintSpaceBetweenSummaries(e.Logger, i)
+			summary.PrintTask(e.Logger, compiledTask)
+		}
 		return nil
 	}
 

--- a/variables.go
+++ b/variables.go
@@ -25,6 +25,7 @@ func (e *Executor) CompiledTask(call taskfile.Call) (*taskfile.Task, error) {
 	new := taskfile.Task{
 		Task:        origTask.Task,
 		Desc:        r.Replace(origTask.Desc),
+		Summary:     r.Replace(origTask.Summary),
 		Sources:     r.ReplaceSlice(origTask.Sources),
 		Generates:   r.ReplaceSlice(origTask.Generates),
 		Status:      r.ReplaceSlice(origTask.Status),


### PR DESCRIPTION
Updates the `help.go` file to compile a task before printing its description. This enables templatization for the `-l` flag.

Also updates `summary/summary.go` and `task.go` to compile tasks before printing a summary.

Relates to https://github.com/go-task/task/issues/276