### PR TITLE
task: Check context error

### DIFF
--- a/task.go
+++ b/task.go
@@ -315,6 +315,10 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 		}
 
 		if !e.Force {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
 			preCondMet, err := e.areTaskPreconditionsMet(ctx, t)
 			if err != nil {
 				return err


### PR DESCRIPTION
Fix #597

Check context error after running dependencies, to prevent false
negative precondition errors due to "context canceled".