### PR TITLE
Fix GHA grouping examples

### DIFF
--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -1058,7 +1058,7 @@ version: '3'
 
 output:
   group:
-    begin: '::begin::{{.TASK}}'
+    begin: '::group::{{.TASK}}'
     end: '::endgroup::'
 
 tasks:
@@ -1070,7 +1070,7 @@ tasks:
 
 ```bash
 $ task default
-::begin::default
+::group::default
 Hello, World!
 ::endgroup::
 ```


### PR DESCRIPTION
Our example was not using the correct syntax required for grouping
command output on GHA.

Documentation at https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines