### PR TITLE
Update curl arguments in installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,11 +74,11 @@ easily generating this script.
 
 ```bash
 # For Default Installion to ./bin with debug logging
-sh -c "$(curl -ssL https://taskfile.dev/install.sh)" -- -d
+sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d
 
 # For Installation To /usr/local/bin for userwide access with debug logging
 # May require sudo sh
-sh -c "$(curl -ssL https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
+sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
 
 ```
 


### PR DESCRIPTION
Double -s argument does not make sense according to curl manual page.
-s stands for silent, while -S (capital S) stands for showing the error.
When used in combination, curl shows an error message if it fails, but disables progress meter.

Finally, in the end of sh command there is -d, which stands for debug and contradicts -sS curl arguments.
I suggest to remove curl silencers all together, because more debug is better in CIs.
I also suggest to use --location instead of -L for clarity.