### PR TITLE
Add package.json to allow users to install Task using npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ tags
 !/bin/.keep
 /testdata/vars/v1
 /tmp
+node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `npm` as new installation method: `npm i -g @go-task/cli`
+  ([#870](https://github.com/go-task/task/issues/870), [#871](https://github.com/go-task/task/pull/871), [npm package](https://www.npmjs.com/package/@go-task/cli)).
 - Add support to marking tasks and includes as internal, which will hide them
   from `--list` and `--list-all`
   ([#818](https://github.com/go-task/task/pull/818)).

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -93,6 +93,11 @@ tasks:
       - 'echo "" >> {{.FILE}}'
       - 'cat CHANGELOG.md >> {{.FILE}}'
 
+  npm:publish:
+    desc: Publish release to npm
+    cmds:
+      - npm publish --access=public
+
   packages:
     cmds:
       - echo '{{.GO_PACKAGES}}'

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -71,7 +71,7 @@ the source code instead of downloading the binary from the
 yay -S go-task
 ```
 
-This installation method is community owned. 
+This installation method is community owned.
 
 ### Fedora
 
@@ -96,6 +96,15 @@ nix-env -iA nixpkgs.go-task
 
 This installation method is community owned. After a new release of Task, it
 may take some time until it's available in [nixpkgs](https://github.com/NixOS/nixpkgs).
+
+### npm
+
+You can also use Node and npm to install Task by installing
+[this package](https://www.npmjs.com/package/@go-task/cli).
+
+```bash
+npm install -g @go-task/cli
+```
 
 ## Get The Binary
 

--- a/docs/docs/releasing.md
+++ b/docs/docs/releasing.md
@@ -19,15 +19,19 @@ defined in the above GitHub Actions.
 
 # Homebrew
 
-To release a new version on the [Homebrew tap][homebrewtap] edit the
-[Formula/go-task.rb][gotaskrb] file, updating with the new version, download
-URL and sha256.
+Goreleaser will automatically push a new commit to the
+[Formula/go-task.rb][gotaskrb] file in the [Homebrew tap][homebrewtap]
+repository to release the new version.
+
+# npm
+
+To release to npm update the version in the [`package.json`][packagejson] file
+and then run `task npm:publish` to push it.
 
 # Snapcraft
 
-The exception is the publishing of a new version of the
-[snap package][snappackage]. This current require two steps after publishing
-the binaries:
+The [snap package][snappackage] requires to manual steps to release a new
+version:
 
 * Updating the current version on [snapcraft.yaml][snapcraftyaml].
 * Moving both `amd64`, `armhf` and `arm64` new artifacts to the stable channel on
@@ -50,6 +54,7 @@ If you think its Task version is outdated, open an issue to let us know.
 [goreleaser]: https://goreleaser.com/
 [homebrewtap]: https://github.com/go-task/homebrew-tap
 [gotaskrb]: https://github.com/go-task/homebrew-tap/blob/master/Formula/go-task.rb
+[packagejson]: https://github.com/go-task/homebrew-tap/blob/master/package.json#3
 [snappackage]: https://github.com/go-task/snap
 [snapcraftyaml]: https://github.com/go-task/snap/blob/master/snap/snapcraft.yaml#L2
 [snapcraftdashboard]: https://snapcraft.io/task/releases

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "@go-task/cli",
+  "version": "3.15.2",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@go-task/cli",
+      "version": "3.15.2",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@go-task/go-npm": "^0.1.15"
+      }
+    },
+    "node_modules/@go-task/go-npm": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@go-task/go-npm/-/go-npm-0.1.15.tgz",
+      "integrity": "sha512-xG+6SsSQsa6MzWML1CABWHTwHrCrBqXc/D1POoMDGIgjsRE/PB1noSBGLFhvU5DWHdPksqbAt/w9VOjbqlXpYw==",
+      "bin": {
+        "go-npm": "bin/index.js"
+      }
+    }
+  },
+  "dependencies": {
+    "@go-task/go-npm": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@go-task/go-npm/-/go-npm-0.1.15.tgz",
+      "integrity": "sha512-xG+6SsSQsa6MzWML1CABWHTwHrCrBqXc/D1POoMDGIgjsRE/PB1noSBGLFhvU5DWHdPksqbAt/w9VOjbqlXpYw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@go-task/cli",
+  "version": "3.15.2",
+  "description": "A task runner / simpler Make alternative written in Go",
+  "scripts": {
+    "postinstall": "go-npm install",
+    "preuninstall": "go-npm uninstall"
+  },
+  "goBinary": {
+    "name": "task",
+    "path": "./bin",
+    "url": "https://github.com/go-task/task/releases/download/v{{version}}/task_{{platform}}_{{arch}}{{archive_ext}}"
+  },
+  "files": [],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/go-task/task.git"
+  },
+  "keywords": [
+    "task",
+    "taskfile",
+    "build-tool",
+    "task-runner"
+  ],
+  "author": "Andrey Nering",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/go-task/task/issues"
+  },
+  "homepage": "https://taskfile.dev",
+  "dependencies": {
+    "@go-task/go-npm": "^0.1.15"
+  }
+}


### PR DESCRIPTION
Closes #870

TODO:

- [ ] ~Wait for this PR to be merged and released: https://github.com/gzuidhof/go-npm/pull/5~
- [ ] ~Bump `@gzuidhof/go-npm` version in `package.json` -> `dependencies`~

We're using our own fork, at least for now: https://github.com/go-task/go-npm.

Package published at: https://www.npmjs.com/package/@go-task/cli.