### PR TITLE
Show variable names on verbose mode

### DIFF
--- a/internal/compiler/v3/compiler_v3.go
+++ b/internal/compiler/v3/compiler_v3.go
@@ -64,10 +64,21 @@ func (c *CompilerV3) getVariables(t *taskfile.Task, call *taskfile.Call, evaluat
 			if err := tr.Err(); err != nil {
 				return err
 			}
+
+			debugLog := false
+			if _, ok := c.dynamicCache[v.Sh]; !ok {
+				debugLog = true
+			}
+
 			static, err := c.HandleDynamicVar(v, dir)
 			if err != nil {
 				return err
 			}
+
+			if v.Static == "" && v.Sh != "" && debugLog {
+				c.Logger.VerboseErrf(logger.Magenta, `task: dynamic variable: [%s] '%s' result: '%s'`, k, v.Sh, static)
+			}
+
 			result.Set(k, taskfile.Var{Static: static})
 			return nil
 		}
@@ -144,7 +155,6 @@ func (c *CompilerV3) HandleDynamicVar(v taskfile.Var, dir string) (string, error
 	result := strings.TrimSuffix(stdout.String(), "\n")
 
 	c.dynamicCache[v.Sh] = result
-	c.Logger.VerboseErrf(logger.Magenta, `task: dynamic variable: '%s' result: '%s'`, v.Sh, result)
 
 	return result, nil
 }


### PR DESCRIPTION
This added the variable name in the output of the verbose mode.

I duplicated some logic around the HandleDynamicVar to avoid changing the
public interface. I would prefer to add the `k` parameter there to know the
variable name, but that would break the backward compatibility.

Also, I could print it for each task that defines the variables, but because
all the tasks have access to the variables, it would show it in every single
task, without distintion between the tasks that are using it or not. So I
prefered to show this only once with the variable name, instead of once per
task with the task name.

Fixes #532