### PR TITLE
Allow certain commands to run even if others have failed

### DIFF
--- a/taskfile/cmd.go
+++ b/taskfile/cmd.go
@@ -11,6 +11,7 @@ type Cmd struct {
 	Task        string
 	Vars        *Vars
 	IgnoreError bool
+	Always      bool
 }
 
 // Dep is a task dependency
@@ -34,22 +35,26 @@ func (c *Cmd) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		Cmd         string
 		Silent      bool
 		IgnoreError bool `yaml:"ignore_error"`
+		Always      bool
 	}
 	if err := unmarshal(&cmdStruct); err == nil && cmdStruct.Cmd != "" {
 		c.Cmd = cmdStruct.Cmd
 		c.Silent = cmdStruct.Silent
 		c.IgnoreError = cmdStruct.IgnoreError
+		c.Always = cmdStruct.Always
 		return nil
 	}
 	var taskCall struct {
-		Task string
-		Vars *Vars
+		Task   string
+		Vars   *Vars
+		Always bool
 	}
 	if err := unmarshal(&taskCall); err != nil {
 		return err
 	}
 	c.Task = taskCall.Task
 	c.Vars = taskCall.Vars
+	c.Always = taskCall.Always
 	return nil
 }
 

--- a/taskfile/taskfile_test.go
+++ b/taskfile/taskfile_test.go
@@ -11,8 +11,12 @@ import (
 
 func TestCmdParse(t *testing.T) {
 	const (
-		yamlCmd      = `echo "a string command"`
-		yamlDep      = `"task-name"`
+		yamlCmd       = `echo "a string command"`
+		yamlDep       = `"task-name"`
+		yamlCmdAlways = `
+cmd: echo "always run"
+always: true
+`
 		yamlTaskCall = `
 task: another-task
 vars:
@@ -29,6 +33,11 @@ vars:
 			yamlCmd,
 			&taskfile.Cmd{},
 			&taskfile.Cmd{Cmd: `echo "a string command"`},
+		},
+		{
+			yamlCmdAlways,
+			&taskfile.Cmd{},
+			&taskfile.Cmd{Cmd: `echo "always run"`, Always: true},
 		},
 		{
 			yamlTaskCall,

--- a/testdata/always/Taskfile.yml
+++ b/testdata/always/Taskfile.yml
@@ -1,0 +1,48 @@
+version: "3"
+
+output: prefixed
+
+tasks:
+  always-command:
+    cmds:
+      - exit 1
+      - cmd: echo "always run"
+        always: true
+
+  always-command-skip-other:
+    cmds:
+      - exit 1
+      - echo "won't run"
+      - cmd: echo "always run"
+        always: true
+
+  always-command-that-fails-skip-other:
+    cmds:
+      - exit 1
+      - echo "won't run"
+      - cmd: exit 2
+        always: true
+      - cmd: echo "always run"
+        always: true
+
+  always-command-task:
+    cmds:
+      - task: always-command
+      - cmd: echo "always run (after failed task)"
+        always: true
+
+  dep-of-with-deps:
+    cmds:
+      - task: always-command
+
+  with-deps:
+    deps: [dep-of-with-deps]
+    cmds:
+      - cmd: echo "won't run"
+        always: true
+
+  interrupt-me:
+    cmds:
+      - sleep 30
+      - cmd: echo "run after interrupt"
+        always: true

--- a/variables.go
+++ b/variables.go
@@ -97,6 +97,7 @@ func (e *Executor) compiledTask(call taskfile.Call, evaluateShVars bool) (*taskf
 				Cmd:         r.Replace(cmd.Cmd),
 				Vars:        r.ReplaceVars(cmd.Vars),
 				IgnoreError: cmd.IgnoreError,
+				Always:      cmd.Always,
 			}
 		}
 	}


### PR DESCRIPTION
Something I've been working around recently is the fact that `task` will stop execution as soon as one command fails,
but using `ignore_error` at the command level will bury the error and cause the overall `task` execution to
appear successful.

I've been using this workaround:

```yaml
run-all-tests:
  cmds:
    - |
       task launch-docker-for-tests;
       ( go test ./... ); # run the tests in a subshell
       TEST_EXIT=$?;
       task cleanup-docker-for-tests;
       exit $TEST_EXIT
```

It's a bit clunky, which is what inspired me to open this PR. This PR enables the following:

```yaml
run-all-tests:
  cmds:
    - task: launch-docker-for-tests
    - go test ./...
    - task: cleanup-docker-for-tests
      always: true
```

The behavior is mostly identical, with an exception: the first version will fail to run the cleanup action if the `task run-all-tests` call is terminated with a `CTRL-C`, but the second version will still run the `cleanup-docker-for-tests` if an interrupt is triggered via `CTRL-C` or other means. The error from the first failed task is returned.
