### PR TITLE
Make watch behavior work better

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -81,12 +81,12 @@ func (e *Executor) watchTasks(calls ...taskfile.Call) error {
 	}()
 
 	go func() {
-		// re-register each second because we can have new files
+		// re-register every 20 seconds because we can have new files, but this process is expensive to run
 		for {
 			if err := e.registerWatchedFiles(w, calls...); err != nil {
 				e.Logger.Errf(logger.Red, "%v", err)
 			}
-			time.Sleep(time.Second)
+			time.Sleep(time.Second * 20)
 		}
 	}()
 


### PR DESCRIPTION
Watch wasn't working well for me. I started digging into it some and noticed that the `watcher` cli tool itself never had problems picking up changes for me.  Digging into how `task` is using watcher, I found a few things.

Top-level change explanation

1) My linter complained about the `return err` on line 44 was returning without cancel() being called.  I added this.
2) registerWatchedFiles was removing and adding files over and over to watcher.  Details below

Details on fix:

* While debugging, I added some print statements, and saw that this code kept removing and adding files to Watcher.  I didn't track down into Watcher itself, but this loop (going every second) in Taskfile seems to be the cause of making watch behavior not work well.
* Looking at the code it's unclear to me why `w.Remove(f)` is even being called.  Removed this for loop.
* On old line 149, the `if _, ok := oldWatchedFiles[f]; ok {` was 100% miss rate (at least on Windows).  Watcher uses absolute paths, and task always operates on relative paths.
* I changed that block to use `filepath.Abs(f)` to get the full path (which is the exact same code watcher uses).  I'm not a fan of binding task and watcher together like this, but it is better than what it's doing today.
* Now it will log each time a new file is being watched.  Verbose out will help debug cases if this code brakes, as the logs would be flooded.

This likely will help fix #368 (though that was reported on linux, and I tested on windows)

Potential other change:  I don't know if `registerWatchedFiles` being called every second is good for performance (especially on large projects).  I'd recommend reducing this (maybe 10 seconds?  Maybe longer?)