### PR TITLE
fix: ignore empty dotfile file names

### DIFF
--- a/taskfile/read/dotenv.go
+++ b/taskfile/read/dotenv.go
@@ -27,6 +27,9 @@ func Dotenv(c compiler.Compiler, tf *taskfile.Taskfile, dir string) (*taskfile.V
 
 	for _, dotEnvPath := range tf.Dotenv {
 		dotEnvPath = tr.Replace(dotEnvPath)
+		if dotEnvPath == "" {
+			continue
+		}
 		dotEnvPath = filepathext.SmartJoin(dir, dotEnvPath)
 
 		if _, err := os.Stat(dotEnvPath); os.IsNotExist(err) {


### PR DESCRIPTION
This PR fixes #858 - A bug (introduced in f45dd11) that causes an "is a directory" error when a taskfile contains a `dotfiles` key with unresolved variable.

The bug exists because the new `e.setCurrentDir()` function is setting `e.Dir` to the taskfile's root directory where it was previously `""`. When this variable was empty and the given dotfile was also empty, `os.Stat` would have returned an `os.ErrNotExist` and the loop would have `continued`. However, now that `e.Dir` is set to the taskfile directory, this `os.Stat()` check passes (as the directory exists) and the `godotenv.Read()` function errors causing the program to fail.

This fix simply checks if each value in the list of `dotfiles` is empty (not set) and `continues` if it is. This allows users to continue using the behaviour described in #858 where they could conditionally set environment variables via the `dotfiles` key.