### PR TITLE
Upgrade Goreleaser action to v2 - To ensure mac/m1 mac/arm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           go-version: 1.15.x
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
# Description

Upgrade Goreleaser action to version 2.

Because, it's impossible to use go-task with a M1 Mac.

With this version, I think that will fix the problem.