### PR TITLE
Correct `method: timestamp` example block in usage docs

### DIFF
--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -423,7 +423,7 @@ tasks:
       - ./*.go
     generates:
       - app{{exeExt}}
-    method: checksum
+    method: timestamp
 ```
 
 :::info


### PR DESCRIPTION
The text above this block currently references a `timestamp` method for checking if a task should be run, then the example uses `checksum` instead.