### PR TITLE
Improved bash completion

### DIFF
--- a/completion/bash/task.bash
+++ b/completion/bash/task.bash
@@ -1,48 +1,48 @@
-# vim: set tabstop=4 shiftwidth=4 expandtab:
+# vim: set tabstop=2 shiftwidth=2 expandtab:
 
 _GO_TASK_COMPLETION_LIST_OPTION='--list-all'
 
 function _task()
 {
-    local cur prev words cword
-    _init_completion -n : || return
+  local cur prev words cword
+  _init_completion -n : || return
 
-    # Handle special arguments of options.
-    case "$prev" in
-        -d|--dir)
-            _filedir -d
-            return $?
-        ;;
-        -t|--taskfile)
-            _filedir yaml
-            _filedir yml
-            return $?
-        ;;
-        -o|--output)
-            COMPREPLY=( $( compgen -W "interleaved group prefixed" -- $cur ) )
-            return 0
-        ;;
-    esac
+  # Handle special arguments of options.
+  case "$prev" in
+    -d|--dir)
+      _filedir -d
+      return $?
+    ;;
+    -t|--taskfile)
+      _filedir yaml || return $?
+      _filedir yml
+      return $?
+    ;;
+    -o|--output)
+      COMPREPLY=( $( compgen -W "interleaved group prefixed" -- $cur ) )
+      return 0
+    ;;
+  esac
 
-    # Handle normal options.
-    case "$cur" in
-        -*)
-            COMPREPLY=( $( compgen -W "$(_parse_help $1)" -- $cur ) )
-            return 0
-        ;;
-    esac
+  # Handle normal options.
+  case "$cur" in
+    -*)
+      COMPREPLY=( $( compgen -W "$(_parse_help $1)" -- $cur ) )
+      return 0
+    ;;
+  esac
 
-    # Get task names.
-    local line tasks=()
-    while read line; do
-        if [[ "${line}" =~ ^\*[[:space:]]+([[:alnum:]_:]+): ]]; then
-            tasks+=( ${BASH_REMATCH[1]} )
-        fi
-    done < <("${COMP_WORDS[@]}" $_GO_TASK_COMPLETION_LIST_OPTION 2> /dev/null)
+  # Get task names.
+  local line tasks=()
+  while read line; do
+    if [[ "${line}" =~ ^\*[[:space:]]+([[:alnum:]_:]+): ]]; then
+      tasks+=( ${BASH_REMATCH[1]} )
+    fi
+  done < <("${COMP_WORDS[@]}" $_GO_TASK_COMPLETION_LIST_OPTION 2> /dev/null)
 
-    # Prepare task completions and post-process due to colons.
-    COMPREPLY=( $( compgen -W "${tasks[*]}" -- "$cur" ) )
-    __ltrim_colon_completions "$cur"
+  # Prepare task completions and post-process due to colons.
+  COMPREPLY=( $( compgen -W "${tasks[*]}" -- "$cur" ) )
+  __ltrim_colon_completions "$cur"
 }
 
 complete -F _task task

--- a/completion/bash/task.bash
+++ b/completion/bash/task.bash
@@ -1,26 +1,48 @@
-#!/bin/bash
+# vim: set tabstop=4 shiftwidth=4 expandtab:
 
-GO_TASK_PROGNAME=task
+_GO_TASK_COMPLETION_LIST_OPTION='--list-all'
 
-_go_task_completion()
+function _task()
 {
-  local cur
-  _get_comp_words_by_ref -n : cur
+    local cur prev words cword
+    _init_completion -n : || return
 
-  case "$cur" in
-  --*)
-    local options
-    options="$(_parse_help task)"
-    mapfile -t COMPREPLY < <(compgen -W "$options" -- "$cur")
-    ;;
-  *)
-    local tasks
-    tasks="$($GO_TASK_PROGNAME --list-all 2> /dev/null | awk 'NR>1 { sub(/:$/,"",$2); print $2 }')"
-    mapfile -t COMPREPLY < <(compgen -W "$tasks" -- "$cur")
-    ;;
-  esac
+    # Handle special arguments of options.
+    case "$prev" in
+        -d|--dir)
+            _filedir -d
+            return $?
+        ;;
+        -t|--taskfile)
+            _filedir yaml
+            _filedir yml
+            return $?
+        ;;
+        -o|--output)
+            COMPREPLY=( $( compgen -W "interleaved group prefixed" -- $cur ) )
+            return 0
+        ;;
+    esac
 
-  __ltrim_colon_completions "$cur"
+    # Handle normal options.
+    case "$cur" in
+        -*)
+            COMPREPLY=( $( compgen -W "$(_parse_help $1)" -- $cur ) )
+            return 0
+        ;;
+    esac
+
+    # Get task names.
+    local line tasks=()
+    while read line; do
+        if [[ "${line}" =~ ^\*[[:space:]]+([[:alnum:]_:]+): ]]; then
+            tasks+=( ${BASH_REMATCH[1]} )
+        fi
+    done < <("${COMP_WORDS[@]}" $_GO_TASK_COMPLETION_LIST_OPTION 2> /dev/null)
+
+    # Prepare task completions and post-process due to colons.
+    COMPREPLY=( $( compgen -W "${tasks[*]}" -- "$cur" ) )
+    __ltrim_colon_completions "$cur"
 }
 
-complete -F _go_task_completion $GO_TASK_PROGNAME
+complete -F _task task


### PR DESCRIPTION
Some incremental update. Point 1 below was most annoying during daily use.

Features:
- Handles the -t and -d options correctly, i.e., completes with tasks in the target directory.
- Calls the correct binary for completions, if bound multiple times, by using `$1` or `COMP_WORDS`.
