### PR TITLE
Allow included Taskfiles to use ~/* paths

### DIFF
--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -10,6 +10,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/templater"
 	"github.com/go-task/task/v3/taskfile"
 )
@@ -53,7 +54,7 @@ func Taskfile(dir string, entrypoint string) (*taskfile.Taskfile, error) {
 		if filepath.IsAbs(includedTask.Taskfile) {
 			path = includedTask.Taskfile
 		} else if strings.HasPrefix(includedTask.Taskfile, "~") {
-			home, err := os.UserHomeDir()
+			home, err := execext.Expand("~")
 			if err != nil {
 				return err
 			}

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -51,16 +50,13 @@ func Taskfile(dir string, entrypoint string) (*taskfile.Taskfile, error) {
 			}
 		}
 
-		if filepath.IsAbs(includedTask.Taskfile) {
-			path = includedTask.Taskfile
-		} else if strings.HasPrefix(includedTask.Taskfile, "~") {
-			home, err := execext.Expand("~")
-			if err != nil {
-				return err
-			}
-			path = strings.Replace(includedTask.Taskfile, "~", home, 1)
-		} else {
-			path = filepath.Join(dir, includedTask.Taskfile)
+		path, err := execext.Expand(includedTask.Taskfile)
+		if err != nil {
+			return err
+		}
+
+		if ! filepath.IsAbs(path) {
+			path = filepath.Join(dir, path)
 		}
 
 		info, err := os.Stat(path)

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -51,6 +52,12 @@ func Taskfile(dir string, entrypoint string) (*taskfile.Taskfile, error) {
 
 		if filepath.IsAbs(includedTask.Taskfile) {
 			path = includedTask.Taskfile
+		} else if strings.HasPrefix(includedTask.Taskfile, "~") {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return err
+			}
+			path = strings.Replace(includedTask.Taskfile, "~", home, 1)
 		} else {
 			path = filepath.Join(dir, includedTask.Taskfile)
 		}


### PR DESCRIPTION
This change allows users to include Taskfiles inside the home directory. 

Paths beginning with the `~` character are expanded to absolute paths using `os.UserHomeDir()`

Example:

```yaml
version: "3"

includes:
  common: ~/.task/Taskfile.yml

tasks:
  default:
    cmds:
      - task: common:task1
      - task: common:task2
      - echo 'Finished.'
```

This references #185  and resolves #539 