### PR TITLE
Report Go module version and checksum

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,11 @@ build:
       goarch: 386
   env:
     - CGO_ENABLED=0
+  ldflags:
+    - -s -w # Don't set main.version.
+
+gomod:
+  proxy: true
 
 archives:
   - name_template: "{{.Binary}}_{{.Os}}_{{.Arch}}"

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"syscall"
 
@@ -18,9 +19,7 @@ import (
 	"github.com/go-task/task/v3/taskfile"
 )
 
-var (
-	version = "master"
-)
+var version = ""
 
 const usage = `Usage: task [-ilfwvsd] [--init] [--list] [--force] [--watch] [--verbose] [--silent] [--dir] [--taskfile] [--dry] [--summary] [task...]
 
@@ -93,7 +92,7 @@ func main() {
 	pflag.Parse()
 
 	if versionFlag {
-		fmt.Printf("Task version: %s\n", version)
+		fmt.Printf("Task version: %s\n", getVersion())
 		return
 	}
 
@@ -216,4 +215,22 @@ func getSignalContext() context.Context {
 		cancel()
 	}()
 	return ctx
+}
+
+func getVersion() string {
+	if version != "" {
+		return version
+	}
+
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" {
+		version = info.Main.Version
+
+		if info.Main.Sum != "" {
+			version += fmt.Sprintf(" (%s)", info.Main.Sum)
+		}
+	} else {
+		version = "unknown"
+	}
+
+	return version
 }


### PR DESCRIPTION
At present, when installing Task using `go install`, the version is reported as `master`.

```
$ go version
go version go1.16.3 darwin/amd64
$ go install github.com/go-task/task/v3/cmd/task@latest
$ task --version
Task version: master
```

As of Go 1.16, `go install` uses [module-aware mode by default](https://golang.org/doc/go1.16#go-command). As a result, the module version and checksum is stored within the binary.

```
$ go version -m $(which task)
/Users/jamie/go/bin/task: go1.16.3
	path	github.com/go-task/task/v3/cmd/task
	mod	github.com/go-task/task/v3	v3.3.0	h1:IfyT0z7a8ap4ag2nIDRkx+bkTN9S3AFED6SqBFnuHqU=
	dep	github.com/fatih/color	v1.7.0	h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
	dep	github.com/go-task/slim-sprig	v0.0.0-20210107165309-348f09dbbbc0	h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
	dep	github.com/joho/godotenv	v1.3.0	h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
	dep	github.com/mattn/go-colorable	v0.1.2	h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
	dep	github.com/mattn/go-isatty	v0.0.8	h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
	dep	github.com/mattn/go-zglob	v0.0.1	h1:xsEx/XUoVlI6yXjqBK062zYhRTZltCNmYPx6v+8DNaY=
	dep	github.com/radovskyb/watcher	v1.0.5	h1:wqt7gb+HjGacvFoLTKeT44C+XVPxu7bvHvKT1IvZ7rw=
	dep	github.com/spf13/pflag	v1.0.5	h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
	dep	golang.org/x/sync	v0.0.0-20201020160332-67f06af15bc9	h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
	dep	golang.org/x/sys	v0.0.0-20201029080932-201ba4db2418	h1:HlFl4V6pEMziuLXyRkm5BIYq1y1GAbb02pRlWvI54OM=
	dep	golang.org/x/term	v0.0.0-20191110171634-ad39bd3f0407	h1:5zh5atpUEdIc478E/ebrIaHLKcfVvG6dL/fGv7BcMoM=
	dep	gopkg.in/yaml.v3	v3.0.0-20200313102051-9f266ea9e77c	h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
	dep	mvdan.cc/sh/v3	v3.2.4	h1:+fZaWcXWRjYAvqzEKoDhDM3DkxdDUykU2iw0VMKFe9s=
```

## Version Reporting

This pull request improves version reporting by reading the module version and checksum from [`BuildInfo`](https://pkg.go.dev/runtime/debug#BuildInfo).

The `main.version` symbol remains so that a commit hash can be written when building from source using `task install`, although it should not be written to in other build scenarios (e.g. when creating release builds). As such, to suppress the `-X main.version=...` linker argument, the default GoReleaser [`ldflags` build configuration option](https://goreleaser.com/customization/build/) is overridden so that only the `-s -w` flags are used.

## GoReleaser Verifiable Builds

Published binaries do not currently contain module version and checksum information.

```
$ curl -sSL -o task.tar.gz https://github.com/go-task/task/releases/download/v3.3.0/task_darwin_amd64.tar.gz
$ tar -zxf task.tar.gz
$ go version -m task
task: go1.15.10
	path	command-line-arguments
	mod	github.com/go-task/task/v3	(devel)	
	dep	github.com/fatih/color	v1.7.0	h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
	dep	github.com/go-task/slim-sprig	v0.0.0-20210107165309-348f09dbbbc0	h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
	dep	github.com/joho/godotenv	v1.3.0	h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
	dep	github.com/mattn/go-colorable	v0.1.2	h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
	dep	github.com/mattn/go-isatty	v0.0.8	h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
	dep	github.com/mattn/go-zglob	v0.0.1	h1:xsEx/XUoVlI6yXjqBK062zYhRTZltCNmYPx6v+8DNaY=
	dep	github.com/radovskyb/watcher	v1.0.5	h1:wqt7gb+HjGacvFoLTKeT44C+XVPxu7bvHvKT1IvZ7rw=
	dep	github.com/spf13/pflag	v1.0.5	h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
	dep	golang.org/x/sync	v0.0.0-20201020160332-67f06af15bc9	h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
	dep	golang.org/x/sys	v0.0.0-20201029080932-201ba4db2418	h1:HlFl4V6pEMziuLXyRkm5BIYq1y1GAbb02pRlWvI54OM=
	dep	golang.org/x/term	v0.0.0-20191110171634-ad39bd3f0407	h1:5zh5atpUEdIc478E/ebrIaHLKcfVvG6dL/fGv7BcMoM=
	dep	gopkg.in/yaml.v3	v3.0.0-20200313102051-9f266ea9e77c	h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
	dep	mvdan.cc/sh/v3	v3.2.4	h1:+fZaWcXWRjYAvqzEKoDhDM3DkxdDUykU2iw0VMKFe9s=
```

To address this, the [verifiable builds option](https://goreleaser.com/customization/gomod/) of GoReleaser has been enabled, meaning that Task will be [obtained from the Go modules proxy before being built](https://goreleaser.com/cookbooks/build-go-modules/). As this option does not affect snapshot builds and instead requires that a tagged commit is built, I have been **unable** to verify that module details are added to the build information of binaries as expected. This is something which I would advise to test before merging to the main branch, otherwise release binaries might display `unknown` as their version.