### PR TITLE
feat: run default task in included file when task is omitted

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -1107,6 +1107,30 @@ func TestInternalTask(t *testing.T) {
 	}
 }
 
+func TestIncludesShadowedDefault(t *testing.T) {
+	tt := fileContentTest{
+		Dir:       "testdata/includes_shadowed_default",
+		Target:    "included",
+		TrimSpace: true,
+		Files: map[string]string{
+			"file.txt": "shadowed",
+		},
+	}
+	tt.Run(t)
+}
+
+func TestIncludesUnshadowedDefault(t *testing.T) {
+	tt := fileContentTest{
+		Dir:       "testdata/includes_unshadowed_default",
+		Target:    "included",
+		TrimSpace: true,
+		Files: map[string]string{
+			"file.txt": "included",
+		},
+	}
+	tt.Run(t)
+}
+
 func TestSupportedFileNames(t *testing.T) {
 	fileNames := []string{
 		"Taskfile.yml",

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -153,6 +153,13 @@ func Taskfile(readerNode *ReaderNode) (*taskfile.Taskfile, error) {
 		if err = taskfile.Merge(t, includedTaskfile, &includedTask, namespace); err != nil {
 			return err
 		}
+
+		if includedTaskfile.Tasks["default"] != nil && t.Tasks[namespace] == nil {
+			defaultTaskName := fmt.Sprintf("%s:default", namespace)
+			t.Tasks[defaultTaskName].Aliases = append(t.Tasks[defaultTaskName].Aliases, namespace)
+			t.Tasks[defaultTaskName].Aliases = append(t.Tasks[defaultTaskName].Aliases, includedTask.Aliases...)
+		}
+
 		return nil
 	})
 	if err != nil {

--- a/testdata/includes_shadowed_default/Taskfile.yml
+++ b/testdata/includes_shadowed_default/Taskfile.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+includes:
+  included:
+    taskfile: Taskfile2.yml
+
+tasks:
+  included:
+    cmds:
+      - echo "shadowed" > file.txt

--- a/testdata/includes_shadowed_default/Taskfile2.yml
+++ b/testdata/includes_shadowed_default/Taskfile2.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+tasks:
+  default:
+    cmds:
+      - echo "included" > file.txt

--- a/testdata/includes_shadowed_default/file.txt
+++ b/testdata/includes_shadowed_default/file.txt
@@ -1,0 +1,1 @@
+shadowed

--- a/testdata/includes_unshadowed_default/Taskfile.yml
+++ b/testdata/includes_unshadowed_default/Taskfile.yml
@@ -1,0 +1,5 @@
+version: '3'
+
+includes:
+  included:
+    taskfile: Taskfile2.yml

--- a/testdata/includes_unshadowed_default/Taskfile2.yml
+++ b/testdata/includes_unshadowed_default/Taskfile2.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+tasks:
+  default:
+    cmds:
+      - echo "included" > file.txt

--- a/testdata/includes_unshadowed_default/file.txt
+++ b/testdata/includes_unshadowed_default/file.txt
@@ -1,0 +1,1 @@
+included


### PR DESCRIPTION
I was experimenting with refactoring my (now very large) Taskfile into smaller, more manageable files and I came across #661. This functionality would really help us to make our tasks a bit simpler.

This PR adds the functionality mentioned by @tylermmorton and @andreynering in that issue. Namely:

- When a Taskfile with a `default` task inside is included, the `default` task is available by calling `task <namespace>` as opposed to `task <namespace>:default`.
- If the parent Taskfile contains a task with the same name as the namespace (i.e. the task is "shadowed"), the task in the _parent_ is run, and _not_ the default task in the included file.
  - This ensures that we maintain backward compatibility with existing Taskfiles.
- A couple of unit tests for ensuring the functionality works going forwards.

Note: Not sure about the "shadowed" terminology. Open to better suggestions.

An example below:

```yaml
# Taskfile.yml
version: '3'

includes:
  included:
    taskfile: Taskfile2.yml
```

```yaml
# Taskfile2.yml
version: '3'

tasks:
  default:
    cmds:
      - echo "included task"
```

`task included` will output: `included task`.
Currently you are required to run `task included:default`.

If we amend the parent taskfile like so:

```yaml
# Taskfile.yml
version: '3'

includes:
  included:
    taskfile: Taskfile2.yml

tasks:
  included:
    cmds:
      - echo "shadowed task"
```

`task included` will now output: `shadowed task` instead.