### PR TITLE
Changes --watch to respect task directory

### DIFF
--- a/internal/status/checksum.go
+++ b/internal/status/checksum.go
@@ -53,7 +53,7 @@ func (c *Checksum) IsUpToDate() (bool, error) {
 	if len(c.Generates) > 0 {
 		// For each specified 'generates' field, check whether the files actually exist
 		for _, g := range c.Generates {
-			generates, err := glob(c.TaskDir, g)
+			generates, err := Glob(c.TaskDir, g)
 			if os.IsNotExist(err) {
 				return false, nil
 			}

--- a/internal/status/glob.go
+++ b/internal/status/glob.go
@@ -13,7 +13,7 @@ import (
 func globs(dir string, globs []string) ([]string, error) {
 	files := make([]string, 0)
 	for _, g := range globs {
-		f, err := glob(dir, g)
+		f, err := Glob(dir, g)
 		if err != nil {
 			continue
 		}
@@ -23,7 +23,7 @@ func globs(dir string, globs []string) ([]string, error) {
 	return files, nil
 }
 
-func glob(dir string, g string) ([]string, error) {
+func Glob(dir string, g string) ([]string, error) {
 	files := make([]string, 0)
 	if !filepath.IsAbs(g) {
 		g = filepath.Join(dir, g)

--- a/watch.go
+++ b/watch.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/go-task/task/v3/internal/logger"
+	"github.com/go-task/task/v3/internal/status"
 	"github.com/go-task/task/v3/taskfile"
-	"github.com/mattn/go-zglob"
 	"github.com/radovskyb/watcher"
 )
 
@@ -128,7 +128,7 @@ func (e *Executor) registerWatchedFiles(w *watcher.Watcher, calls ...taskfile.Ca
 		}
 
 		for _, s := range task.Sources {
-			files, err := zglob.Glob(s)
+			files, err := status.Glob(task.Dir, s)
 			if err != nil {
 				return fmt.Errorf("task: %s: %w", s, err)
 			}


### PR DESCRIPTION
Fixes https://github.com/go-task/task/issues/484

Exports internal/status.glob() and uses that for the watch globbing as well so that watch uses the task directory.

The only problem I see is that status.glob() never returns an error, while zglob.Glob() does, so the behavior will be changed beyond the intended scope. The only solutions I see are to re-implement the code from status.glob, change status.glob to return an error and thereby changing the behavior in other cases, or leave it be and accept the changed behavior of watch.

I prefer never silently ignoring errors, so I would change the behavior in other cases (checksum and timestamp checking), but it's not my call.