### PR TITLE
Make fish completions compatible with MacOS

### DIFF
--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -1,5 +1,5 @@
 function __task_get_tasks --description "Prints all available tasks with their description"
-	task -l | sed '1d' | awk '{ $1=""; print $0 }' | sed 's/: /\t/' | string trim
+	task -l | sed '1d' | awk '{ $1=""; print $0 }' | tr ': ', '\t' | string trim
 end
 
 complete -c task -d 'Runs the specified task(s). Falls back to the "default" task if no task name was specified, or lists all tasks if an unknown task name was 


### PR DESCRIPTION
MacOS by default does not use gnu sed, which makes it not work. This patch will work with MacOS and also Linux