### PR TITLE
feat: improve installation script documentation for shell installs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,10 +74,10 @@ easily generating this script.
 
 ```bash
 # For Default Installion to ./bin with debug logging
-url -sL https://taskfile.dev/install.sh | sh -s -- -d 
+curl -sL https://taskfile.dev/install.sh | sh -s -- -d 
 
 # For Installation To /usr/local/bin with debug logging
-url -sL https://taskfile.dev/install.sh | sudo sh -s --  -b /usr/local/bin -d 
+curl -sL https://taskfile.dev/install.sh | sudo sh -s -- -d -b /usr/local/bin
 ```
 
 > This method will download the binary on the local `./bin` directory by default.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,10 +74,12 @@ easily generating this script.
 
 ```bash
 # For Default Installion to ./bin with debug logging
-curl -sL https://taskfile.dev/install.sh | sh -s -- -d 
+sh -c "$(curl -ssL https://taskfile.dev/install.sh)" -- -d
 
-# For Installation To /usr/local/bin with debug logging
-curl -sL https://taskfile.dev/install.sh | sudo sh -s -- -d -b /usr/local/bin
+# For Installation To /usr/local/bin for userwide access with debug logging
+# May require sudo sh
+sh -c "$(curl -ssL https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+
 ```
 
 > This method will download the binary on the local `./bin` directory by default.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -73,7 +73,11 @@ scenarios like CIs. Many thanks to [GoDownloader][godownloader] for allowing
 easily generating this script.
 
 ```bash
-curl -sL https://taskfile.dev/install.sh | sh
+# For Default Installion to ./bin with debug logging
+url -sL https://taskfile.dev/install.sh | sh -s -- -d 
+
+# For Installation To /usr/local/bin with debug logging
+url -sL https://taskfile.dev/install.sh | sudo sh -s --  -b /usr/local/bin -d 
 ```
 
 > This method will download the binary on the local `./bin` directory by default.


### PR DESCRIPTION
- The default didn't work well for me out of the gate.
- This is the modified version to support passing in the arguments easily as well as an example for installing to `/usr/local/bin` for using in Codespaces or equivalent development workflow.