### PR TITLE
Adding a jobs flag to limit the number of tasks running in goroutines

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -65,6 +65,7 @@ func main() {
 		dry         bool
 		summary     bool
 		parallel    bool
+		concurrency int
 		dir         string
 		entrypoint  string
 		output      string
@@ -87,6 +88,7 @@ func main() {
 	pflag.StringVarP(&entrypoint, "taskfile", "t", "", `choose which Taskfile to run. Defaults to "Taskfile.yml"`)
 	pflag.StringVarP(&output, "output", "o", "", "sets output style: [interleaved|group|prefixed]")
 	pflag.BoolVarP(&color, "color", "c", true, "colored output")
+	pflag.IntVarP(&concurrency, "concurrency", "C", 0, "limit number tasks to run concurrently")
 	pflag.Parse()
 
 	if versionFlag {
@@ -122,16 +124,17 @@ func main() {
 	}
 
 	e := task.Executor{
-		Force:      force,
-		Watch:      watch,
-		Verbose:    verbose,
-		Silent:     silent,
-		Dir:        dir,
-		Dry:        dry,
-		Entrypoint: entrypoint,
-		Summary:    summary,
-		Parallel:   parallel,
-		Color:      color,
+		Force:            force,
+		Watch:            watch,
+		Verbose:          verbose,
+		Silent:           silent,
+		Dir:              dir,
+		Dry:              dry,
+		Entrypoint:       entrypoint,
+		Summary:          summary,
+		Parallel:         parallel,
+		Color:            color,
+		ConcurrencyLimit: concurrency,
 
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,

--- a/task_test.go
+++ b/task_test.go
@@ -171,6 +171,22 @@ func TestVarsInvalidTmpl(t *testing.T) {
 	assert.EqualError(t, e.Run(context.Background(), taskfile.Call{Task: target}), expectError, "e.Run(target)")
 }
 
+func TestConcurrency(t *testing.T) {
+	const (
+		dir    = "testdata/concurrency"
+		target = "default"
+	)
+
+	e := &task.Executor{
+		Dir:              dir,
+		Stdout:           ioutil.Discard,
+		Stderr:           ioutil.Discard,
+		ConcurrencyLimit: 1,
+	}
+	assert.NoError(t, e.Setup(), "e.Setup()")
+	assert.NoError(t, e.Run(context.Background(), taskfile.Call{Task: target}), "e.Run(target)")
+}
+
 func TestParams(t *testing.T) {
 	tt := fileContentTest{
 		Dir:       "testdata/params",

--- a/testdata/concurrency/Taskfile.yml
+++ b/testdata/concurrency/Taskfile.yml
@@ -1,0 +1,33 @@
+version: '2'
+output: 'prefixed'
+
+tasks:
+  default:
+    deps:
+      - t1
+
+  t1:
+    deps:
+      - t3
+      - t4
+    cmds:
+      - task: t2
+      - echo done 1
+  t2:
+    deps:
+      - t5
+      - t6
+    cmds:
+      - echo done 2
+  t3:
+    cmds:
+      - echo done 3
+  t4:
+    cmds:
+      - echo done 4
+  t5:
+    cmds:
+      - echo done 5
+  t6:
+    cmds:
+      - echo done 6


### PR DESCRIPTION
We are using a single taskfile to build all of our application which consists of many different docker images. This can overwhelm our computer when we start building it and it actually runs faster if limit how many things run at once. There are not many dependencies between the images so a lot is run in parallel and we want to limit it based off the developer's system rather than coding it in the taskfile directly.

I used the term jobs for everything using make as an example people may be familiar with.