### PR TITLE
Task: Add interactive parameter

### DIFF
--- a/task.go
+++ b/task.go
@@ -417,6 +417,12 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 
 		stdOut := e.Output.WrapWriter(e.Stdout, t.Prefix)
 		stdErr := e.Output.WrapWriter(e.Stderr, t.Prefix)
+
+		if t.Interactive {
+			stdOut = output.Interleaved{}.WrapWriter(e.Stdout, t.Prefix)
+			stdErr = output.Interleaved{}.WrapWriter(e.Stderr, t.Prefix)
+		}
+
 		defer func() {
 			if _, ok := stdOut.(*os.File); !ok {
 				if closer, ok := stdOut.(io.Closer); ok {

--- a/taskfile/task.go
+++ b/taskfile/task.go
@@ -19,6 +19,7 @@ type Task struct {
 	Vars          *Vars
 	Env           *Vars
 	Silent        bool
+	Interactive   bool
 	Method        string
 	Prefix        string
 	IgnoreError   bool
@@ -59,6 +60,7 @@ func (t *Task) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		Vars          *Vars
 		Env           *Vars
 		Silent        bool
+		Interactive   bool
 		Method        string
 		Prefix        string
 		IgnoreError   bool `yaml:"ignore_error"`
@@ -80,6 +82,7 @@ func (t *Task) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	t.Vars = task.Vars
 	t.Env = task.Env
 	t.Silent = task.Silent
+	t.Interactive = task.Interactive
 	t.Method = task.Method
 	t.Prefix = task.Prefix
 	t.IgnoreError = task.IgnoreError

--- a/variables.go
+++ b/variables.go
@@ -56,6 +56,7 @@ func (e *Executor) compiledTask(call taskfile.Call, evaluateShVars bool) (*taskf
 		Vars:        nil,
 		Env:         nil,
 		Silent:      origTask.Silent,
+		Interactive: origTask.Interactive,
 		Method:      r.Replace(origTask.Method),
 		Prefix:      r.Replace(origTask.Prefix),
 		IgnoreError: origTask.IgnoreError,


### PR DESCRIPTION
Add the task parameter "interactive" to force interleaved output in order
to make interactive CLI apps work.

Feature request in #217

TODO:
* Update documentation

Signed-off-by: Marcello Sylvester Bauer <sylv@sylv.io>