### PR TITLE
Always resolve relative include paths relative to the including Taskfile

### DIFF
--- a/docs/docs/api_reference.md
+++ b/docs/docs/api_reference.md
@@ -81,7 +81,7 @@ Some environment variables can be overriden to adjust Task behavior.
 
 | Attribute | Type | Default | Description |
 | - | - | - | - |
-| `taskfile` | `string` | | The path for the Taskfile or directory to be included. If a directory, Task will look for files named `Taskfile.yml` or `Taskfile.yaml` inside that directory. |
+| `taskfile` | `string` | | The path for the Taskfile or directory to be included. <br/>If a directory, Task will look for files named `Taskfile.yml` or `Taskfile.yaml` inside that directory.<br/>If a relative path, resolved relative to the directory containing the including Taskfile. |
 | `dir` | `string` | The parent Taskfile directory | The working directory of the included tasks when run. |
 | `optional` | `bool` | `false` | If `true`, no errors will be thrown if the specified file does not exist. |
 

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -136,6 +136,8 @@ namespace. So, you'd call `task docs:serve` to run the `serve` task from
 `documentation/Taskfile.yml` or `task docker:build` to run the `build` task
 from the `DockerTasks.yml` file.
 
+Relative paths are resolved relative to the directory containing the including Taskfile.
+
 ### OS-specific Taskfiles
 
 With `version: '2'`, task automatically includes any `Taskfile_{{OS}}.yml`

--- a/task_test.go
+++ b/task_test.go
@@ -52,13 +52,14 @@ func (fct fileContentTest) Run(t *testing.T) {
 
 	for name, expectContent := range fct.Files {
 		t.Run(fct.name(name), func(t *testing.T) {
-			b, err := os.ReadFile(filepath.Join(fct.Dir, name))
+			path := filepath.Join(fct.Dir, name)
+			b, err := os.ReadFile(path)
 			assert.NoError(t, err, "Error reading file")
 			s := string(b)
 			if fct.TrimSpace {
 				s = strings.TrimSpace(s)
 			}
-			assert.Equal(t, expectContent, s, "unexpected file content")
+			assert.Equal(t, expectContent, s, "unexpected file content in %s", path)
 		})
 	}
 }

--- a/task_test.go
+++ b/task_test.go
@@ -775,7 +775,16 @@ func TestIncludesMultiLevel(t *testing.T) {
 
 func TestIncludeCycle(t *testing.T) {
 	const dir = "testdata/includes_cycle"
-	expectedError := "task: include cycle detected between testdata/includes_cycle/Taskfile.yml <--> testdata/includes_cycle/one/two/Taskfile.yml"
+
+	wd, err := os.Getwd()
+	assert.Nil(t, err)
+
+	expectedError := fmt.Sprintf(
+		"task: include cycle detected between %s/%s/one/Taskfile.yml <--> %s/%s/Taskfile.yml",
+		wd,
+		dir,
+		wd,
+		dir)
 
 	var buff bytes.Buffer
 	e := task.Executor{
@@ -853,27 +862,43 @@ func TestIncludesOptional(t *testing.T) {
 }
 
 func TestIncludesOptionalImplicitFalse(t *testing.T) {
+	const dir = "testdata/includes_optional_implicit_false"
+	wd, _ := os.Getwd()
+
+	expected := fmt.Sprintf(
+		"stat %s/%s/TaskfileOptional.yml: no such file or directory",
+		wd,
+		dir)
+
 	e := task.Executor{
-		Dir:    "testdata/includes_optional_implicit_false",
+		Dir:    dir,
 		Stdout: io.Discard,
 		Stderr: io.Discard,
 	}
 
 	err := e.Setup()
 	assert.Error(t, err)
-	assert.Equal(t, "stat testdata/includes_optional_implicit_false/TaskfileOptional.yml: no such file or directory", err.Error())
+	assert.Equal(t, expected, err.Error())
 }
 
 func TestIncludesOptionalExplicitFalse(t *testing.T) {
+	const dir = "testdata/includes_optional_explicit_false"
+	wd, _ := os.Getwd()
+
+	expected := fmt.Sprintf(
+		"stat %s/%s/TaskfileOptional.yml: no such file or directory",
+		wd,
+		dir)
+
 	e := task.Executor{
-		Dir:    "testdata/includes_optional_explicit_false",
+		Dir:    dir,
 		Stdout: io.Discard,
 		Stderr: io.Discard,
 	}
 
 	err := e.Setup()
 	assert.Error(t, err)
-	assert.Equal(t, "stat testdata/includes_optional_explicit_false/TaskfileOptional.yml: no such file or directory", err.Error())
+	assert.Equal(t, expected, err.Error())
 }
 
 func TestIncludesFromCustomTaskfile(t *testing.T) {

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -44,6 +44,7 @@ func Taskfile(readerNode *ReaderNode) (*taskfile.Taskfile, error) {
 		}
 		readerNode.Dir = d
 	}
+
 	path, err := exists(filepath.Join(readerNode.Dir, readerNode.Entrypoint))
 	if err != nil {
 		return nil, err
@@ -60,17 +61,13 @@ func Taskfile(readerNode *ReaderNode) (*taskfile.Taskfile, error) {
 		return nil, err
 	}
 
-	// Resolve any relative paths used by includes to absolute ones
+	// Annotate any included Taskfile reference with a base directory for resolving relative paths
 	_ = t.Includes.Range(func(key string, includedFile taskfile.IncludedTaskfile) error {
-		if !filepath.IsAbs(includedFile.Taskfile) {
-			includedFile.Taskfile = filepath.Join(readerNode.Dir, includedFile.Taskfile)
+		// Set the base directory for resolving relative paths, but only if not already set
+		if includedFile.BaseDir == "" {
+			includedFile.BaseDir = readerNode.Dir
+			t.Includes.Set(key, includedFile)
 		}
-
-		if includedFile.Dir != "" && !filepath.IsAbs(includedFile.Dir) {
-			includedFile.Dir = filepath.Join(readerNode.Dir, includedFile.Dir)
-		}
-
-		t.Includes.Set(key, includedFile)
 		return nil
 	})
 
@@ -83,19 +80,23 @@ func Taskfile(readerNode *ReaderNode) (*taskfile.Taskfile, error) {
 				Optional:       includedTask.Optional,
 				AdvancedImport: includedTask.AdvancedImport,
 				Vars:           includedTask.Vars,
+				BaseDir:        includedTask.BaseDir,
 			}
 			if err := tr.Err(); err != nil {
 				return err
 			}
 		}
 
-		path, err := execext.Expand(includedTask.Taskfile)
+		tf, err := includedTask.FullTaskfilepath()
 		if err != nil {
 			return err
 		}
-		if !filepath.IsAbs(path) {
-			path = filepath.Join(readerNode.Dir, path)
+
+		path, err := execext.Expand(tf)
+		if err != nil {
+			return err
 		}
+
 		path, err = exists(path)
 		if err != nil {
 			if includedTask.Optional {
@@ -128,21 +129,27 @@ func Taskfile(readerNode *ReaderNode) (*taskfile.Taskfile, error) {
 		}
 
 		if includedTask.AdvancedImport {
+			dir, err := includedTask.FullDirPath()
+			if err != nil {
+				return err
+			}
+
 			for k, v := range includedTaskfile.Vars.Mapping {
 				o := v
-				o.Dir = filepath.Join(readerNode.Dir, includedTask.Dir)
+				o.Dir = dir
 				includedTaskfile.Vars.Mapping[k] = o
 			}
 			for k, v := range includedTaskfile.Env.Mapping {
 				o := v
-				o.Dir = filepath.Join(readerNode.Dir, includedTask.Dir)
+				o.Dir = dir
 				includedTaskfile.Env.Mapping[k] = o
 			}
 
 			for _, task := range includedTaskfile.Tasks {
 				if !filepath.IsAbs(task.Dir) {
-					task.Dir = filepath.Join(includedTask.Dir, task.Dir)
+					task.Dir = dir
 				}
+
 				task.IncludeVars = includedTask.Vars
 				task.IncludedTaskfileVars = includedTaskfile.Vars
 			}
@@ -190,19 +197,31 @@ func readTaskfile(file string) (*taskfile.Taskfile, error) {
 	return &t, yaml.NewDecoder(f).Decode(&t)
 }
 
+// exists finds a Taskfile at the stated location, returning a fully qualified path to the file
 func exists(path string) (string, error) {
 	fi, err := os.Stat(path)
 	if err != nil {
 		return "", err
 	}
 	if fi.Mode().IsRegular() {
-		return path, nil
+		// File exists, return a fully qualified path
+		result, err := filepath.Abs(path)
+		if err != nil {
+			return "", err
+		}
+
+		return result, nil
 	}
 
 	for _, n := range defaultTaskfiles {
 		fpath := filepath.Join(path, n)
 		if _, err := os.Stat(fpath); err == nil {
-			return fpath, nil
+			result, err := filepath.Abs(fpath)
+			if err != nil {
+				return "", err
+			}
+
+			return result, nil
 		}
 	}
 

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -147,7 +147,7 @@ func Taskfile(readerNode *ReaderNode) (*taskfile.Taskfile, error) {
 
 			for _, task := range includedTaskfile.Tasks {
 				if !filepath.IsAbs(task.Dir) {
-					task.Dir = dir
+					task.Dir = filepath.Join(dir, task.Dir)
 				}
 
 				task.IncludeVars = includedTask.Vars


### PR DESCRIPTION
Enforces consistency by always resolving relative filepath references to Taskfiles from the directory containing the parent Taskfile.

Resolves #822

Previously, relative filepath references were resolved multiple times, leading to some unanticipated behaviour.

To illustrate, consider the following directory structure:

- `/path/to/project/Taskfile.yaml` # top level
- `/path/to/project/alpha/Taskfile.yaml` # first subfolder
- `/path/to/project/common/Taskfile.yaml` # second subfolder, a sibling of alpha

With the following includes

``` yaml
# /path/to/project/Taskfile.yaml
includes:
  alpha:
    taskfile: ./alpha/Taskfile.yaml
    dir: ./alpha
  common: 
    taskfile: ./common/Taskfile.yaml
    dir: ./common
```

``` yaml
# /path/to/project/alpha/Taskfile.yaml
includes:
  common: 
    taskfile: ../common/Taskfile.yaml
    dir: ../common
```

When loading `/path/to/project/alpha/Taskfile.yaml`, the include `../common/Taskfile.yaml` is correctly being resolved as `/path/to/project/common/Taskfile.yaml`.

But when loading the top level Taskfile `/path/to/project/Taskfile.yaml`, that same import (`../common/Taskfile.yaml`) is being resolved a second time, as `/path/to/common/Taskfile.yaml`, leading to an error.

This fix modifies all includes to use absolute paths, ensuring the correct Taskfile is read.

