### PR TITLE
feat (help): allow cli option to list tasks with no description

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -150,8 +150,12 @@ func main() {
 		return
 	}
 
-	if list || listAll {
-		e.PrintTasksHelp(listAll)
+	if list {
+		e.ListTasksWithDesc()
+	}
+
+	if listAll {
+		e.ListAllTasks()
 		return
 	}
 

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -57,6 +57,7 @@ func main() {
 		helpFlag    bool
 		init        bool
 		list        bool
+		listAll     bool
 		status      bool
 		force       bool
 		watch       bool
@@ -75,6 +76,7 @@ func main() {
 	pflag.BoolVarP(&helpFlag, "help", "h", false, "shows Task usage")
 	pflag.BoolVarP(&init, "init", "i", false, "creates a new Taskfile.yml in the current folder")
 	pflag.BoolVarP(&list, "list", "l", false, "lists tasks with description of current Taskfile")
+	pflag.BoolVarP(&listAll, "list-all", "a", false, "list tasks with or without a description")
 	pflag.BoolVar(&status, "status", false, "exits with non-zero exit code if any of the given tasks is not up-to-date")
 	pflag.BoolVarP(&force, "force", "f", false, "forces execution even when the task is up-to-date")
 	pflag.BoolVarP(&watch, "watch", "w", false, "enables watch of the given task")
@@ -148,8 +150,8 @@ func main() {
 		return
 	}
 
-	if list {
-		e.PrintTasksHelp()
+	if list || listAll {
+		e.PrintTasksHelp(listAll)
 		return
 	}
 

--- a/help.go
+++ b/help.go
@@ -15,7 +15,7 @@ import (
 func (e *Executor) PrintTasksHelp(listAll bool) {
 	var tasks []*taskfile.Task
 	if listAll == true {
-		tasks = e.taskNames()
+		tasks = e.allTaskNames()
 	} else {
 		tasks = e.tasksWithDesc()
 	}
@@ -35,7 +35,7 @@ func (e *Executor) PrintTasksHelp(listAll bool) {
 	w.Flush()
 }
 
-func (e *Executor) taskNames() (tasks []*taskfile.Task) {
+func (e *Executor) allTaskNames() (tasks []*taskfile.Task) {
 	tasks = make([]*taskfile.Task, 0, len(e.Taskfile.Tasks))
 	for _, task := range e.Taskfile.Tasks {
 		tasks = append(tasks, task)
@@ -56,5 +56,17 @@ func (e *Executor) tasksWithDesc() (tasks []*taskfile.Task) {
 		}
 	}
 	sort.Slice(tasks, func(i, j int) bool { return tasks[i].Task < tasks[j].Task })
+	return
+}
+
+// ListTasksWithDesc reports tasks that have a description spec.
+func (e *Executor) ListTasksWithDesc() {
+	e.PrintTasksHelp(false)
+	return
+}
+
+// ListAllTasks reports all tasks, with or without a description spec.
+func (e *Executor) ListAllTasks() {
+	e.PrintTasksHelp(true)
 	return
 }

--- a/help.go
+++ b/help.go
@@ -9,10 +9,19 @@ import (
 	"github.com/go-task/task/v3/taskfile"
 )
 
-// PrintTasksHelp prints help os tasks that have a description
-func (e *Executor) PrintTasksHelp() {
-	tasks := e.tasksWithDesc()
+// PrintTasksHelp prints tasks' help.
+// Behavior is governed by listAll. When false, only tasks with descriptions are reported.
+// When true, all tasks are reported with descriptions shown where available.
+func (e *Executor) PrintTasksHelp(listAll bool) {
+	var tasks []*taskfile.Task
+	if listAll == true {
+		tasks = e.taskNames()
+	} else {
+		tasks = e.tasksWithDesc()
+	}
+
 	if len(tasks) == 0 {
+		// TODO: This message should be more informative. Maybe a hint to try -la for showing all?
 		e.Logger.Outf(logger.Yellow, "task: No tasks with description available")
 		return
 	}
@@ -24,6 +33,15 @@ func (e *Executor) PrintTasksHelp() {
 		fmt.Fprintf(w, "* %s: \t%s\n", task.Name(), task.Desc)
 	}
 	w.Flush()
+}
+
+func (e *Executor) taskNames() (tasks []*taskfile.Task) {
+	tasks = make([]*taskfile.Task, 0, len(e.Taskfile.Tasks))
+	for _, task := range e.Taskfile.Tasks {
+		tasks = append(tasks, task)
+	}
+	sort.Slice(tasks, func(i, j int) bool { return tasks[i].Task < tasks[j].Task })
+	return
 }
 
 func (e *Executor) tasksWithDesc() (tasks []*taskfile.Task) {

--- a/task.go
+++ b/task.go
@@ -64,9 +64,7 @@ func (e *Executor) Run(ctx context.Context, calls ...taskfile.Call) error {
 	for _, c := range calls {
 		if _, ok := e.Taskfile.Tasks[c.Task]; !ok {
 			// FIXME: move to the main package
-			// FIXME: (ard.kevin.84@gmail.com) changed the PrintTasksHelp signature to support show all/some.
-			// 	False preserves original behavior, but should be reviewed.
-			e.PrintTasksHelp(false)
+			e.ListTasksWithDesc()
 			return &taskNotFoundError{taskName: c.Task}
 		}
 	}

--- a/task.go
+++ b/task.go
@@ -64,7 +64,9 @@ func (e *Executor) Run(ctx context.Context, calls ...taskfile.Call) error {
 	for _, c := range calls {
 		if _, ok := e.Taskfile.Tasks[c.Task]; !ok {
 			// FIXME: move to the main package
-			e.PrintTasksHelp()
+			// FIXME: (ard.kevin.84@gmail.com) changed the PrintTasksHelp signature to support show all/some.
+			// 	False preserves original behavior, but should be reviewed.
+			e.PrintTasksHelp(false)
 			return &taskNotFoundError{taskName: c.Task}
 		}
 	}

--- a/task_test.go
+++ b/task_test.go
@@ -492,7 +492,7 @@ func TestListAllShowsNoDesc(t *testing.T) {
 	assert.NoError(t, e.Setup())
 
 	var title string
-	e.PrintTasksHelp(true)
+	e.ListAllTasks()
 	for _, title = range []string{
 		"foo",
 		"voo",
@@ -514,7 +514,7 @@ func TestListCanListDescOnly(t *testing.T) {
 	}
 
 	assert.NoError(t, e.Setup())
-	e.PrintTasksHelp(false)
+	e.ListTasksWithDesc()
 
 	var title string
 	assert.Contains(t, buff.String(), "foo")

--- a/task_test.go
+++ b/task_test.go
@@ -474,8 +474,56 @@ func TestLabelInList(t *testing.T) {
 		Stderr: &buff,
 	}
 	assert.NoError(t, e.Setup())
-	e.PrintTasksHelp()
+	e.PrintTasksHelp(false)
 	assert.Contains(t, buff.String(), "foobar")
+}
+
+// task -al case 1: listAll list all tasks
+func TestListAllShowsNoDesc(t *testing.T) {
+	const dir = "testdata/list_mixed_desc"
+
+	var buff bytes.Buffer
+	e := task.Executor{
+		Dir:    dir,
+		Stdout: &buff,
+		Stderr: &buff,
+	}
+
+	assert.NoError(t, e.Setup())
+
+	var title string
+	e.PrintTasksHelp(true)
+	for _, title = range []string{
+		"foo",
+		"voo",
+		"doo",
+	} {
+		assert.Contains(t, buff.String(), title)
+	}
+}
+
+// task -al case 2: !listAll list some tasks (only those with desc)
+func TestListCanListDescOnly(t *testing.T) {
+	const dir = "testdata/list_mixed_desc"
+
+	var buff bytes.Buffer
+	e := task.Executor{
+		Dir:    dir,
+		Stdout: &buff,
+		Stderr: &buff,
+	}
+
+	assert.NoError(t, e.Setup())
+	e.PrintTasksHelp(false)
+
+	var title string
+	assert.Contains(t, buff.String(), "foo")
+	for _, title = range []string{
+		"voo",
+		"doo",
+	} {
+		assert.NotContains(t, buff.String(), title)
+	}
 }
 
 func TestStatusVariables(t *testing.T) {

--- a/testdata/list_mixed_desc/Taskfile.yml
+++ b/testdata/list_mixed_desc/Taskfile.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+tasks:
+  foo:
+    label: "foobar"
+    desc: "foo has desc and label"
+
+  voo:
+    label: "voo has no desc"
+
+  doo:
+    label: "doo has desc, no label"


### PR DESCRIPTION
added an add'l cli option that lists all tasks, with or without description.
orig. behavior: task -l lists tasks with desc field
new behaviour: task -la or task -a will list all tasks. if task has desc, it will be included.

BREAKING CHANGES: none, that I know of.
NOTES/Concerns:
- This is wip.
- Haven't checked how it interacts with bash completion.
- The new Executor.TaskNames func does not use e.CompiledTask(taskfile.Call{Task: task.Task})

This relates to https://github.com/go-task/task/issues/383 