### PR TITLE
signals: do not try to catch uncatchable signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,9 @@ dist/
 
 .DS_Store
 
-# intellij idea/goland
+# editors
 .idea/
+.vscode/
 
 # exuberant ctags
 tags

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -208,7 +208,7 @@ func getArgs() (tasksAndVars, cliArgs []string) {
 
 func getSignalContext() context.Context {
 	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, os.Interrupt, os.Kill, syscall.SIGTERM)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		sig := <-ch


### PR DESCRIPTION
os.Kill is SIGKILL (kill -9), cannot be intercepted.
(see golang/go#13080)

Part of #458.