### PR TITLE
Create default taskfile by constructing go object

### DIFF
--- a/init.go
+++ b/init.go
@@ -5,21 +5,30 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"gopkg.in/yaml.v3"
 )
 
-const defaultTaskfile = `# https://taskfile.dev
+const defaultTaskfileHeader = `# https://taskfile.dev
 
-version: '3'
-
-vars:
-  GREETING: Hello, World!
-
-tasks:
-  default:
-    cmds:
-      - echo "{{.GREETING}}"
-    silent: true
 `
+
+type Tasks map[string]*Task
+
+type Task struct {
+	Task   string   `yaml:"task,omitempty"`
+	Cmds   []string `yaml:"cmds,omitempty"`
+	Silent bool     `yaml:"silent,omitempty"`
+}
+
+type Vars map[string]string
+
+type Taskfile struct {
+	Version string `yaml:"version,omitempty"`
+	Vars    *Vars  `yaml:"vars,omitempty"`
+	Tasks   Tasks  `yaml:"tasks,omitempty"`
+	Silent  bool   `yaml:"silent,omitempty"`
+}
 
 // InitTaskfile Taskfile creates a new Taskfile
 func InitTaskfile(w io.Writer, dir string) error {
@@ -29,7 +38,27 @@ func InitTaskfile(w io.Writer, dir string) error {
 		return ErrTaskfileAlreadyExists
 	}
 
-	if err := os.WriteFile(f, []byte(defaultTaskfile), 0644); err != nil {
+	taskfile := Taskfile{
+		Version: "3",
+		Vars: &Vars{
+			"GREETING": "Hello, World!",
+		},
+		Tasks: Tasks{
+			"default": &Task{
+				Cmds: []string{
+					"echo \"{{.GREETING}}\"",
+				},
+				Silent: true,
+			},
+		},
+	}
+	out, err := yaml.Marshal(taskfile)
+	if err != nil {
+		return err
+	}
+	data := []byte(defaultTaskfileHeader)
+	data = append(data, out...)
+	if err := os.WriteFile(f, data, 0644); err != nil {
 		return err
 	}
 	fmt.Fprintf(w, "Taskfile.yaml created in the current directory\n")


### PR DESCRIPTION
Signed-off-by: R0CKSTAR <yeahdongcn@gmail.com>

Currently, I use `task` with static `Taskfile.yaml` to perform CI in `Drone`. While the `Taskfile.yaml` becomes larger and larger, I would like to use a go program to generate that file without worrying about the lint and incorrect syntax.

But then I found the definition of Taskfile under `/taskfile/taskfile.go` is a kind of structure used internally, so I decided to add new definition in init.go (I don't know if this is the best place) and use it to generate the default `Taskfile.yaml`.

`Taskfile` structure is now a minimal one that only targets to support `task --init`, we can extend all possible configurations later.