### PR TITLE
Allow users to override task logging colors

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -2,6 +2,8 @@ package logger
 
 import (
 	"io"
+	"os"
+	"strconv"
 
 	"github.com/fatih/color"
 )
@@ -16,6 +18,11 @@ func Cyan() PrintFunc    { return color.New(color.FgCyan).FprintfFunc() }
 func Yellow() PrintFunc  { return color.New(color.FgYellow).FprintfFunc() }
 func Magenta() PrintFunc { return color.New(color.FgMagenta).FprintfFunc() }
 func Red() PrintFunc     { return color.New(color.FgRed).FprintfFunc() }
+
+func Fail() PrintFunc { return color.New(EnvColor("TASK_COLOR_FAIL", color.FgRed)).FprintfFunc() }
+func Exec() PrintFunc { return color.New(EnvColor("TASK_COLOR_EXEC", color.FgGreen)).FprintfFunc() }
+func Skip() PrintFunc { return color.New(EnvColor("TASK_COLOR_SKIP", color.FgMagenta)).FprintfFunc() }
+func Warn() PrintFunc { return color.New(EnvColor("TASK_COLOR_WARN", color.FgYellow)).FprintfFunc() }
 
 // Logger is just a wrapper that prints stuff to STDOUT or STDERR,
 // with optional color.
@@ -62,4 +69,12 @@ func (l *Logger) VerboseErrf(color Color, s string, args ...interface{}) {
 	if l.Verbose {
 		l.Errf(color, s, args...)
 	}
+}
+
+func EnvColor(envKey string, defaultColor color.Attribute) color.Attribute {
+	envColor, err := strconv.Atoi(os.Getenv(envKey))
+	if err != nil {
+		return defaultColor
+	}
+	return color.Attribute(envColor)
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -73,8 +73,8 @@ func (l *Logger) VerboseErrf(color Color, s string, args ...interface{}) {
 
 func EnvColor(envKey string, defaultColor color.Attribute) color.Attribute {
 	envColor, err := strconv.Atoi(os.Getenv(envKey))
-	if err != nil {
-		return defaultColor
+	if err == nil {
+		return color.Attribute(envColor)
 	}
-	return color.Attribute(envColor)
+	return defaultColor
 }

--- a/task.go
+++ b/task.go
@@ -327,24 +327,24 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 
 			if upToDate && preCondMet {
 				if !e.Silent {
-					e.Logger.Errf(logger.Magenta, `task: Task "%s" is up to date`, t.Name())
+					e.Logger.Errf(logger.Skip, `task: Task "%s" is up to date`, t.Name())
 				}
 				return nil
 			}
 		}
 
 		if err := e.mkdir(t); err != nil {
-			e.Logger.Errf(logger.Red, "task: cannot make directory %q: %v", t.Dir, err)
+			e.Logger.Errf(logger.Fail, "task: cannot make directory %q: %v", t.Dir, err)
 		}
 
 		for i := range t.Cmds {
 			if err := e.runCommand(ctx, t, call, i); err != nil {
 				if err2 := e.statusOnError(t); err2 != nil {
-					e.Logger.VerboseErrf(logger.Yellow, "task: error cleaning status on error: %v", err2)
+					e.Logger.VerboseErrf(logger.Warn, "task: error cleaning status on error: %v", err2)
 				}
 
 				if execext.IsExitError(err) && t.IgnoreError {
-					e.Logger.VerboseErrf(logger.Yellow, "task: task error ignored: %v", err)
+					e.Logger.VerboseErrf(logger.Warn, "task: task error ignored: %v", err)
 					continue
 				}
 
@@ -408,7 +408,7 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 		return nil
 	case cmd.Cmd != "":
 		if e.Verbose || (!cmd.Silent && !t.Silent && !e.Taskfile.Silent && !e.Silent) {
-			e.Logger.Errf(logger.Green, "task: [%s] %s", t.Name(), cmd.Cmd)
+			e.Logger.Errf(logger.Exec, "task: [%s] %s", t.Name(), cmd.Cmd)
 		}
 
 		if e.Dry {
@@ -439,7 +439,7 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 			Stderr:  stdErr,
 		})
 		if execext.IsExitError(err) && cmd.IgnoreError {
-			e.Logger.VerboseErrf(logger.Yellow, "task: [%s] command error ignored: %v", t.Name(), err)
+			e.Logger.VerboseErrf(logger.Warn, "task: [%s] command error ignored: %v", t.Name(), err)
 			return nil
 		}
 		return err
@@ -486,7 +486,7 @@ func (e *Executor) startExecution(ctx context.Context, t *taskfile.Task, execute
 
 	if ok {
 		e.executionHashesMutex.Unlock()
-		e.Logger.VerboseErrf(logger.Magenta, "task: skipping execution of task: %s", h)
+		e.Logger.VerboseErrf(logger.Skip, "task: skipping execution of task: %s", h)
 		<-otherExecutionCtx.Done()
 		return nil
 	}


### PR DESCRIPTION
As I introduce some of my coworkers to Task some of them have expressed dissatisfaction with the default coloring scheme of Task's logs. Specifically, some of them use custom mapped values so that "magenta" on their machine is much closer to "orange" or "red" than a standard setup.

This PR attempts to provide a mechanism for users to minimally customize the logging colors without too much hassle.

Introduce 4 new loggers in internal/logging/logging.go:
- Exec: color of task commands as they execute
- Fail: color of failed task logs
- Skip: color of skipped tasks (eg, status up-to-date)
- Warn: color of warning (eg, ignored errors)

Colors of these loggers are configurable via ENV vars:
- TASK_COLOR_EXEC
- TASK_COLOR_FAIL
- TASK_COLOR_SKIP
- TASK_COLOR_WARN

Example usage:

```bash
TASK_COLOR_EXEC=36 task test
# => task executes with Cyan-colored execution logs
```