### PR TITLE
Fix bash completions when the current argument begins with a dash

### DIFF
--- a/completion/bash/task.bash
+++ b/completion/bash/task.bash
@@ -15,7 +15,7 @@ _task_completion()
     return
   fi
 
-  COMPREPLY=($(compgen -c | echo "$scripts" | grep $curr_arg));
+  COMPREPLY=($(compgen -c | echo "$scripts" | grep -- $curr_arg));
 }
 
 complete -F _task_completion task


### PR DESCRIPTION
When trying to complete an argument that begins with a dash, the bash completion will potentially cause grep to output error messages:

For example, doing "task -d" followed by tabs in task source tree:
```
$ task -dgrep: option requires an argument -- 'd'
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
```