### PR TITLE
Add task hooks

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -653,8 +653,10 @@ There are a series of hooks that can be used to execute commands in response to 
 - `before_all` commands are called before a task starts execution
 - `after_all` commands are called after a task completes, success or failure
 - `on_success` commands are called when a task completes successfully
-- `on_failure` commands are called when a task fails an exit code other than `0`
+- `on_failure` commands are called when a task completes with an exit code other than `0`
 - `on_skipped` commands are called when a task is skipped due to status, precondition or checksum
+
+Hooks are simply event listeners and do not have the ability to control the flow of a task. If a command within a hook fails to execute, the failure will simply be pushed to the verbose logger and the task will continue its execution.
 
 Examples:
 ```yml
@@ -719,6 +721,7 @@ tasks:
 
   skippy2:
     status:
+      - touch status.txt
       - test -f status.txt
     cmds:
       - echo "i won't get here"

--- a/hooks.go
+++ b/hooks.go
@@ -1,0 +1,63 @@
+package task
+
+import (
+	"context"
+
+	"github.com/go-task/task/v3/internal/logger"
+	"github.com/go-task/task/v3/taskfile"
+)
+
+func (e *Executor) hookBeforeAll(ctx context.Context, t *taskfile.Task) {
+	if t.Hooks != nil && len(t.Hooks.BeforeAll) != 0 {
+		var err error
+		for _, cmd := range t.Hooks.BeforeAll {
+			if err = e.runCommand(ctx, t, cmd); err != nil {
+				e.Logger.VerboseErrf(logger.Red, "task: error executing command in before_all hook: %v", err)
+			}
+		}
+	}
+}
+
+func (e *Executor) hookAfterAll(ctx context.Context, t *taskfile.Task) {
+	if t.Hooks != nil && len(t.Hooks.AfterAll) != 0 {
+		var err error
+		for _, cmd := range t.Hooks.AfterAll {
+			if err = e.runCommand(ctx, t, cmd); err != nil {
+				e.Logger.VerboseErrf(logger.Red, "task: error executing command in after_all hook: %v", err)
+			}
+		}
+	}
+}
+
+func (e *Executor) hookSuccess(ctx context.Context, t *taskfile.Task) {
+	if t.Hooks != nil && len(t.Hooks.OnSuccess) != 0 {
+		var err error
+		for _, cmd := range t.Hooks.OnSuccess {
+			if err = e.runCommand(ctx, t, cmd); err != nil {
+				e.Logger.VerboseErrf(logger.Red, "task: error executing command in on_success hook: %v", err)
+			}
+		}
+	}
+}
+
+func (e *Executor) hookFailure(ctx context.Context, t *taskfile.Task) {
+	if t.Hooks != nil && len(t.Hooks.OnFailure) != 0 {
+		var err error
+		for _, cmd := range t.Hooks.OnFailure {
+			if err = e.runCommand(ctx, t, cmd); err != nil {
+				e.Logger.VerboseErrf(logger.Red, "task: error executing command in on_failure hook: %v", err)
+			}
+		}
+	}
+}
+
+func (e *Executor) hookSkipped(ctx context.Context, t *taskfile.Task) {
+	if t.Hooks != nil && len(t.Hooks.OnSkipped) != 0 {
+		var err error
+		for _, cmd := range t.Hooks.OnSkipped {
+			if err = e.runCommand(ctx, t, cmd); err != nil {
+				e.Logger.VerboseErrf(logger.Red, "task: error executing command in on_skipped hook: %v", err)
+			}
+		}
+	}
+}

--- a/task.go
+++ b/task.go
@@ -330,6 +330,13 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 				if !e.Silent {
 					e.Logger.Errf(logger.Magenta, `task: Task "%s" is up to date`, t.Name())
 				}
+				if t.Hooks != nil && len(t.Hooks.OnSkipped) != 0 {
+					for _, cmd := range t.Hooks.OnSkipped {
+						if err = e.runCommand(ctx, t, cmd); err != nil {
+							e.Logger.VerboseErrf(logger.Red, "task: error executing command in on_skipped hook: %v", err)
+						}
+					}
+				}
 				return nil
 			}
 		}

--- a/task_test.go
+++ b/task_test.go
@@ -290,6 +290,32 @@ func TestHooksTaskFailure(t *testing.T) {
 	tt.Run(t)
 }
 
+func TestHooksTaskSkippedByStatus(t *testing.T) {
+	tt := fileContentTest{
+		Dir:       "testdata/hooks",
+		Target:    "skipped_status",
+		TrimSpace: true,
+		ExpectErr: true,
+		Files: map[string]string{
+			"on_skipped.txt": "on_skipped_status",
+		},
+	}
+	tt.Run(t)
+}
+
+func TestHooksTaskSkippedByPrecondition(t *testing.T) {
+	tt := fileContentTest{
+		Dir:       "testdata/hooks",
+		Target:    "skipped_preconditions",
+		TrimSpace: true,
+		ExpectErr: true,
+		Files: map[string]string{
+			"on_skipped.txt": "on_skipped_preconditions",
+		},
+	}
+	tt.Run(t)
+}
+
 func TestHooksIncludedTaskSuccess(t *testing.T) {
 	tt := fileContentTest{
 		Dir:        "testdata/hooks/",
@@ -318,6 +344,34 @@ func TestHooksIncludedTaskFailure(t *testing.T) {
 			"after_all.txt":  "failure",
 			"before_all.txt": "failure",
 			"on_failure.txt": "on_failure",
+		},
+	}
+	tt.Run(t)
+}
+
+func TestHooksIncludedTaskSkippedByStatus(t *testing.T) {
+	tt := fileContentTest{
+		Dir:        "testdata/hooks",
+		Entrypoint: "Taskfile2.yml",
+		Target:     "included:skipped_status",
+		TrimSpace:  true,
+		ExpectErr:  true,
+		Files: map[string]string{
+			"on_skipped.txt": "on_skipped_status",
+		},
+	}
+	tt.Run(t)
+}
+
+func TestHooksIncludedTaskSkippedByPrecondition(t *testing.T) {
+	tt := fileContentTest{
+		Dir:        "testdata/hooks",
+		Entrypoint: "Taskfile2.yml",
+		Target:     "included:skipped_preconditions",
+		TrimSpace:  true,
+		ExpectErr:  true,
+		Files: map[string]string{
+			"on_skipped.txt": "on_skipped_preconditions",
 		},
 	}
 	tt.Run(t)

--- a/taskfile/hooks.go
+++ b/taskfile/hooks.go
@@ -11,7 +11,8 @@ type Hooks struct {
 	OnSuccess []*Cmd `yaml:"on_success"`
 	// OnFailure commands are called when a task fails with an error
 	OnFailure []*Cmd `yaml:"on_failure"`
-
+	// OnSkipped commands are called when a task is skipped due to status, precondition or checksum
+	OnSkipped []*Cmd `yaml:"on_skipped"`
 	/**
 	// Other useful hooks?
 

--- a/taskfile/hooks.go
+++ b/taskfile/hooks.go
@@ -1,0 +1,25 @@
+package taskfile
+
+// Hooks represents events fired during a task's execution. Hooks do not stop
+// task execution if any of their commands fail.
+type Hooks struct {
+	// BeforeAll commands are called before a task starts execution
+	BeforeAll []*Cmd `yaml:"before_all"`
+	// AfterAll commands are called after a task completes, success or failure
+	AfterAll []*Cmd `yaml:"after_all"`
+	// OnSuccess commands are called when a task completes successfully
+	OnSuccess []*Cmd `yaml:"on_success"`
+	// OnFailure commands are called when a task fails with an error
+	OnFailure []*Cmd `yaml:"on_failure"`
+
+	/**
+	// Other useful hooks?
+
+	// OnAbort commands are called when a task is aborted with Ctrl+C
+	OnAbort   []*Cmd `yaml:"on_abort"`
+	// OnRetry commands are called when a task retries after an error
+	OnRetry   []*Cmd `yaml:"on_retry"`
+	// OnTimeout commands are called when a task hits a timeout error
+	OnTimeout []*Cmd `yaml:"on_timeout"`
+	**/
+}

--- a/taskfile/task.go
+++ b/taskfile/task.go
@@ -18,6 +18,7 @@ type Task struct {
 	Dir           string
 	Vars          *Vars
 	Env           *Vars
+	Hooks         *Hooks
 	Silent        bool
 	Interactive   bool
 	Method        string
@@ -59,6 +60,7 @@ func (t *Task) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		Dir           string
 		Vars          *Vars
 		Env           *Vars
+		Hooks         *Hooks
 		Silent        bool
 		Interactive   bool
 		Method        string
@@ -81,6 +83,7 @@ func (t *Task) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	t.Dir = task.Dir
 	t.Vars = task.Vars
 	t.Env = task.Env
+	t.Hooks = task.Hooks
 	t.Silent = task.Silent
 	t.Interactive = task.Interactive
 	t.Method = task.Method

--- a/testdata/hooks/.gitignore
+++ b/testdata/hooks/.gitignore
@@ -2,3 +2,4 @@ before_all.txt
 after_all.txt
 *failure.txt
 *success.txt
+*skipped.txt

--- a/testdata/hooks/.gitignore
+++ b/testdata/hooks/.gitignore
@@ -1,0 +1,4 @@
+before_all.txt
+after_all.txt
+*failure.txt
+*success.txt

--- a/testdata/hooks/Taskfile.yml
+++ b/testdata/hooks/Taskfile.yml
@@ -23,3 +23,21 @@ tasks:
         - echo "failure" > before_all.txt
       on_failure:
         - echo "on_failure" > on_failure.txt
+
+  skipped_status:
+    status:
+      - echo "no errors here"
+    cmds:
+      - echo "i won't get here" > skipped.txt
+    hooks:
+      on_skipped:
+        - echo "on_skipped_status" > on_skipped.txt
+
+  skipped_preconditions:
+    preconditions:
+      - sh: "exit 1"
+    cmds:
+      - echo "i won't get here" > skipped.txt
+    hooks:
+      on_skipped:
+        - echo "on_skipped_preconditions" > on_skipped.txt

--- a/testdata/hooks/Taskfile.yml
+++ b/testdata/hooks/Taskfile.yml
@@ -1,0 +1,25 @@
+version: '3'
+
+tasks:
+  success:
+    cmds:
+      - echo "command executed" > success.txt
+    hooks:
+      after_all:
+        - echo "success" > after_all.txt
+      before_all:
+        - echo "success" > before_all.txt
+      on_success:
+        - echo "on_success" > on_success.txt
+
+  failure:
+    cmds:
+      - echo "command executed" > failure.txt
+      - exit 1
+    hooks:
+      after_all:
+        - echo "failure" > after_all.txt
+      before_all:
+        - echo "failure" > before_all.txt
+      on_failure:
+        - echo "on_failure" > on_failure.txt

--- a/testdata/hooks/Taskfile2.yml
+++ b/testdata/hooks/Taskfile2.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+includes: 
+  included: "./Taskfile.yml"
+
+tasks:
+  success:
+    - task: included:success
+
+  failure:
+    - task: included:failure

--- a/variables.go
+++ b/variables.go
@@ -55,6 +55,7 @@ func (e *Executor) compiledTask(call taskfile.Call, evaluateShVars bool) (*taskf
 		Dir:         r.Replace(origTask.Dir),
 		Vars:        nil,
 		Env:         nil,
+		Hooks:       origTask.Hooks,
 		Silent:      origTask.Silent,
 		Interactive: origTask.Interactive,
 		Method:      r.Replace(origTask.Method),


### PR DESCRIPTION
This PR is in response to a series of issues: #141, #204 and #344. This code adds "hooks" as a feature, with the initial implementation containing 5 hooks. I've added unit tests to cover all of the new behavior, and additional documentation containing examples of each hook!

- `before_all` commands are called before a task starts execution
- `after_all` commands are called after a task completes, success or failure
- `on_success` commands are called when a task completes successfully
- `on_failure` commands are called when a task fails due to an exit code other than 0
- `on_skipped` commands are called when a task is skipped due to status, precondition or checksum

Here is an example of the usage:
```yml
version: '3'

tasks:
  notify:
    vars:
      STATUS: "NONE"
    cmds:
      - curl -d "status={{.STATUS}}" -X POST http://webhook.example.com
      
  test:
    cmds:
      - go test
    hooks:
      on_success:
        - task: notify
          vars:
            STATUS: "PASS" 
      on_failure:
        - task: notify
          vars:
            STATUS: "FAIL"
```