### PR TITLE
Add dist fallbacks to defaultTaskfiles

### DIFF
--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -20,7 +20,7 @@ var (
 	// ErrIncludedTaskfilesCantHaveDotenvs is returned when a included Taskfile contains dotenvs
 	ErrIncludedTaskfilesCantHaveDotenvs = errors.New("task: Included Taskfiles can't have dotenv declarations. Please, move the dotenv declaration to the main Taskfile")
 
-	defaultTaskfiles = []string{"Taskfile.yml", "Taskfile.yaml"}
+	defaultTaskfiles = []string{"Taskfile.yml", "Taskfile.yaml", "Taskfile.dist.yml", "Taskfile.dist.yaml"}
 )
 
 // Taskfile reads a Taskfile for a given directory


### PR DESCRIPTION
This PR addresses issues mentioned in #498 

I've added `Taskfile.dist.yml` and `Taskfile.dist.yaml` to the list of default taskfiles to look for when including a directory.