### PR TITLE
Correct install instructions to use standard user bin

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -108,8 +108,8 @@ scenarios like CI. Many thanks to [GoDownloader][godownloader] for enabling the
 easy generation of this script.
 
 ```bash
-# For Default Installation to ./bin with debug logging
-sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d
+# For user-level installation to ~/.local/bin with debug logging
+sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
 
 # For Installation To /usr/local/bin for userwide access with debug logging
 # May require sudo sh


### PR DESCRIPTION
Update user-level install script to advertise the recommended location
for user binaries, which is `~/.local/bin`.

Most operating systems already has this inside their default PATH.
