### PR TITLE
Colorize --list, --list-all and --summary output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add colored output to `--list`, `--list-all` and `--summary` flags ([#845](https://github.com/go-task/task/pull/845), [#874](https://github.com/go-task/task/pull/874)).
 - Fix unexpected behavior where `label:` was being shown instead of the task
   name on `--list`
   ([#603](https://github.com/go-task/task/issues/603), [#877](https://github.com/go-task/task/pull/877)).

--- a/help.go
+++ b/help.go
@@ -42,9 +42,12 @@ func (e *Executor) printTasks(listAll bool) {
 	e.Logger.Outf(logger.Default, "task: Available tasks for this project:")
 
 	// Format in tab-separated columns with a tab stop of 8.
-	w := tabwriter.NewWriter(e.Stdout, 0, 8, 0, '\t', 0)
+	w := tabwriter.NewWriter(e.Stdout, 0, 8, 6, ' ', 0)
 	for _, task := range tasks {
-		fmt.Fprintf(w, "* %s: \t%s\n", task.Task, task.Desc)
+		e.Logger.FOutf(w, logger.Yellow, "* ")
+		e.Logger.FOutf(w, logger.Green, task.Task)
+		e.Logger.FOutf(w, logger.Default, ": \t%s", task.Desc)
+		fmt.Fprint(w, "\n")
 	}
 	w.Flush()
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -53,6 +53,11 @@ type Logger struct {
 
 // Outf prints stuff to STDOUT.
 func (l *Logger) Outf(color Color, s string, args ...interface{}) {
+	l.FOutf(l.Stdout, color, s+"\n", args...)
+}
+
+// FOutf prints stuff to the given writer.
+func (l *Logger) FOutf(w io.Writer, color Color, s string, args ...interface{}) {
 	if len(args) == 0 {
 		s, args = "%s", []interface{}{s}
 	}
@@ -60,7 +65,7 @@ func (l *Logger) Outf(color Color, s string, args ...interface{}) {
 		color = Default
 	}
 	print := color()
-	print(l.Stdout, s+"\n", args...)
+	print(w, s, args...)
 }
 
 // VerboseOutf prints stuff to STDOUT if verbose mode is enabled.

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -56,7 +56,8 @@ func printTaskSummary(l *logger.Logger, t *taskfile.Task) {
 }
 
 func printTaskName(l *logger.Logger, t *taskfile.Task) {
-	l.Outf(logger.Default, "task: %s", t.Name())
+	l.FOutf(l.Stdout, logger.Default, "task: ")
+	l.FOutf(l.Stdout, logger.Green, "%s\n", t.Name())
 	l.Outf(logger.Default, "")
 }
 
@@ -94,10 +95,11 @@ func printTaskCommands(l *logger.Logger, t *taskfile.Task) {
 	l.Outf(logger.Default, "commands:")
 	for _, c := range t.Cmds {
 		isCommand := c.Cmd != ""
+		l.FOutf(l.Stdout, logger.Default, " - ")
 		if isCommand {
-			l.Outf(logger.Default, " - %s", c.Cmd)
+			l.FOutf(l.Stdout, logger.Yellow, "%s\n", c.Cmd)
 		} else {
-			l.Outf(logger.Default, " - Task: %s", c.Task)
+			l.FOutf(l.Stdout, logger.Green, "Task: %s\n", c.Task)
 		}
 	}
 }


### PR DESCRIPTION
@andreynering @orenmazor This seemed like low-hanging fruit, so I've done a quick first draft (see the [associated branch](https://github.com/go-task/task/tree/845-colorize-output) and screenshots:

`task --list-all`:

![image](https://user-images.githubusercontent.com/9294862/193102831-d80dc4ef-fa6a-4fd0-9eee-f3dd6febf191.png)

`task foo --summary`:

![image](https://user-images.githubusercontent.com/9294862/193432585-438d1fa0-4050-4b27-a0b9-6420d4a70a40.png)

Let me know what you think of the colours - I'm happy to change them. I went with: 
- `green` for tasks as this matches the green when running a task
- `cyan` for descriptions as it complements the green (and the Task logo)
- `yellow` for commands

Could we do something more interesting with namespaces? Each layer of the namespace be a different colour? This might be too noisy... Or maybe just a different colour for the colons?

---

Sidenote: I noticed that `logger.Outf` automatically adds a `\n` to the input string. I'm not a fan of this behaviour as it gives less control to the caller. The new `logger.FOutf` function does not do this to mimic the behaviour of the standard `fmt.Printf` functions and this allows me to use multiple colours on the same line.

I've left the existing `logger.Outf` functionality as-is for now, but I think we should consider changing this in the future.