### PR TITLE
bash-completion refactoring

### DIFF
--- a/completion/bash/task.bash
+++ b/completion/bash/task.bash
@@ -1,21 +1,22 @@
+# /bin/bash
+
 _task_completion()
 {
-  local scripts;
-  local curr_arg;
+  local cur
+  _get_comp_words_by_ref -n : cur
 
-  # Remove colon from word breaks
-  COMP_WORDBREAKS=${COMP_WORDBREAKS//:}
+  case "$cur" in
+  --*)
+    local options="$(_parse_help task)"
+    COMPREPLY=( $(compgen -W "$options" -- "$cur") )
+    ;;
+  *)
+    local tasks="$(task --list-all | awk 'NR>1 { sub(/:$/,"",$2); print $2 }')"
+    COMPREPLY=( $(compgen -W "$tasks" -- "$cur") )
+    ;;
+  esac
 
-  scripts=$(task -l | sed '1d' | awk '{ print $2 }' | sed 's/:$//');
-
-  curr_arg="${COMP_WORDS[COMP_CWORD]:-"."}"
-
-  # Do not accept more than 1 argument
-  if [ "${#COMP_WORDS[@]}" != "2" ]; then
-    return
-  fi
-
-  COMPREPLY=($(compgen -c | echo "$scripts" | grep -- $curr_arg));
+  __ltrim_colon_completions "$cur"
 }
 
 complete -F _task_completion task


### PR DESCRIPTION
1. 'compgen -c' lists _all_ command names on the system, which is not
   appropriate for this script, furthermore echo does not read from stdin
   so the output is lost.

2. use _get_comp_words_by_ref and __ltrim_colon_completions to handle task
   names with colons.

   "...modifying COMP_WORDBREAKS in your completion script is not safe
   (as it is a global variable and it has the side effect of affecting
   the behavior of other completion scripts"
   Ref.: https://stackoverflow.com/a/12495727/7044304

3. Add options completion

4. Use task --list-all