### PR TITLE
Add setup hook

### DIFF
--- a/internal/compiler/v2/compiler_v2.go
+++ b/internal/compiler/v2/compiler_v2.go
@@ -104,12 +104,12 @@ func (c *CompilerV2) HandleDynamicVar(v taskfile.Var, _ string) (string, error) 
 
 	var stdout bytes.Buffer
 	opts := &execext.RunCommandOptions{
-		Command: v.Sh,
-		Stdout:  &stdout,
-		Stderr:  c.Logger.Stderr,
+		Commands: []string{v.Sh},
+		Stdout:   &stdout,
+		Stderr:   c.Logger.Stderr,
 	}
 	if err := execext.RunCommand(context.Background(), opts); err != nil {
-		return "", fmt.Errorf(`task: Command "%s" failed: %s`, opts.Command, err)
+		return "", fmt.Errorf(`task: Command "%s" failed: %s`, v.Sh, err)
 	}
 
 	// Trim a single trailing newline from the result to make most command

--- a/internal/compiler/v3/compiler_v3.go
+++ b/internal/compiler/v3/compiler_v3.go
@@ -130,13 +130,13 @@ func (c *CompilerV3) HandleDynamicVar(v taskfile.Var, dir string) (string, error
 
 	var stdout bytes.Buffer
 	opts := &execext.RunCommandOptions{
-		Command: v.Sh,
-		Dir:     dir,
-		Stdout:  &stdout,
-		Stderr:  c.Logger.Stderr,
+		Commands: []string{v.Sh},
+		Dir:      dir,
+		Stdout:   &stdout,
+		Stderr:   c.Logger.Stderr,
 	}
 	if err := execext.RunCommand(context.Background(), opts); err != nil {
-		return "", fmt.Errorf(`task: Command "%s" failed: %s`, opts.Command, err)
+		return "", fmt.Errorf(`task: Command "%s" failed: %s`, v.Sh, err)
 	}
 
 	// Trim a single trailing newline from the result to make most command

--- a/internal/execext/exec.go
+++ b/internal/execext/exec.go
@@ -16,12 +16,12 @@ import (
 
 // RunCommandOptions is the options for the RunCommand func
 type RunCommandOptions struct {
-	Command string
-	Dir     string
-	Env     []string
-	Stdin   io.Reader
-	Stdout  io.Writer
-	Stderr  io.Writer
+	Commands []string
+	Dir      string
+	Env      []string
+	Stdin    io.Reader
+	Stdout   io.Writer
+	Stderr   io.Writer
 }
 
 var (
@@ -35,9 +35,14 @@ func RunCommand(ctx context.Context, opts *RunCommandOptions) error {
 		return ErrNilOptions
 	}
 
-	p, err := syntax.NewParser().Parse(strings.NewReader(opts.Command), "")
-	if err != nil {
-		return err
+	script := &syntax.File{}
+	parser := syntax.NewParser()
+	for _, c := range opts.Commands {
+		parsed, err := parser.Parse(strings.NewReader(c), "")
+		if err != nil {
+			return err
+		}
+		script.Stmts = append(script.Stmts, parsed.Stmts...)
 	}
 
 	environ := opts.Env
@@ -55,7 +60,7 @@ func RunCommand(ctx context.Context, opts *RunCommandOptions) error {
 	if err != nil {
 		return err
 	}
-	return r.Run(ctx, p)
+	return r.Run(ctx, script)
 }
 
 // IsExitError returns true the given error is an exis status error

--- a/precondition.go
+++ b/precondition.go
@@ -17,9 +17,9 @@ var (
 func (e *Executor) areTaskPreconditionsMet(ctx context.Context, t *taskfile.Task) (bool, error) {
 	for _, p := range t.Preconditions {
 		err := execext.RunCommand(ctx, &execext.RunCommandOptions{
-			Command: p.Sh,
-			Dir:     t.Dir,
-			Env:     getEnviron(t),
+			Commands: []string{p.Sh},
+			Dir:      t.Dir,
+			Env:      getEnviron(t),
 		})
 
 		if err != nil {

--- a/status.go
+++ b/status.go
@@ -107,9 +107,9 @@ func (e *Executor) checksumChecker(t *taskfile.Task) status.Checker {
 func (e *Executor) isTaskUpToDateStatus(ctx context.Context, t *taskfile.Task) (bool, error) {
 	for _, s := range t.Status {
 		err := execext.RunCommand(ctx, &execext.RunCommandOptions{
-			Command: s,
-			Dir:     t.Dir,
-			Env:     getEnviron(t),
+			Commands: []string{s},
+			Dir:      t.Dir,
+			Env:      getEnviron(t),
 		})
 		if err != nil {
 			e.Logger.VerboseOutf(logger.Yellow, "task: status command %s exited non-zero: %s", s, err)

--- a/task.go
+++ b/task.go
@@ -451,13 +451,21 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 			}
 		}()
 
+		cmds := []string{}
+		if e.Taskfile.Setup != nil {
+			for _, setupCmd := range *e.Taskfile.Setup {
+				cmds = append(cmds, setupCmd.Cmd)
+			}
+		}
+		cmds = append(cmds, cmd.Cmd)
+
 		err := execext.RunCommand(ctx, &execext.RunCommandOptions{
-			Command: cmd.Cmd,
-			Dir:     t.Dir,
-			Env:     getEnviron(t),
-			Stdin:   e.Stdin,
-			Stdout:  stdOut,
-			Stderr:  stdErr,
+			Commands: cmds,
+			Dir:      t.Dir,
+			Env:      getEnviron(t),
+			Stdin:    e.Stdin,
+			Stdout:   stdOut,
+			Stderr:   stdErr,
 		})
 		if execext.IsExitError(err) && cmd.IgnoreError {
 			e.Logger.VerboseErrf(logger.Yellow, "task: [%s] command error ignored: %v", t.Name(), err)

--- a/taskfile/taskfile.go
+++ b/taskfile/taskfile.go
@@ -15,6 +15,7 @@ type Taskfile struct {
 	Vars       *Vars
 	Env        *Vars
 	Tasks      Tasks
+	Setup      *[]Cmd
 	Silent     bool
 	Dotenv     []string
 	Run        string
@@ -30,6 +31,7 @@ func (tf *Taskfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		Includes   *IncludedTaskfiles
 		Vars       *Vars
 		Env        *Vars
+		Setup      *[]Cmd
 		Tasks      Tasks
 		Silent     bool
 		Dotenv     []string
@@ -45,6 +47,7 @@ func (tf *Taskfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	tf.Includes = taskfile.Includes
 	tf.Vars = taskfile.Vars
 	tf.Env = taskfile.Env
+	tf.Setup = taskfile.Setup
 	tf.Tasks = taskfile.Tasks
 	tf.Silent = taskfile.Silent
 	tf.Dotenv = taskfile.Dotenv


### PR DESCRIPTION
This PR is in response to issues described in #204. I've modified `RunCommand` to accept a slice of strings to execute in the same shell. Each string in the slice is run through `syntax.Parser` and the resulting statements are appended to a single `syntax.File` as if it were a small script. 

This ultimately results in all commands under `setup` being run before every single command, the advantage here is that they are executed in the same shell.
```yml
version: '3'

setup:
  - source .env
  - export DIR=$(pwd)

tasks:
  test:
    cmds:
      - echo $DIR
```

This is a rough draft for this feature. Personally I feel like there could be some performance implications with running setup commands before _every single_ command in a task. I'm open to suggestions/feedback from the community!

It might make more sense to have all commands under a task run in the same shell by using the same strategy applied here, ie appending all commands into one script and passing them all at once to the shell.