### PR TITLE
Add --exit-code (-x) flag to enable carrying error codes from task cmds

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -68,7 +68,7 @@ func main() {
 		silent      bool
 		dry         bool
 		summary     bool
-		carryErr    bool
+		exitCode    bool
 		parallel    bool
 		concurrency int
 		dir         string
@@ -90,7 +90,7 @@ func main() {
 	pflag.BoolVarP(&parallel, "parallel", "p", false, "executes tasks provided on command line in parallel")
 	pflag.BoolVar(&dry, "dry", false, "compiles and prints tasks in the order that they would be run, without executing them")
 	pflag.BoolVar(&summary, "summary", false, "show summary about a task")
-	pflag.BoolVar(&carryErr, "carry", false, "carry error code if any")
+	pflag.BoolVarP(&exitCode, "exit-code", "x", false, "pass-through the exit code of the task command")
 	pflag.StringVarP(&dir, "dir", "d", "", "sets directory of execution")
 	pflag.StringVarP(&entrypoint, "taskfile", "t", "", `choose which Taskfile to run. Defaults to "Taskfile.yml"`)
 	pflag.StringVarP(&output.Name, "output", "o", "", "sets output style: [interleaved|group|prefixed]")
@@ -219,7 +219,7 @@ func main() {
 	if err := e.Run(ctx, calls...); err != nil {
 		e.Logger.Errf(logger.Red, "%v", err)
 		code := 1
-		if carryErr {
+		if exitCode {
 			if tre, ok := err.(*task.TaskRunError); ok {
 				code = tre.ExitCode()
 			}

--- a/errors.go
+++ b/errors.go
@@ -3,6 +3,7 @@ package task
 import (
 	"errors"
 	"fmt"
+	"mvdan.cc/sh/v3/interp"
 )
 
 var (
@@ -18,13 +19,21 @@ func (err *taskNotFoundError) Error() string {
 	return fmt.Sprintf(`task: Task "%s" not found`, err.taskName)
 }
 
-type taskRunError struct {
+type TaskRunError struct {
 	taskName string
 	err      error
 }
 
-func (err *taskRunError) Error() string {
+func (err *TaskRunError) Error() string {
 	return fmt.Sprintf(`task: Failed to run task "%s": %v`, err.taskName, err.err)
+}
+
+func (err *TaskRunError) ExitCode() int {
+	if c, ok := interp.IsExitStatus(err.err); ok {
+		return int(c)
+	}
+
+	return 1
 }
 
 // MaximumTaskCallExceededError is returned when a task is called too

--- a/task.go
+++ b/task.go
@@ -363,7 +363,7 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 					continue
 				}
 
-				return &taskRunError{t.Task, err}
+				return &TaskRunError{t.Task, err}
 			}
 		}
 		e.Logger.VerboseErrf(logger.Magenta, `task: "%s" finished`, call.Task)

--- a/task_test.go
+++ b/task_test.go
@@ -1275,3 +1275,22 @@ VAR_2 is included-default-var2
 	t.Log(buff.String())
 	assert.Equal(t, strings.TrimSpace(buff.String()), expectedOutputOrder)
 }
+
+func TestErrorCode(t *testing.T) {
+	const dir = "testdata/error_code"
+
+	var buff bytes.Buffer
+	e := &task.Executor{
+		Dir:    dir,
+		Stdout: &buff,
+		Stderr: &buff,
+		Silent: true,
+	}
+	assert.NoError(t, e.Setup())
+
+	err := e.Run(context.Background(), taskfile.Call{Task: "test-exit-code"})
+	assert.Error(t, err)
+	casted, ok := err.(*task.TaskRunError)
+	assert.True(t, ok, "cannot cast returned error to *task.TaskRunError")
+	assert.Equal(t, 42, casted.ExitCode(), "unexpected exit code from task")
+}

--- a/testdata/error_code/Taskfile.yml
+++ b/testdata/error_code/Taskfile.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+tasks:
+  test-exit-code:
+    cmds:
+      - exit 42

--- a/watch.go
+++ b/watch.go
@@ -88,7 +88,7 @@ func (e *Executor) watchTasks(calls ...taskfile.Call) error {
 }
 
 func isContextError(err error) bool {
-	if taskRunErr, ok := err.(*taskRunError); ok {
+	if taskRunErr, ok := err.(*TaskRunError); ok {
 		err = taskRunErr.err
 	}
 


### PR DESCRIPTION
Hello,

I recently found the need to get the return code that was returned from a failed command from a task's cmds. After investigating quickly it appeared to me that the task tool would always return with status code 1 when an error occurred during a task.

This PR proposes an additional command flag (--carry), false by default, that will carry the error code, if any, over to the calling shell.