### PR TITLE
Have the --help/-h flag print usage.

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -49,6 +49,7 @@ func main() {
 
 	var (
 		versionFlag bool
+		helpFlag    bool
 		init        bool
 		list        bool
 		status      bool
@@ -65,6 +66,7 @@ func main() {
 	)
 
 	pflag.BoolVar(&versionFlag, "version", false, "show Task version")
+	pflag.BoolVarP(&helpFlag, "help", "h", false, "shows Task usage")
 	pflag.BoolVarP(&init, "init", "i", false, "creates a new Taskfile.yml in the current folder")
 	pflag.BoolVarP(&list, "list", "l", false, "lists tasks with description of current Taskfile")
 	pflag.BoolVar(&status, "status", false, "exits with non-zero exit code if any of the given tasks is not up-to-date")
@@ -82,6 +84,11 @@ func main() {
 
 	if versionFlag {
 		log.Printf("Task version: %s\n", version)
+		return
+	}
+
+	if helpFlag {
+		pflag.Usage()
 		return
 	}
 


### PR DESCRIPTION
pflag will output a "pflag: help requested" message after displaying the usage
if we don't explicitly  handle the flag.