### PR TITLE
always treat command line arguments as global

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -16,9 +16,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-var (
-	version = "master"
-)
+var version = "master"
 
 const usage = `Usage: task [-ilfwvsd] [--init] [--list] [--force] [--watch] [--verbose] [--silent] [--dir] [--taskfile] [--dry] [--summary] [task...]
 

--- a/internal/args/args.go
+++ b/internal/args/args.go
@@ -17,19 +17,11 @@ func Parse(args ...string) ([]taskfile.Call, *taskfile.Vars) {
 			continue
 		}
 
-		if len(calls) < 1 {
-			if globals == nil {
-				globals = &taskfile.Vars{}
-			}
-			name, value := splitVar(arg)
-			globals.Set(name, taskfile.Var{Static: value})
-		} else {
-			if calls[len(calls)-1].Vars == nil {
-				calls[len(calls)-1].Vars = &taskfile.Vars{}
-			}
-			name, value := splitVar(arg)
-			calls[len(calls)-1].Vars.Set(name, taskfile.Var{Static: value})
+		if globals == nil {
+			globals = &taskfile.Vars{}
 		}
+		name, value := splitVar(arg)
+		globals.Set(name, taskfile.Var{Static: value})
 	}
 
 	if len(calls) == 0 {

--- a/internal/args/args_test.go
+++ b/internal/args/args_test.go
@@ -27,39 +27,28 @@ func TestArgs(t *testing.T) {
 		{
 			Args: []string{"task-a", "FOO=bar", "task-b", "task-c", "BAR=baz", "BAZ=foo"},
 			ExpectedCalls: []taskfile.Call{
-				{
-					Task: "task-a",
-					Vars: &taskfile.Vars{
-						Keys: []string{"FOO"},
-						Mapping: map[string]taskfile.Var{
-							"FOO": taskfile.Var{Static: "bar"},
-						},
-					},
-				},
+				{Task: "task-a"},
 				{Task: "task-b"},
-				{
-					Task: "task-c",
-					Vars: &taskfile.Vars{
-						Keys: []string{"BAR", "BAZ"},
-						Mapping: map[string]taskfile.Var{
-							"BAR": taskfile.Var{Static: "baz"},
-							"BAZ": taskfile.Var{Static: "foo"},
-						},
-					},
+				{Task: "task-c"},
+			},
+			ExpectedGlobals: &taskfile.Vars{
+				Keys: []string{"FOO", "BAR", "BAZ"},
+				Mapping: map[string]taskfile.Var{
+					"FOO": taskfile.Var{Static: "bar"},
+					"BAR": taskfile.Var{Static: "baz"},
+					"BAZ": taskfile.Var{Static: "foo"},
 				},
 			},
 		},
 		{
 			Args: []string{"task-a", "CONTENT=with some spaces"},
 			ExpectedCalls: []taskfile.Call{
-				{
-					Task: "task-a",
-					Vars: &taskfile.Vars{
-						Keys: []string{"CONTENT"},
-						Mapping: map[string]taskfile.Var{
-							"CONTENT": taskfile.Var{Static: "with some spaces"},
-						},
-					},
+				{Task: "task-a"},
+			},
+			ExpectedGlobals: &taskfile.Vars{
+				Keys: []string{"CONTENT"},
+				Mapping: map[string]taskfile.Var{
+					"CONTENT": taskfile.Var{Static: "with some spaces"},
 				},
 			},
 		},


### PR DESCRIPTION
This pull request converts all command line arguments to global variables.
Fixes #336