### PR TITLE
Fix handling of CLI_ARGS

### DIFF
--- a/completion/bash/task.bash
+++ b/completion/bash/task.bash
@@ -7,6 +7,18 @@ function _task()
   local cur prev words cword
   _init_completion -n : || return
 
+  # Check for `--` within command-line and quit or strip suffix.
+  local i
+  for i in "${!words[@]}"; do
+    if [ "${words[$i]}" == "--" ]; then
+      # Do not complete words following `--` passed to CLI_ARGS.
+      [ $cword -gt $i ] && return
+      # Remove the words following `--` to not put --list in CLI_ARGS.
+      words=( "${words[@]:0:$i}" )
+      break
+    fi
+  done
+
   # Handle special arguments of options.
   case "$prev" in
     -d|--dir)
@@ -33,7 +45,7 @@ function _task()
   esac
 
   # Prepare task name completions.
-  local tasks=( $( "${COMP_WORDS[@]}" --silent $_GO_TASK_COMPLETION_LIST_OPTION 2> /dev/null ) )
+  local tasks=( $( "${words[@]}" --silent $_GO_TASK_COMPLETION_LIST_OPTION 2> /dev/null ) )
   COMPREPLY=( $( compgen -W "${tasks[*]}" -- "$cur" ) )
 
   # Post-process because task names might contain colons.


### PR DESCRIPTION
Improvements:

1. Do not attempt to propose completions if the current position is behind `--` as the arguments would go to task's `CLI_ARGS` variable.
2. Only use the command-line before `--` when proposing task names to prevent the list option from going to task's `CLI_ARGS` variable.
