### PR TITLE
Fix broken completion when no taskfile is found

### DIFF
--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -1,5 +1,8 @@
 function __task_get_tasks --description "Prints all available tasks with their description"
-	task -l | sed '1d' | awk '{ $1=""; print $0 }' | sed 's/:\ /\t/g' | string trim
+  set -l output (task -l 2>&1 < /dev/null | sed '1d' | awk '{ $1=""; print $0 }' | sed 's/:\ /\t/g' | string trim | string split0)
+  if test $output
+      echo $output
+  end
 end
 
 complete -c task -d 'Runs the specified task(s). Falls back to the "default" task if no task name was specified, or lists all tasks if an unknown task name was 


### PR DESCRIPTION
When you are in a directory where there is no `Taskfile.yaml`, the completion will go crazy and keep adding new line on every `Tab` keypress.
```
 task task: No Taskfile found in "/mnt". Use "task --init" to create a new one
tatask task: No Taskfile found in "/mnt". Use "task --init" to create a new one
tatask task: No Taskfile found in "/mnt". Use "task --init" to create a new one
tatask task: No Taskfile found in "/mnt". Use "task --init" to create a new one
tatask task: No Taskfile found in "/mnt". Use "task --init" to create a new one
tatask -l
```
This will silence the error when there's nothing to complete. Of course it will still show completion when there is a `Taskfile.yaml` file.