### PR TITLE
Enhance zsh/bash shell tab-completion

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -124,6 +124,12 @@ func main() {
 
 		OutputStyle: output,
 	}
+
+	if list && silent {
+		e.PrintTaskNames() // silently ignore any errors
+		return
+	}
+
 	if err := e.Setup(); err != nil {
 		log.Fatal(err)
 	}

--- a/completion/bash/task.bash
+++ b/completion/bash/task.bash
@@ -1,21 +1,25 @@
 _task_completion()
 {
-  local scripts;
-  local curr_arg;
+  local scripts curr
 
   # Remove colon from word breaks
   COMP_WORDBREAKS=${COMP_WORDBREAKS//:}
 
-  scripts=$(task -l | sed '1d' | awk '{ print $2 }' | sed 's/:$//');
+  scripts=$(task -l -s)
+  options="--help --dir --dry --force --init --list --output --parallel --silent --status --summary --taskfile --verbose --version --watch"
 
-  curr_arg="${COMP_WORDS[COMP_CWORD]:-"."}"
+  curr="${COMP_WORDS[COMP_CWORD]}"
 
   # Do not accept more than 1 argument
   if [ "${#COMP_WORDS[@]}" != "2" ]; then
     return
   fi
 
-  COMPREPLY=($(compgen -c | echo "$scripts" | grep $curr_arg));
+  if [[ "${curr}" =~ ^- ]] || [[ "${scripts}" == "" ]]; then
+    COMPREPLY=($(compgen -W "${options}" -- ${curr}))
+  elif [[ "${scripts}" != "" ]]; then
+    COMPREPLY=($(compgen -W "${scripts}" -- ${curr}))
+  fi
 }
 
-complete -F _task_completion task
+complete -F _task_completion -o default task

--- a/completion/zsh/_task
+++ b/completion/zsh/_task
@@ -5,7 +5,7 @@ function __list() {
     local -a scripts
 
     if [ -f Taskfile.yml ]; then
-        scripts=($(task -l | sed '1d' | sed 's/^\* //' | awk '{ print $1 }' | sed 's/:$//' | sed 's/:/\\:/'))
+        scripts=($(task -l -s | sed 's/:/\\:/'))
         _describe 'script' scripts
     fi
 }

--- a/help.go
+++ b/help.go
@@ -2,7 +2,10 @@ package task
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"sort"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/go-task/task/v2/internal/taskfile"
@@ -38,4 +41,34 @@ func (e *Executor) tasksWithDesc() (tasks []*taskfile.Task) {
 	}
 	sort.Slice(tasks, func(i, j int) bool { return tasks[i].Task < tasks[j].Task })
 	return
+}
+
+// PrintTaskNames prints only the task names in a taskfile.
+func (e *Executor) PrintTaskNames() error {
+	// if called from cmd/task.go, e.Taskfile has not yet been parsed
+	if nil == e.Taskfile {
+		err := e.readTaskfile()
+		if nil != err {
+			return err
+		}
+	}
+	var w io.Writer = os.Stdout
+	if nil != e.Stdout {
+		w = e.Stdout
+	}
+
+	// create a slice from all map values
+	task := make([]*taskfile.Task, 0, len(e.Taskfile.Tasks))
+	for _, t := range e.Taskfile.Tasks {
+		task = append(task, t)
+	}
+
+	sort.Slice(task,
+		func(i, j int) bool {
+			return task[i].Task < task[j].Task
+		})
+	for _, t := range task {
+		fmt.Fprintf(w, "%s\n", strings.TrimSuffix(t.Task, ":"))
+	}
+	return nil
 }

--- a/task.go
+++ b/task.go
@@ -99,14 +99,20 @@ func (e *Executor) Run(ctx context.Context, calls ...taskfile.Call) error {
 	return g.Wait()
 }
 
-// Setup setups Executor's internal state
-func (e *Executor) Setup() error {
+// readTaskfile selects and parses the entrypoint.
+func (e *Executor) readTaskfile() error {
+	// select the default entrypoint if not provided
 	if e.Entrypoint == "" {
 		e.Entrypoint = "Taskfile.yml"
 	}
-
 	var err error
 	e.Taskfile, err = read.Taskfile(e.Dir, e.Entrypoint)
+	return err
+}
+
+// Setup setups Executor's internal state
+func (e *Executor) Setup() error {
+	err := e.readTaskfile()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The tab-completion scripts for bash/zsh are very slow. The bash tab-completion would also not actually auto-complete unambiguous task names and would just display them (I didn't verify zsh/powershell).

The problem is that `cmd/task` was parsing the YAML, compiling tasks, initializing the `Logger` instances, etc. just to print out the task names. 

Instead of adding a new command-line flag, I've just combined two incompatible flags `--list` and `--silent` that will perform only as much overhead as required to print just the available task names, e.g. `task -l -s`

Also updated the bash/zsh completion scripts to use these flags instead of running through a bunch of sed/awk pipes. Added auto-completion for tasks and command-line options too (bash only).

The completion scripts could still use work to perform context-aware suggestions.