### PR TITLE
Update docs for new arduino/setup-task action repository

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -27,7 +27,7 @@ and is published [here](https://marketplace.visualstudio.com/items?itemName=paul
 
 Some installation methods are maintained by third party:
 
-- [GitHub Actions](https://github.com/arduino/actions/tree/master/setup-taskfile)
+- [GitHub Actions](https://github.com/arduino/setup-task)
   by [@arduino](https://github.com/arduino)
 - [AUR](https://aur.archlinux.org/packages/taskfile-git)
   by [@kovetskiy](https://github.com/kovetskiy)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -87,12 +87,12 @@ sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/b
 #### **GitHub Actions**
 
 If you want to install Task in GitHub Actions you can try using
-[this action](https://github.com/arduino/actions/tree/master/setup-taskfile)
+[this action](https://github.com/arduino/setup-task)
 by the Arduino team:
 
 ```yaml
 - name: Install Task
-  uses: Arduino/actions/setup-taskfile@master
+  uses: arduino/setup-task@v1
 ```
 
 This installation method is community owned.


### PR DESCRIPTION
The GitHub Actions action for installing Task has graduated from its original home in [the experimental `arduino/action` repository](https://github.com/arduino/actions) with a move to a dedicated permanent repository at [`arduino/setup-task`](https://github.com/arduino/setup-task).

This move was accompanied by [significant upgrades](https://github.com/arduino/setup-task/pulls?q=is%3Apr+is%3Aclosed) to the project infrastructure to facilitate its maintenance and quality assurance.

A [1.0.0 release](https://github.com/arduino/setup-task/releases/tag/v1.0.0) has been made and [a `v1` ref](https://github.com/arduino/setup-task/tree/v1) that will track all releases in the major version 1 series.

In addition to the name change, I have updated the example snippet to use this `v1` ref because this will cause the user's workflows to use stable release versions of the action while also benefiting from ongoing development to the action at each patch or minor release up until such time as a new major release is made. At this time the user will be given the opportunity to evaluate whether any changes to the workflow are required by the breaking change to the action that triggered the major release before manually updating the major ref in the workflows (e.g., `uses: arduino/setup-task@v2`).