### PR TITLE
#100 confirm prompt before proceeding

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"bufio"
 	"io"
 	"os"
 	"strconv"
@@ -87,4 +88,25 @@ func (l *Logger) VerboseErrf(color Color, s string, args ...interface{}) {
 	if l.Verbose {
 		l.Errf(color, s, args...)
 	}
+}
+
+// Print to STDOUT a string without '\n' and read a key pressed from STDIN
+func (l *Logger) ReadKeyln(color Color, s string, args ...interface{}) byte {
+	if len(args) == 0 {
+		s, args = "%s", []interface{}{s}
+	}
+	if !l.Color {
+		color = Default
+	}
+	print := color()
+	print(l.Stdout, s, args...)
+
+	r := bufio.NewReader(l.Stdin)
+	b, err := r.ReadByte()
+
+	if err != nil {
+		panic(err)
+	}
+
+	return b
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -46,6 +46,7 @@ func envColor(env string, defaultColor color.Attribute) color.Attribute {
 // Logger is just a wrapper that prints stuff to STDOUT or STDERR,
 // with optional color.
 type Logger struct {
+	Stdin   io.Reader
 	Stdout  io.Writer
 	Stderr  io.Writer
 	Verbose bool

--- a/setup.go
+++ b/setup.go
@@ -100,6 +100,7 @@ func (e *Executor) setupStdFiles() {
 
 func (e *Executor) setupLogger() {
 	e.Logger = &logger.Logger{
+		Stdin:   e.Stdin,
 		Stdout:  e.Stdout,
 		Stderr:  e.Stderr,
 		Verbose: e.Verbose,

--- a/task.go
+++ b/task.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -118,6 +119,14 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 		e.Logger.VerboseErrf(logger.Magenta, `task: "%s" started`, call.Task)
 		if err := e.runDeps(ctx, t); err != nil {
 			return err
+		}
+
+		if t.Warn != "" {
+			answer := e.Logger.ReadKeyln(logger.Yellow, "task: [%s] %s Proceed [y/N]? ", call.Task, t.Warn)
+			if !bytes.Contains([]byte("yY"), []byte(string(answer))) {
+				e.Logger.Errf(logger.Red, "task: [%s] skipped", call.Task)
+				return nil
+			}
 		}
 
 		if !e.Force {

--- a/task_test.go
+++ b/task_test.go
@@ -1371,3 +1371,42 @@ func TestEvaluateSymlinksInPaths(t *testing.T) {
 	err = os.RemoveAll(dir + "/.task")
 	assert.NoError(t, err)
 }
+
+func TestWarnNo(t *testing.T) {
+	const dir = "testdata/warn"
+	var buff_out bytes.Buffer
+	buff_in := bytes.NewBufferString("n")
+	e := task.Executor{
+		Dir:    dir,
+		Stdin:  buff_in,
+		Stdout: &buff_out,
+		Stderr: &buff_out,
+	}
+	assert.NoError(t, e.Setup())
+
+	expectedOutputOrder := `task: [task-warning] display this warning. Proceed [y/N]? ` +
+		`task: [task-warning] skipped`
+	assert.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "task-warning"}))
+	assert.Contains(t, buff_out.String(), expectedOutputOrder)
+}
+
+func TestWarnYes(t *testing.T) {
+	const dir = "testdata/warn"
+	var buff_out bytes.Buffer
+	buff_in := bytes.NewBufferString("y")
+	e := task.Executor{
+		Dir:    dir,
+		Stdin:  buff_in,
+		Stdout: &buff_out,
+		Stderr: &buff_out,
+	}
+	assert.NoError(t, e.Setup())
+
+	expectedOutputOrder := `task: [task-warning] display this warning. Proceed [y/N]? ` +
+		strings.TrimSpace(`task: [task-warning] echo 'display this'
+display this
+	`)
+
+	assert.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "task-warning"}))
+	assert.Contains(t, buff_out.String(), expectedOutputOrder)
+}

--- a/taskfile/task.go
+++ b/taskfile/task.go
@@ -26,6 +26,7 @@ type Task struct {
 	Run                  string
 	IncludeVars          *Vars
 	IncludedTaskfileVars *Vars
+	Warn                 string
 }
 
 func (t *Task) Name() string {
@@ -67,6 +68,7 @@ func (t *Task) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		Prefix        string
 		IgnoreError   bool `yaml:"ignore_error"`
 		Run           string
+		Warn          string
 	}
 	if err := unmarshal(&task); err != nil {
 		return err
@@ -89,5 +91,6 @@ func (t *Task) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	t.Prefix = task.Prefix
 	t.IgnoreError = task.IgnoreError
 	t.Run = task.Run
+	t.Warn = task.Warn
 	return nil
 }

--- a/testdata/warn/Taskfile.yml
+++ b/testdata/warn/Taskfile.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+tasks:
+  task-warning:
+    cmds:
+      - echo 'display this'
+    warn: 'display this warning.'

--- a/variables.go
+++ b/variables.go
@@ -63,6 +63,7 @@ func (e *Executor) compiledTask(call taskfile.Call, evaluateShVars bool) (*taskf
 		Run:                  r.Replace(origTask.Run),
 		IncludeVars:          origTask.IncludeVars,
 		IncludedTaskfileVars: origTask.IncludedTaskfileVars,
+		Warn:                 origTask.Warn,
 	}
 	new.Dir, err = execext.Expand(new.Dir)
 	if err != nil {


### PR DESCRIPTION
fixes [A warning/confirm field that shows a confirm prompt before proceeding #100](https://github.com/go-task/task/issues/100)

Example 

```
version: '3'

tasks:
  task-warning:
    cmds:
      - echo 'display this'
    warn: 'display this warning.'

```

Output

```
m@linux:~/Workspaces/go/task/testdata/warn$ task task-warning
task: [task-warning] display this warning. Proceed [y/N]? 
task: [task-warning] skipped
m@linux:~/Workspaces/go/task/testdata/warn$ task task-warning
task: [task-warning] display this warning. Proceed [y/N]? n
task: [task-warning] skipped
m@linux:~/Workspaces/go/task/testdata/warn$ task task-warning
task: [task-warning] display this warning. Proceed [y/N]? y
task: [task-warning] echo 'display this'
display this
m@linux:~/Workspaces/go/task/testdata/warn
```
