### PR TITLE
Include task name in log output

### DIFF
--- a/task.go
+++ b/task.go
@@ -346,7 +346,7 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 		return nil
 	case cmd.Cmd != "":
 		if e.Verbose || (!cmd.Silent && !t.Silent && !e.Taskfile.Silent && !e.Silent) {
-			e.Logger.Errf(logger.Green, "task: %s", cmd.Cmd)
+			e.Logger.Errf(logger.Green, "task [%s]: %s", t.Name(), cmd.Cmd)
 		}
 
 		if e.Dry {
@@ -377,7 +377,7 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 			Stderr:  stdErr,
 		})
 		if execext.IsExitError(err) && cmd.IgnoreError {
-			e.Logger.VerboseErrf(logger.Yellow, "task: command error ignored: %v", err)
+			e.Logger.VerboseErrf(logger.Yellow, "task [%s]: command error ignored: %v", t.Name(), err)
 			return nil
 		}
 		return err

--- a/task_test.go
+++ b/task_test.go
@@ -610,7 +610,7 @@ func TestDry(t *testing.T) {
 	assert.NoError(t, e.Setup())
 	assert.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "build"}))
 
-	assert.Equal(t, "task: touch file.txt", strings.TrimSpace(buff.String()))
+	assert.Equal(t, "task [build]: touch file.txt", strings.TrimSpace(buff.String()))
 	if _, err := os.Stat(file); err == nil {
 		t.Errorf("File should not exist %s", file)
 	}


### PR DESCRIPTION
When running tasks which have dependencies which run concurrently, it is hard to understand what is going on. Including the specific task name in the output would help with this.

```
task: go test ./... -tags=noexit
task: ./scripts/verify_boilerplate.sh
task: go fmt .
task: golangci-lint run -v
```

After:
```
task [generator:test]: go test ./... -tags=noexit
task [header-check]: ./scripts/verify_boilerplate.sh
task [generator:format-code]: go fmt .
task [generator:lint]: golangci-lint run -v
```

I structured the name to match how `output: prefixed` works.