### PR TITLE
Add support to alias included default task

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -117,6 +117,30 @@ namespace. So, you'd call `task docs:serve` to run the `serve` task from
 `documentation/Taskfile.yml` or `task docker:build` to run the `build` task
 from the `DockerTasks.yml` file.
 
+Included Taskfiles that declare a `default` task will be aliased automatically
+to their namespace only if there is not a conflicting task in the parent Taskfile.
+
+```yaml
+version: '3'
+includes:
+  docker: ./DockerTasks.yml
+tasks:
+  deploy:
+    - task: docker # will run docker:default
+```
+
+...
+
+```yaml
+version: '3'
+includes:
+  docker: ./DockerTasks.yml
+tasks:
+  docker: # declaring `docker` will prevent the above behavior
+    cmds:
+      - task: docker:default # but the default task can still be used
+```
+
 ### OS-specific Taskfiles
 
 With `version: '2'`, task automatically includes any `Taskfile_{{OS}}.yml`

--- a/task_test.go
+++ b/task_test.go
@@ -753,6 +753,18 @@ func TestIncludes(t *testing.T) {
 	tt.Run(t)
 }
 
+func TestIncludesFlattenDefault(t *testing.T) {
+	tt := fileContentTest{
+		Dir:       "testdata/includes_flatten_default",
+		Target:    "default",
+		TrimSpace: true,
+		Files: map[string]string{
+			"file.txt": "hello world",
+		},
+	}
+	tt.Run(t)
+}
+
 func TestIncorrectVersionIncludes(t *testing.T) {
 	const dir = "testdata/incorrect_includes"
 	expectedError := "task: Import with additional parameters is only available starting on Taskfile version v3"

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -113,6 +113,11 @@ func Taskfile(dir string, entrypoint string) (*taskfile.Taskfile, error) {
 		if err = taskfile.Merge(t, includedTaskfile, namespace); err != nil {
 			return err
 		}
+
+		if t.Tasks[namespace] == nil && includedTaskfile.Tasks["default"] != nil {
+			t.Tasks[namespace] = includedTaskfile.Tasks["default"]
+		}
+
 		return nil
 	})
 	if err != nil {

--- a/testdata/includes_flatten_default/.gitignore
+++ b/testdata/includes_flatten_default/.gitignore
@@ -1,0 +1,1 @@
+file.txt

--- a/testdata/includes_flatten_default/Taskfile.yml
+++ b/testdata/includes_flatten_default/Taskfile.yml
@@ -1,0 +1,9 @@
+version: 3
+
+includes:
+  flat: "./Taskfile2.yml"
+
+tasks:
+  default:
+    cmds:
+      - task: flat

--- a/testdata/includes_flatten_default/Taskfile2.yml
+++ b/testdata/includes_flatten_default/Taskfile2.yml
@@ -1,0 +1,6 @@
+version: 3
+
+tasks:
+  default:
+    cmds:
+      - echo "hello world" > file.txt


### PR DESCRIPTION
This PR addresses the issue brought up in #661. I've also updated the docs and added test coverage!

Included Taskfiles that declare a `default` task will be aliased automatically to their namespace only if there is not a conflicting task in the parent Taskfile.

```yaml
version: '3'
includes:
  docker: ./DockerTasks.yml
tasks:
  deploy:
    - task: docker # will run docker:default
```

...

```yaml
version: '3'
includes:
  docker: ./DockerTasks.yml
tasks:
  docker: # declaring `docker` will prevent the above behavior
    cmds:
      - task: docker:default # but the default task can still be used
```
