### PR TITLE
Use --silent to get the list of tasks (bash completion)

### DIFF
--- a/completion/bash/task.bash
+++ b/completion/bash/task.bash
@@ -32,16 +32,11 @@ function _task()
     ;;
   esac
 
-  # Get task names.
-  local line tasks=()
-  while read line; do
-    if [[ "${line}" =~ ^\*[[:space:]]+([[:alnum:]_:]+): ]]; then
-      tasks+=( ${BASH_REMATCH[1]} )
-    fi
-  done < <("${COMP_WORDS[@]}" $_GO_TASK_COMPLETION_LIST_OPTION 2> /dev/null)
-
-  # Prepare task completions and post-process due to colons.
+  # Prepare task name completions.
+  local tasks=( $( "${COMP_WORDS[@]}" --silent $_GO_TASK_COMPLETION_LIST_OPTION 2> /dev/null ) )
   COMPREPLY=( $( compgen -W "${tasks[*]}" -- "$cur" ) )
+
+  # Post-process because task names might contain colons.
   __ltrim_colon_completions "$cur"
 }
 


### PR DESCRIPTION
This is a small update of PR <https://github.com/go-task/task/pull/835>.

I may have missed the `--silent` option which is much better suited to get the list of tasks than digging in output intended for human readers with regular expressions.