### PR TITLE
Fix duplicate task name on "Short task syntax" example

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -865,7 +865,7 @@ $ task default
 ## Short task syntax
 
 Starting on Task v3, you can now write tasks with a shorter syntax if they
-have the default settings (e.g. no custom `env:`, `vars:`, `silent:` , etc):
+have the default settings (e.g. no custom `env:`, `vars:`, `desc:`, `silent:` , etc):
 
 ```yaml
 version: '3'
@@ -873,7 +873,7 @@ version: '3'
 tasks:
   build: go build -v -o ./app{{exeExt}} .
 
-  build:
+  run:
     - task: build
     - ./app{{exeExt}} -h localhost -p 8080
 ```


### PR DESCRIPTION
To make it a valid YAML file and avoid the error:

```
yaml: unmarshal errors:
  line 6: mapping key "build" already defined at line 4
```

Also, mention `desc:` key in that section, as it's an important keyword.