### PR TITLE
"file does not exist" improving for watchers

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -129,7 +130,7 @@ func (e *Executor) registerWatchedFiles(w *watcher.Watcher, calls ...taskfile.Ca
 		for _, s := range task.Sources {
 			files, err := zglob.Glob(s)
 			if err != nil {
-				return err
+				return fmt.Errorf("%s: %w", s, err)
 			}
 			for _, f := range files {
 				absFile, err := filepath.Abs(f)


### PR DESCRIPTION
Adds additional (initial missing) context to the go generic `os.ErrNotExist` error, in addition to other errors that (possibly) can be returned by `zglob.Glob`

Context: I am working on a few small files that are sources of different generators (that generate stuff that other stuff use to generate their own stuff). And if one of the stages fails, there literally no possible way to tell which file is it - just simple - `file not exists` if all what you got.


## Before 
![image](https://user-images.githubusercontent.com/651824/115192099-049fa300-a0f3-11eb-87ee-2a94b3b880ac.png)

## After
![image](https://user-images.githubusercontent.com/651824/115192115-09fced80-a0f3-11eb-96e5-becd05d3dd6d.png)
