### PR TITLE
Fix name_template in Go Releaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,4 +40,4 @@ nfpms:
     formats:
       - deb
       - rpm
-    name_template: "{{.ProjectName}}_{{.Os}}_{{.Arch}}"
+    file_name_template: "{{.ProjectName}}_{{.Os}}_{{.Arch}}"


### PR DESCRIPTION
As mentioned in #325  config name_template is now file_name_template.

See https://goreleaser.com/deprecations/#nfpmsname_template for details.

