### PR TITLE
Added string functions in template system

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -551,6 +551,10 @@ Task also adds the following functions:
   converts a string from `\` path format to `/`.
 - `exeExt`: Returns the right executable extension for the current OS
   (`".exe"` for Windows, `""` for others).
+- `toUpper` Returns string with all Unicode letters mapped to their upper case.
+- `toLower` Opposite of `toUpper`. It returns string with all Unicode letters mapped to their lower case.
+- `replace` Returns a new string with all matches of a old value replaced by a new value.
+- `substring` Returns the part of the string between the start and end indexes.
 
 Example:
 
@@ -564,6 +568,7 @@ tasks:
       - echo '{{if eq OS "windows"}}windows-command{{else}}unix-command{{end}}'
       # This will be path/to/file on Unix but path\to\file on Windows
       - echo '{{fromSlash "path/to/file"}}'
+
   enumerated-file:
     vars:
       CONTENT: |
@@ -575,6 +580,19 @@ tasks:
         {{range $i, $line := .CONTENT | splitLines -}}
         {{printf "%3d" $i}}: {{$line}}
         {{end}}EOF
+
+  string-functions:
+    vars:
+      VALUE: 'Hello Beautiful Word!'
+    cmds:
+      # This will print HELLO BEAUTIFUL WORD!
+      - echo '{{.VALUE | toUpper}}'
+      # This will print hello beautiful word!
+      - echo '{{.VALUE | toLower}}'
+      # This will print Hello_beautiful_word!
+      - echo '{{replace .VALUE " " "_"}}'
+      # This will print beautiful word!
+      - echo '{{substring .VALUE 6 -1}}'
 ```
 
 ## Help

--- a/internal/templater/funcs.go
+++ b/internal/templater/funcs.go
@@ -39,6 +39,22 @@ func init() {
 		},
 		// IsSH is deprecated.
 		"IsSH": func() bool { return true },
+		"toUpper": func(s string) string {
+			return strings.ToUpper(s)
+		},
+		"toLower": func(s string) string {
+			return strings.ToLower(s)
+		},
+		"replace": func(s, old, new string) string {
+			return strings.ReplaceAll(s, old, new)
+		},
+		"substring": func(s string, start, end int) string {
+			lastIndex := len(s) - 1
+			if end == -1 || end > lastIndex {
+				end = lastIndex
+			}
+			return s[start:end]
+		},
 	}
 	// Deprecated aliases for renamed functions.
 	taskFuncs["FromSlash"] = taskFuncs["fromSlash"]


### PR DESCRIPTION
Hi, I've added some functions for strings. These can be useful for easy variables formatting. For example:
```yaml
version: '3'

vars:
  GIT_COMMIT:
    sh: git log -n 1 --format=%h

tasks:
  build:
    cmds:
      - go build -v -ldflags="-s -w -X main.Version=dev-{{ .GIT_COMMIT | toUpper }}"
```