### PR TITLE
suppress context errors when use watch option

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -91,6 +91,10 @@ func (e *Executor) watchTasks(calls ...taskfile.Call) error {
 }
 
 func isContextError(err error) bool {
+	if taskRunErr, ok := err.(*taskRunError); ok {
+		err = taskRunErr.err
+	}
+
 	return err == context.Canceled || err == context.DeadlineExceeded
 }
 


### PR DESCRIPTION
When I launch `task` with --watch option, occur context canceled occurs.
issue is here. https://github.com/go-task/task/issues/313

The cause was that it couldn't check custom error struct ([taskRunError](https://github.com/go-task/task/blob/master/errors.go#L21)).
this pr resolve it.