### PR TITLE
Make progname easier to configure in task.{bash,fish}

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 indent_style = tab
 
-[*.{md,yml,yaml,json,toml,htm,html,js,css,svg}]
+[*.{md,yml,yaml,json,toml,htm,html,js,css,svg,sh,bash}]
 indent_style = space
 indent_size = 2

--- a/completion/bash/task.bash
+++ b/completion/bash/task.bash
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-_task_completion()
+GO_TASK_PROGNAME=task
+
+_go_task_completion()
 {
   local cur
   _get_comp_words_by_ref -n : cur
@@ -13,7 +15,7 @@ _task_completion()
     ;;
   *)
     local tasks
-    tasks="$(task --list-all | awk 'NR>1 { sub(/:$/,"",$2); print $2 }')"
+    tasks="$($GO_TASK_PROGNAME --list-all 2> /dev/null | awk 'NR>1 { sub(/:$/,"",$2); print $2 }')"
     mapfile -t COMPREPLY < <(compgen -W "$tasks" -- "$cur")
     ;;
   esac
@@ -21,4 +23,4 @@ _task_completion()
   __ltrim_colon_completions "$cur"
 }
 
-complete -F _task_completion task
+complete -F _go_task_completion $GO_TASK_PROGNAME

--- a/completion/bash/task.bash
+++ b/completion/bash/task.bash
@@ -1,4 +1,4 @@
-# /bin/bash
+#!/bin/bash
 
 _task_completion()
 {
@@ -7,12 +7,14 @@ _task_completion()
 
   case "$cur" in
   --*)
-    local options="$(_parse_help task)"
-    COMPREPLY=( $(compgen -W "$options" -- "$cur") )
+    local options
+    options="$(_parse_help task)"
+    mapfile -t COMPREPLY < <(compgen -W "$options" -- "$cur")
     ;;
   *)
-    local tasks="$(task --list-all | awk 'NR>1 { sub(/:$/,"",$2); print $2 }')"
-    COMPREPLY=( $(compgen -W "$tasks" -- "$cur") )
+    local tasks
+    tasks="$(task --list-all | awk 'NR>1 { sub(/:$/,"",$2); print $2 }')"
+    mapfile -t COMPREPLY < <(compgen -W "$tasks" -- "$cur")
     ;;
   esac
 

--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -1,11 +1,11 @@
 function __task_get_tasks --description "Prints all available tasks with their description"
-  set -l output (task -l 2>&1 < /dev/null | sed '1d' | awk '{ $1=""; print $0 }' | sed 's/:\ /\t/g' | string trim | string split0)
+	set -l output (task --list-all | sed '1d; s/\* \(.*\):\s*\(.*\)/\1\t\2/' | string split0)
   if test $output
       echo $output
   end
 end
 
-complete -c task -d 'Runs the specified task(s). Falls back to the "default" task if no task name was specified, or lists all tasks if an unknown task name was 
+complete -c task -d 'Runs the specified task(s). Falls back to the "default" task if no task name was specified, or lists all tasks if an unknown task name was
 specified.' -xa "(__task_get_tasks)"
 
 

--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -1,27 +1,29 @@
+set GO_TASK_PROGNAME task
+
 function __task_get_tasks --description "Prints all available tasks with their description"
-	set -l output (task --list-all | sed '1d; s/\* \(.*\):\s*\(.*\)/\1\t\2/' | string split0)
+	set -l output ($GO_TASK_PROGNAME --list-all | sed '1d; s/\* \(.*\):\s*\(.*\)/\1\t\2/' | string split0)
   if test $output
       echo $output
   end
 end
 
-complete -c task -d 'Runs the specified task(s). Falls back to the "default" task if no task name was specified, or lists all tasks if an unknown task name was
+complete -c $GO_TASK_PROGNAME -d 'Runs the specified task(s). Falls back to the "default" task if no task name was specified, or lists all tasks if an unknown task name was
 specified.' -xa "(__task_get_tasks)"
 
 
-complete -c task -s c -l color     -d 'colored output (default true)'
-complete -c task -s d -l dir       -d 'sets directory of execution'
-complete -c task      -l dry       -d 'compiles and prints tasks in the order that they would be run, without executing them'
-complete -c task -s f -l force     -d 'forces execution even when the task is up-to-date'
-complete -c task -s h -l help      -d 'shows Task usage'
-complete -c task -s i -l init      -d 'creates a new Taskfile.yml in the current folder'
-complete -c task -s l -l list      -d 'lists tasks with description of current Taskfile'
-complete -c task -s o -l output    -d 'sets output style: [interleaved|group|prefixed]' -xa "interleaved group prefixed"
-complete -c task -s p -l parallel  -d 'executes tasks provided on command line in parallel'
-complete -c task -s s -l silent    -d 'disables echoing'
-complete -c task      -l status    -d 'exits with non-zero exit code if any of the given tasks is not up-to-date'
-complete -c task      -l summary   -d 'show summary about a task'
-complete -c task -s t -l taskfile  -d 'choose which Taskfile to run. Defaults to "Taskfile.yml"'
-complete -c task -s v -l verbose   -d 'enables verbose mode'
-complete -c task      -l version   -d 'show Task version'
-complete -c task -s w -l watch     -d 'enables watch of the given task'
+complete -c $GO_TASK_PROGNAME -s c -l color     -d 'colored output (default true)'
+complete -c $GO_TASK_PROGNAME -s d -l dir       -d 'sets directory of execution'
+complete -c $GO_TASK_PROGNAME      -l dry       -d 'compiles and prints tasks in the order that they would be run, without executing them'
+complete -c $GO_TASK_PROGNAME -s f -l force     -d 'forces execution even when the task is up-to-date'
+complete -c $GO_TASK_PROGNAME -s h -l help      -d 'shows Task usage'
+complete -c $GO_TASK_PROGNAME -s i -l init      -d 'creates a new Taskfile.yml in the current folder'
+complete -c $GO_TASK_PROGNAME -s l -l list      -d 'lists tasks with description of current Taskfile'
+complete -c $GO_TASK_PROGNAME -s o -l output    -d 'sets output style: [interleaved|group|prefixed]' -xa "interleaved group prefixed"
+complete -c $GO_TASK_PROGNAME -s p -l parallel  -d 'executes tasks provided on command line in parallel'
+complete -c $GO_TASK_PROGNAME -s s -l silent    -d 'disables echoing'
+complete -c $GO_TASK_PROGNAME      -l status    -d 'exits with non-zero exit code if any of the given tasks is not up-to-date'
+complete -c $GO_TASK_PROGNAME      -l summary   -d 'show summary about a task'
+complete -c $GO_TASK_PROGNAME -s t -l taskfile  -d 'choose which Taskfile to run. Defaults to "Taskfile.yml"'
+complete -c $GO_TASK_PROGNAME -s v -l verbose   -d 'enables verbose mode'
+complete -c $GO_TASK_PROGNAME      -l version   -d 'show Task version'
+complete -c $GO_TASK_PROGNAME -s w -l watch     -d 'enables watch of the given task'


### PR DESCRIPTION
As task is a very generic name that conflicts with for example
taskwarrior, some packagers might choose to change it. See my package in
the AUR: https://aur.archlinux.org/packages/go-task.

This change makes it easier to configure the name for downstream
packagers.