### PR TITLE
Modify goreleaser defaults for reproducible builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,9 @@ build:
       goarch: 386
   env:
     - CGO_ENABLED=0
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+    - -trimpath
   ldflags:
     - -s -w # Don't set main.version.
 


### PR DESCRIPTION
This should make it easier to generate the same builds locally (tested with --snapshot).
https://goreleaser.com/customization/build/#reproducible-builds