### PR TITLE
Remove trailing colon from task listing

### DIFF
--- a/completion/bash/task.bash
+++ b/completion/bash/task.bash
@@ -6,7 +6,7 @@ _task_completion()
   # Remove colon from word breaks
   COMP_WORDBREAKS=${COMP_WORDBREAKS//:}
 
-  scripts=$(task -l | sed '1d' | sed 's/^\* //' | awk '{ print $1 }');
+  scripts=$(task -l | sed '1d' | awk '{ print $2 }' | sed 's/:$//');
 
   curr_arg="${COMP_WORDS[COMP_CWORD]:-"."}"
 


### PR DESCRIPTION
This fixes bash autocompletion that fails by producing an extra colon at the end of completions.  Note that there is a similar sed for colon removal already present in the zsh autocomplete

It also removes an unnecessary `sed 's/^\* //'` in favor of just using `print $2` in the awk command.

