### PR TITLE
Add ARM64 in supported platforms

### DIFF
--- a/install-task.sh
+++ b/install-task.sh
@@ -68,6 +68,7 @@ is_supported_platform() {
     darwin/amd64) found=0 ;;
     linux/386) found=0 ;;
     linux/amd64) found=0 ;;
+    linux/arm64) found=0 ;;
   esac
   case "$platform" in
     darwin/386) found=1 ;;


### PR DESCRIPTION
The following files have been modified:

- In **install-task.sh**: Added linux/arm64 architecture in **is_supported_platform()** function in order to install the binary for arm64 through the script.
