### PR TITLE
Add command-level and task-level warning

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -68,6 +68,7 @@ func main() {
 		entrypoint  string
 		output      string
 		color       bool
+		yes         bool
 	)
 
 	pflag.BoolVar(&versionFlag, "version", false, "show Task version")
@@ -86,6 +87,7 @@ func main() {
 	pflag.StringVarP(&entrypoint, "taskfile", "t", "", `choose which Taskfile to run. Defaults to "Taskfile.yml"`)
 	pflag.StringVarP(&output, "output", "o", "", "sets output style: [interleaved|group|prefixed]")
 	pflag.BoolVarP(&color, "color", "c", true, "colored output")
+	pflag.BoolVarP(&yes, "yes", "y", false, "automatic yes to warning prompts")
 	pflag.Parse()
 
 	if versionFlag {
@@ -131,6 +133,7 @@ func main() {
 		Summary:    summary,
 		Parallel:   parallel,
 		Color:      color,
+		Yes:        yes,
 
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -920,3 +920,47 @@ so task know which files to watch.
 
 [gotemplate]: https://golang.org/pkg/text/template/
 [minify]: https://github.com/tdewolff/minify/tree/master/cmd/minify
+
+## Warning prompts
+
+You can add both task level and command level warning prompts to your Taskfile.
+
+Here is how `warning` can be used at both levels:
+
+```yaml
+version: '3'
+
+tasks:
+  delete-things:
+    desc: Remove both important and unimportant files
+    warning: Are you sure you want to run this task?
+    cmds:
+      - rm -rf /unimportant-files
+      - cmd: rm -rf /important-files
+        warning: Are you sure you want to run this command?
+```
+
+In this example, a warning prompt will be presented both at the start of the task,
+and again when the task reaches the command with a warning.
+
+> NOTE: as with [silent mode](#silent-mode) and [ignore errors](#ignore-errors), 
+> to add an option at the command level requires prefixing the target command with `cmd:`
+
+### Behavior of denied warnings
+
+When a task level warning is denied, the task is skipped.  Command level warnings have
+the same behavior: when denied, the task continues on to the next command (if any).
+
+### Automatic confirmation
+
+The `[-y | --yes]` option passed with a task call enables the ability to automatically
+confirm a task with warnings.  When provided, all warnings, at both task and command
+levels are confirmed.
+
+To build off the example above:
+
+```bash
+$ task delete-things -y
+```
+
+Will run the entire task without warning. Use with caution!

--- a/internal/taskfile/cmd.go
+++ b/internal/taskfile/cmd.go
@@ -11,6 +11,7 @@ type Cmd struct {
 	Silent      bool
 	Task        string
 	Vars        *Vars
+	Warning     string
 	IgnoreError bool
 }
 
@@ -41,11 +42,13 @@ func (c *Cmd) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var cmdStruct struct {
 		Cmd         string
 		Silent      bool
+		Warning     string
 		IgnoreError bool `yaml:"ignore_error"`
 	}
 	if err := unmarshal(&cmdStruct); err == nil && cmdStruct.Cmd != "" {
 		c.Cmd = cmdStruct.Cmd
 		c.Silent = cmdStruct.Silent
+		c.Warning = cmdStruct.Warning
 		c.IgnoreError = cmdStruct.IgnoreError
 		return nil
 	}

--- a/internal/taskfile/task.go
+++ b/internal/taskfile/task.go
@@ -25,6 +25,7 @@ type Task struct {
 	Silent        bool
 	Method        string
 	Prefix        string
+	Warning       string
 	IgnoreError   bool
 }
 
@@ -69,6 +70,7 @@ func (t *Task) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		Silent        bool
 		Method        string
 		Prefix        string
+		Warning       string
 		IgnoreError   bool `yaml:"ignore_error"`
 	}
 	if err := unmarshal(&task); err == nil {
@@ -87,6 +89,7 @@ func (t *Task) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		t.Silent = task.Silent
 		t.Method = task.Method
 		t.Prefix = task.Prefix
+		t.Warning = task.Warning
 		t.IgnoreError = task.IgnoreError
 
 		return nil

--- a/internal/taskfile/taskfile.go
+++ b/internal/taskfile/taskfile.go
@@ -16,6 +16,7 @@ type Taskfile struct {
 	Env        *Vars
 	Tasks      Tasks
 	Silent     bool
+	Warning    string
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler interface
@@ -30,6 +31,7 @@ func (tf *Taskfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		Env        *Vars
 		Tasks      Tasks
 		Silent     bool
+		Warning    string
 	}
 	if err := unmarshal(&taskfile); err != nil {
 		return err
@@ -43,6 +45,7 @@ func (tf *Taskfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	tf.Env = taskfile.Env
 	tf.Tasks = taskfile.Tasks
 	tf.Silent = taskfile.Silent
+	tf.Warning = taskfile.Warning
 	if tf.Expansions <= 0 {
 		tf.Expansions = 2
 	}

--- a/task.go
+++ b/task.go
@@ -43,6 +43,7 @@ type Executor struct {
 	Summary    bool
 	Parallel   bool
 	Color      bool
+	Yes        bool
 
 	Stdin  io.Reader
 	Stdout io.Writer
@@ -256,9 +257,10 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 		return &MaximumTaskCallExceededError{task: call.Task}
 	}
 
-	if t.Warning != "" {
+	if t.Warning != "" && !e.Yes {
 		response := promptWithWarning(t.Warning)
 		if !isConfirmed(response) {
+			// Skip task
 			return nil
 		}
 	}
@@ -353,10 +355,10 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 		}
 		return nil
 	case cmd.Cmd != "":
-		if cmd.Warning != "" {
+		if cmd.Warning != "" && !e.Yes {
 			response := promptWithWarning(cmd.Warning)
 			if !isConfirmed(response) {
-				// Continue to next cmd
+				// Skip command
 				return nil
 			}
 		}

--- a/task.go
+++ b/task.go
@@ -259,7 +259,7 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 	if t.Warning != "" {
 		response := promptWithWarning(t.Warning)
 		if !isConfirmed(response) {
-			return errors.New("cancelled at warning")
+			return nil
 		}
 	}
 

--- a/variables.go
+++ b/variables.go
@@ -41,6 +41,7 @@ func (e *Executor) CompiledTask(call taskfile.Call) (*taskfile.Task, error) {
 		Vars:        nil,
 		Env:         nil,
 		Silent:      origTask.Silent,
+		Warning:     origTask.Warning,
 		Method:      r.Replace(origTask.Method),
 		Prefix:      r.Replace(origTask.Prefix),
 		IgnoreError: origTask.IgnoreError,
@@ -77,6 +78,7 @@ func (e *Executor) CompiledTask(call taskfile.Call) (*taskfile.Task, error) {
 			new.Cmds[i] = &taskfile.Cmd{
 				Task:        r.Replace(cmd.Task),
 				Silent:      cmd.Silent,
+				Warning:     cmd.Warning,
 				Cmd:         r.Replace(cmd.Cmd),
 				Vars:        r.ReplaceVars(cmd.Vars),
 				IgnoreError: cmd.IgnoreError,


### PR DESCRIPTION
Hey @andreynering, just saw your comment on issue #100 regarding the pending upstream ability to pass a `-p` flag to `read`. Coincidentally, I just finished writing this patch before your reply.

I understand that [mdvan/sh#551](https://github.com/mvdan/sh/issues/551) will clear up the ability to add a prompt, but I think that having an explicit `warning` option at both task and command levels may improve this tool.  What do you think?

Here is how `warning` can be used at both levels:

```yml
version: '3'

tasks:
  example-task:
    desc: An example
    warning: Are you sure you want to run this task?
    cmds:
      - cmd: rm -rf /important-files
        warning: Are you sure you want to run this command?
      - rm -rf /unimportant-files
```
Declining to run a command with a command-level warning results in the command being skipped, and the rest of the commands in the task (without warnings) will run unhindered.

I know you will have this project's best interest in mind.  Thanks for considering this feature!