### PR TITLE
chore: include taskfile vars in task scope

### DIFF
--- a/variables.go
+++ b/variables.go
@@ -23,6 +23,8 @@ func (e *Executor) CompiledTask(call taskfile.Call) (*taskfile.Task, error) {
 		return nil, err
 	}
 
+	vars.Merge(e.Taskfile.Vars)
+
 	v, err := e.Taskfile.ParsedVersion()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Without this change, the variables present on a Taskfile are not available from
within the Task.  This means that in the case of a "Live" variable, the task
template is unable to access these objects as expected.

Here we merge the Taskfile vars into the vars for the given Task, allowing the
Live variables to be accessed from within the Task template scope.