### PR TITLE
Update 'community.md' to add IntelliJ plugin link

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -29,6 +29,12 @@ There is a convenience wrapper for initializing and running tasks from Sublime T
 developed by [@biozz](https://github.com/biozz), the source code is available [here](https://github.com/biozz/sublime-taskfile)
 and it is published on Package Control [here](https://packagecontrol.io/packages/Taskfile).
 
+### IntelliJ Taskfile Plugin
+
+There's a JetBrains IntelliJ plugin done by
+[@lechuckroh](https://github.com/lechuckroh), which has its code [here](https://github.com/lechuckroh/task-intellij-plugin)
+and is published [here](https://plugins.jetbrains.com/plugin/17058-taskfile).
+
 ## Installation methods
 
 Some installation methods are maintained by third party:


### PR DESCRIPTION
Hi..

I've published JetBrains IntelliJ plugin for task.

Can you add the plugin link to the community page? 😄 
