### PR TITLE
Eliminate use of single quotes for version string.

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 # silent: true
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Once [installed](installation.md), you just need to describe your build tasks
 using a simple [YAML][yaml] schema in a file called `Taskfile.yml`:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   hello:

--- a/docs/Taskfile.yml
+++ b/docs/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 tasks:
   install:

--- a/docs/taskfile_versions.md
+++ b/docs/taskfile_versions.md
@@ -38,7 +38,7 @@ with new features without breaking existing Taskfiles. The new syntax is as
 follows:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   echo:
@@ -50,7 +50,7 @@ Version 2 allows you to write global variables directly in the Taskfile,
 if you don't want to create a `Taskvars.yml`:
 
 ```yaml
-version: '2'
+version: 2
 
 vars:
   GREETING: Hello, World!
@@ -73,7 +73,7 @@ A new global option was added to configure the number of variables expansions
 (which default to 2):
 
 ```yaml
-version: '2'
+version: 2
 
 expansions: 3
 
@@ -97,7 +97,7 @@ over how commands output are printed to the console
 (see [documentation][output] for more info):
 
 ```yaml
-version: '2'
+version: 2
 
 output: prefixed
 
@@ -112,7 +112,7 @@ From this version it's not also possible to ignore errors of a command or task
 (check documentation [here][ignore_errors]):
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   example-1:
@@ -134,7 +134,7 @@ Version 2.2 comes with a global `includes` options to include other
 Taskfiles:
 
 ```yaml
-version: '2'
+version: 2
 
 includes:
   docs: ./documentation # will look for ./documentation/Taskfile.yml
@@ -146,7 +146,7 @@ includes:
 Version 2.6 comes with `preconditions` stanza in tasks.
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   upload_environment:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,7 @@ The example below allows compiling a Go app and uses [Minify][minify] to concat
 and minify multiple CSS files into a single one.
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   build:
@@ -38,7 +38,7 @@ If you omit a task name, "default" will be assumed.
 You can use `env` to set custom environment variables for a specific task:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   greet:
@@ -52,7 +52,7 @@ Additionally, you can set globally environment variables, that'll be available
 to all tasks:
 
 ```yaml
-version: '2'
+version: 2
 
 env:
   GREETING: Hey, there!
@@ -76,7 +76,7 @@ Example:
 Taskfile.yml:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   build:
@@ -87,7 +87,7 @@ tasks:
 Taskfile_linux.yml:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   build:
@@ -112,7 +112,7 @@ If you want to share tasks between different projects (Taskfiles), you can use
 the importing mechanism to include other Taskfiles using the `includes` keyword:
 
 ```yaml
-version: '2'
+version: 2
 
 includes:
   docs: ./documentation # will look for ./documentation/Taskfile.yml
@@ -138,7 +138,7 @@ located. But you can easily make the task run in another folder informing
 `dir`:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   serve:
@@ -160,7 +160,7 @@ You may have tasks that depend on others. Just pointing them on `deps` will
 make them run automatically before running the parent task:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   build:
@@ -179,7 +179,7 @@ In the above example, `assets` will always run right before `build` if you run
 A task can have only dependencies and no commands to group tasks together:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   assets:
@@ -204,7 +204,7 @@ If you want to pass information to dependencies, you can do that the same
 manner as you would to [call another task](#calling-another-task):
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   default:
@@ -228,7 +228,7 @@ often result in a faster build pipeline. But in some situations you may need
 to call other tasks serially. In this case, just use the following syntax:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   main-task:
@@ -250,7 +250,7 @@ Overriding variables in the called task is as simple as informing `vars`
 attribute:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   main-task:
@@ -277,7 +277,7 @@ If a task generates something, you can inform Task the source and generated
 files, so Task will prevent to run them if not necessary.
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   build:
@@ -313,7 +313,7 @@ You will probably want to ignore the `.task` folder in your `.gitignore` file
 (It's there that Task stores the last checksum).
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   build:
@@ -332,7 +332,7 @@ Alternatively, you can inform a sequence of tests as `status`. If no error
 is returned (exit status 0), the task is considered up-to-date:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   generate-files:
@@ -358,7 +358,7 @@ If you need a certain set of conditions to be _true_ you can use the
 lines except they support `sh` expansion and they SHOULD all return 0.
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   generate-files:
@@ -386,7 +386,7 @@ executing tasks that depend on it, a `precondition` will fail a task, along
 with any other tasks that depend on it.
 
 ```yaml
-version: '2'
+version: 2
 tasks:
   task_will_fail:
     preconditions:
@@ -438,7 +438,7 @@ $ task OUTPUT=file.txt generate-file
 Example of locally declared vars:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   print-var:
@@ -451,7 +451,7 @@ tasks:
 Example of global vars in a `Taskfile.yml`:
 
 ```yaml
-version: '2'
+version: 2
 
 vars:
   GREETING: Hello from Taskfile!
@@ -477,7 +477,7 @@ Variables are expanded 2 times by default. You can change that by setting the
 variables together:
 
 ```yaml
-version: '2'
+version: 2
 
 expansions: 3
 
@@ -501,7 +501,7 @@ The value will be treated as a command and the output assigned. If there is one
 or more trailing newlines, the last newline will be trimmed.
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   build:
@@ -523,7 +523,7 @@ All functions by the Go's [sprig lib](http://masterminds.github.io/sprig/)
 are available. The following example gets the current date in a given format:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   print-date:
@@ -549,7 +549,7 @@ Task also adds the following functions:
 Example:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   print-os:
@@ -577,7 +577,7 @@ Running `task --list` (or `task -l`) lists all tasks with a description.
 The following Taskfile:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   build:
@@ -612,7 +612,7 @@ Running `task --summary task-name` will show a summary of a task
 The following Taskfile:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   release:
@@ -657,7 +657,7 @@ Silent mode disables echoing of commands before Task runs it.
 For the following Taskfile:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   echo:
@@ -683,7 +683,7 @@ There are four ways to enable silent mode:
 * At command level:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   echo:
@@ -695,7 +695,7 @@ tasks:
 * At task level:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   echo:
@@ -707,7 +707,7 @@ tasks:
 * Globally at Taskfile level:
 
 ```yaml
-version: '2'
+version: 2
 
 silent: true
 
@@ -722,7 +722,7 @@ tasks:
 If you want to suppress STDOUT instead, just redirect a command to `/dev/null`:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   echo:
@@ -741,7 +741,7 @@ You have the option to ignore errors during command execution.
 Given the following Taskfile:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   echo:
@@ -754,7 +754,7 @@ Task will abort the execution after running `exit 1` because the status code `1`
 However it is possible to continue with execution using `ignore_error`:
 
 ```yaml
-version: '2'
+version: 2
 
 tasks:
   echo:
@@ -785,7 +785,7 @@ options you can choose:
 To choose another one, just set it to root in the Taskfile:
 
 ```yaml
-version: '2'
+version: 2
 
 output: 'group'
 
@@ -802,7 +802,7 @@ tasks:
  with the `prefix:` attribute:
 
  ```yaml
-version: '2'
+version: 2
 
 output: prefixed
 

--- a/init.go
+++ b/init.go
@@ -10,7 +10,7 @@ import (
 
 const defaultTaskfile = `# https://taskfile.dev
 
-version: '2'
+version: 2
 
 vars:
   GREETING: Hello, World!

--- a/testdata/dir/Taskfile.yml
+++ b/testdata/dir/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 tasks:
   whereami:

--- a/testdata/dir/explicit_doesnt_exist/Taskfile.yml
+++ b/testdata/dir/explicit_doesnt_exist/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 tasks:
   whereami:

--- a/testdata/dir/explicit_exists/Taskfile.yml
+++ b/testdata/dir/explicit_exists/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 tasks:
   whereami:

--- a/testdata/dry/Taskfile.yml
+++ b/testdata/dry/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 tasks:
   build:

--- a/testdata/dry_checksum/Taskfile.yml
+++ b/testdata/dry_checksum/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 tasks:
   default:

--- a/testdata/env/Taskfile.yml
+++ b/testdata/env/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 vars:
   BAZ:

--- a/testdata/expand/Taskfile.yml
+++ b/testdata/expand/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 tasks:
   pwd:

--- a/testdata/ignore_errors/Taskfile.yml
+++ b/testdata/ignore_errors/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 tasks:
   task-should-pass:

--- a/testdata/includes/Taskfile.yml
+++ b/testdata/includes/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 includes:
   included: ./included

--- a/testdata/includes/Taskfile2.yml
+++ b/testdata/includes/Taskfile2.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 tasks:
   gen:

--- a/testdata/includes/included/Taskfile.yml
+++ b/testdata/includes/included/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 tasks:
   gen:

--- a/testdata/includes_call_root_task/Taskfile.yml
+++ b/testdata/includes_call_root_task/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 includes:
   included: Taskfile2.yml

--- a/testdata/includes_call_root_task/Taskfile2.yml
+++ b/testdata/includes_call_root_task/Taskfile2.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 tasks:
   call-root:

--- a/testdata/includes_deps/Taskfile.yml
+++ b/testdata/includes_deps/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 includes:
   included: Taskfile2.yml

--- a/testdata/includes_deps/Taskfile2.yml
+++ b/testdata/includes_deps/Taskfile2.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 tasks:
   default:

--- a/testdata/includes_empty/Taskfile.yml
+++ b/testdata/includes_empty/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 includes:
   included: Taskfile2.yml

--- a/testdata/includes_empty/Taskfile2.yml
+++ b/testdata/includes_empty/Taskfile2.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 vars:
   FILE: file.txt

--- a/testdata/precondition/Taskfile.yml
+++ b/testdata/precondition/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 tasks:
   foo:

--- a/testdata/vars/v2/Taskfile.yml
+++ b/testdata/vars/v2/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 
 vars:
   NESTED2: "{{.NESTED1}}-TaskfileVars"

--- a/testdata/vars/v2/multiline/Taskfile.yml
+++ b/testdata/vars/v2/multiline/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: 2
 tasks:
   default:
     vars:


### PR DESCRIPTION
According to the [Styleguide](https://taskfile.dev/#/styleguide), the `version` string should not use single quotes for its value.

This PR attempts to consistently fix this in examples and tests across the codebase.