### PR TITLE
update goreleaser config to include `completion/*` files

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,8 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+    files:
+      - completion/*
 
 release:
   draft: true


### PR DESCRIPTION
tested by building and inspecting the various archives,`goreleaser release --skip-publish --skip-sign --skip-validate --rm-dist`. this is half of what it should take to install shell completions via homebrew for https://github.com/go-task/task/issues/264

once the completions are packaged with the binary, we can confirm theyre installed by homebrew,  https://github.com/go-task/homebrew-tap/pull/2