### PR TITLE
fix: goreleaser brew completions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,4 +23,4 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.GH_PAT}}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,10 @@ gomod:
 
 archives:
   - name_template: "{{.Binary}}_{{.Os}}_{{.Arch}}"
+    files:
+      - README.md
+      - LICENSE
+      - completion/**/*
     format_overrides:
       - goos: windows
         format: zip
@@ -62,5 +66,8 @@ brews:
       name: homebrew-tap
     test:
       system "#{bin}/task", "--help"
-    url_template: https://github.com/go-task/task/releases/download/{{.Tag}}/{{.ArtifactName}}
-    skip_upload: true
+    install: |-
+      bin.install "task"
+      bash_completion.install "completion/bash/task.bash" => "task"
+      zsh_completion.install "completion/zsh/_task" => "_task"
+      fish_completion.install "completion/fish/task.fish"


### PR DESCRIPTION
- fixed release to use a Personal Access Token: judging by history/blame, brew upload was disabled because it wasn't working, its likely because you need to use a PAT for it to work, check https://goreleaser.com/ci/actions/#token-permissions for more details
- added completion files to the archives
- installing the completions on the homebrew-tap

this should close https://github.com/go-task/homebrew-tap/pull/2 as well