### PR TITLE
Add note about Arch Linux package

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,6 +40,19 @@ scoop install task
 This installation method is community owned. After a new release of Task, it
 may take some time until it's available on Scoop.
 
+## Arch Linux
+
+If you're on Arch Linux you can install Task from
+[AUR](https://aur.archlinux.org/packages/taskfile-git) using your favorite
+package manager such as `yay`, `pacaur` or `yaourt`:
+
+```cmd
+yay -S taskfile-git
+```
+
+This installation method is community owned, but since it's `-git` version of
+the package, it's always latest available version based on the git repository.
+
 ## Go
 
 Task now uses [Go Modules](https://github.com/golang/go/wiki/Modules), which

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,7 +51,7 @@ yay -S taskfile-git
 ```
 
 This installation method is community owned, but since it's `-git` version of
-the package, it's always latest available version based on the git repository.
+the package, it's always latest available version based on the Git repository.
 
 ## Go
 


### PR DESCRIPTION
Hi, I've recently started maintaining Task for Arch Linux users here:
https://aur.archlinux.org/packages/taskfile-git

Any Arch Linux user can install it through their favorite package manager and
get the latest version of package. Unfortunately, `task` and `task-git` package
names are already taken.