### PR TITLE
Fix fish completions

### DIFF
--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -1,5 +1,5 @@
 function __task_get_tasks --description "Prints all available tasks with their description"
-	task -l | awk '{ $1=""; print $0 }' | sed 's/:\ /\t/g' | string trim
+	task -l | sed '1d' | awk '{ $1=""; print $0 }' | sed 's/:\ /\t/g' | string trim
 end
 
 complete -c task -d 'Runs the specified task(s). Falls back to the "default" task if no task name was specified, or lists all tasks if an unknown task name was 

--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -1,5 +1,5 @@
 function __task_get_tasks --description "Prints all available tasks with their description"
-	task -l | sed '1d' | awk '{ $1=""; print $0 }' | tr ': ', '\t' | string trim
+	task -l | awk '{ $1=""; print $0 }' | sed 's/:\ /\t/g' | string trim
 end
 
 complete -c task -d 'Runs the specified task(s). Falls back to the "default" task if no task name was specified, or lists all tasks if an unknown task name was 


### PR DESCRIPTION
The existing fish completions are broken for any task names that contain a colon. The issue seems to be incorrectly parsing the output of `task -l` to replace all colons and spaces with tabs. For example,

This is how the list is currently parsed, 
```
➜ task -l | sed '1d' | grep docs:ico | awk '{ $1=""; print $0 }' | tr ': ', '\t' | string trim
docs    ico             Generate        favicon.ico     from    Logo.png
```
<img width="1081" alt="image" src="https://user-images.githubusercontent.com/672246/131701490-eeca8807-1cbc-407c-8bfa-abea8b7c4203.png">

In this situation none of the `docs:*` tasks can be tab completed. The intention _seems_ to be to replace the string `': 
'` but it's not done correctly.

After these changes you can tab complete to each colon within a name like you'd expect,
```
➜ task -l | sed '1d' | grep docs:ico | awk '{ $1=""; print $0 }' | sed 's/:\ /\t/g' | string trim
docs:ico        Generate favicon.ico from Logo.png
```
<img width="1250" alt="image" src="https://user-images.githubusercontent.com/672246/131702158-c55ff2a0-50f7-41a3-b09a-de9f17d90410.png">


