### PR TITLE
[fish-completions] use expressions from zsh auto-completions

### DIFF
--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -1,5 +1,5 @@
 function __task_get_tasks --description "Prints all available tasks with their description"
-	task -l | sed '1d' | awk '{ $1=""; print $0 }' | tr ': ', '\t' | string trim
+	task -l | sed '1d' | sed 's/^\* //' | awk '{ print $1 }' | sed 's/:$//' | sed 's/:/\\:/g
 end
 
 complete -c task -d 'Runs the specified task(s). Falls back to the "default" task if no task name was specified, or lists all tasks if an unknown task name was 


### PR DESCRIPTION
Currently, while my last PR worked on mac. There still was an issue of tasks that were named with colons e.g. `ansible:playbook:common` breaking the auto-completions

Instead of fussing around creating a new expression, I updated it use what the ZSH script is using. This works on Mac as well.