### PR TITLE
Build with Go 1.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15.x
+          go-version: 1.16.x
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.15.x, 1.16.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.platform}}
     steps:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,6 @@
 build:
   binary: task
-  main: cmd/task
+  main: ./cmd/task
   goos:
     - windows
     - darwin


### PR DESCRIPTION
This enables `darwin-arm64` builds to support Apple Silicon-based Macs.