### PR TITLE
Don't overwrite Executor's Output if it is already configured

### DIFF
--- a/task.go
+++ b/task.go
@@ -172,15 +172,18 @@ func (e *Executor) Setup() error {
 	if e.OutputStyle != "" {
 		e.Taskfile.Output = e.OutputStyle
 	}
-	switch e.Taskfile.Output {
-	case "", "interleaved":
-		e.Output = output.Interleaved{}
-	case "group":
-		e.Output = output.Group{}
-	case "prefixed":
-		e.Output = output.Prefixed{}
-	default:
-		return fmt.Errorf(`task: output option "%s" not recognized`, e.Taskfile.Output)
+
+	if e.Output == nil {
+		switch e.Taskfile.Output {
+		case "", "interleaved":
+			e.Output = output.Interleaved{}
+		case "group":
+			e.Output = output.Group{}
+		case "prefixed":
+			e.Output = output.Prefixed{}
+		default:
+			return fmt.Errorf(`task: output option "%s" not recognized`, e.Taskfile.Output)
+		}
 	}
 
 	if v <= 2.1 {


### PR DESCRIPTION
When using `task` as a Go package (which works extremely well, it's a great public interface!) the `Executor`'s `Output` property gets overwritten in `(*Executor).Setup()`. This PR changes the behaviour to not override the `Output` if it has already been configured (e.g. by a different app).

I'm happy to make any changes to this if you want. Thanks!

**EDIT**: So I just realised that `taskfile` is actually in the `internal` directory, so it can't be used outside of this project. I didn't realise until now because I was experimenting on a fork. Would you be open to exposing this?