### PR TITLE
Add capability to print only task names

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -158,10 +158,12 @@ func main() {
 
 		OutputStyle: output,
 	}
-	if list && silent {
-		e.PrintTaskNames()
+
+	if (list || listAll) && silent {
+		e.ListTaskNames(listAll)
 		return
 	}
+
 	if err := e.Setup(); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -158,6 +158,10 @@ func main() {
 
 		OutputStyle: output,
 	}
+	if list && silent {
+		e.PrintTaskNames()
+		return
+	}
 	if err := e.Setup(); err != nil {
 		log.Fatal(err)
 	}

--- a/task.go
+++ b/task.go
@@ -104,10 +104,21 @@ func (e *Executor) Run(ctx context.Context, calls ...taskfile.Call) error {
 	return g.Wait()
 }
 
-// Setup setups Executor's internal state
-func (e *Executor) Setup() error {
+// readTaskfile selects and parses the entrypoint.
+func (e *Executor) readTaskfile() error {
+	// select the default entrypoint if not provided
+	if e.Entrypoint == "" {
+		e.Entrypoint = "Taskfile.yml"
+	}
+
 	var err error
 	e.Taskfile, err = read.Taskfile(e.Dir, e.Entrypoint)
+	return err
+}
+
+// Setup setups Executor's internal state
+func (e *Executor) Setup() error {
+	err := e.readTaskfile()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#310 was closed recently in favor of the much better shell-completion refactor of #671.

However, #310 included useful functionality that has been lost in the process – specifically the capability to list only task names (without descriptions and without `*` decorations), which, like @shilangyu pointed out, is useful for more than just shell completions; IDE integration, CI/CD tooling, and SCM/container tooling to name a few.

 - This PR reintroduces that capability without any changes to the shell-completion scripts. 
 - The capability was modified to support the new `--list-all, -a` flag such that: 
 	- `task --list --silent` (`task -ls`) will print only task names that have a description
 	- `task --list-all --silent` (`task -as`) will print all task names
 - The review comments from the previous PR have also been addressed.

Note that if this is merged, consider updating the shell-completion scripts to eliminate the `awk` dependency. The scripts can use this functionality to obtain the desired format.