### PR TITLE
feat: optional task filtering with `task -l=foo`

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -57,7 +57,7 @@ func main() {
 		versionFlag bool
 		helpFlag    bool
 		init        bool
-		list        bool
+		list        string
 		listAll     bool
 		status      bool
 		force       bool
@@ -79,7 +79,7 @@ func main() {
 	pflag.BoolVar(&versionFlag, "version", false, "show Task version")
 	pflag.BoolVarP(&helpFlag, "help", "h", false, "shows Task usage")
 	pflag.BoolVarP(&init, "init", "i", false, "creates a new Taskfile.yaml in the current folder")
-	pflag.BoolVarP(&list, "list", "l", false, "lists tasks with description of current Taskfile")
+	pflag.StringVarP(&list, "list", "l", "", "lists tasks with description of current Taskfile. optionally accepts an regex argument to filter tasks")
 	pflag.BoolVarP(&listAll, "list-all", "a", false, "lists tasks with or without a description")
 	pflag.BoolVar(&status, "status", false, "exits with non-zero exit code if any of the given tasks is not up-to-date")
 	pflag.BoolVarP(&force, "force", "f", false, "forces execution even when the task is up-to-date")
@@ -98,6 +98,7 @@ func main() {
 	pflag.BoolVarP(&color, "color", "c", true, "colored output. Enabled by default. Set flag to false or use NO_COLOR=1 to disable")
 	pflag.IntVarP(&concurrency, "concurrency", "C", 0, "limit number tasks to run concurrently")
 	pflag.StringVarP(&interval, "interval", "I", "5s", "interval to watch for changes")
+	pflag.Lookup("list").NoOptDefVal = ".*"
 	pflag.Parse()
 
 	if versionFlag {
@@ -153,6 +154,7 @@ func main() {
 		Parallel:    parallel,
 		Color:       color,
 		Concurrency: concurrency,
+		ListFilter:  list,
 		Interval:    interval,
 
 		Stdin:  os.Stdin,
@@ -162,7 +164,7 @@ func main() {
 		OutputStyle: output,
 	}
 
-	if (list || listAll) && silent {
+	if (list != "" || listAll) && silent {
 		e.ListTaskNames(listAll)
 		return
 	}
@@ -176,7 +178,7 @@ func main() {
 		return
 	}
 
-	if list {
+	if list != "" {
 		e.ListTasksWithDesc()
 		return
 	}

--- a/task.go
+++ b/task.go
@@ -43,6 +43,7 @@ type Executor struct {
 	Parallel    bool
 	Color       bool
 	Concurrency int
+	ListFilter  string
 	Interval    string
 
 	Stdin  io.Reader

--- a/task_test.go
+++ b/task_test.go
@@ -661,6 +661,45 @@ func TestListCanListDescOnly(t *testing.T) {
 	}
 }
 
+// task -l=foo case 1: tasks can be filtered by name
+func TestListCanFilterList(t *testing.T) {
+	const dir = "testdata/list_desc"
+
+	var buff bytes.Buffer
+	e := task.Executor{
+		Dir:        dir,
+		Stdout:     &buff,
+		Stderr:     &buff,
+		ListFilter: "foo",
+	}
+
+	assert.NoError(t, e.Setup())
+	e.ListTasksWithDesc()
+
+	assert.Contains(t, buff.String(), "foo")
+	assert.NotContains(t, buff.String(), "bar")
+}
+
+// task -l=foo --silent: tasks are filtered with silent
+func TestListCanFilterListWithSilent(t *testing.T) {
+	const dir = "testdata/list_desc"
+
+	var buff bytes.Buffer
+	e := task.Executor{
+		Dir:        dir,
+		Stdout:     &buff,
+		Stderr:     &buff,
+		ListFilter: "foo",
+		Silent:     true,
+	}
+
+	assert.NoError(t, e.Setup())
+	e.ListTaskNames(false)
+
+	assert.Contains(t, buff.String(), "foo")
+	assert.NotContains(t, buff.String(), "bar")
+}
+
 func TestStatusVariables(t *testing.T) {
 	const dir = "testdata/status_vars"
 

--- a/testdata/list_desc/Taskfile.yml
+++ b/testdata/list_desc/Taskfile.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+tasks:
+  foo:
+    desc: "foo has desc, no label"
+
+  bar:
+    desc: "bar has desc, no label"


### PR DESCRIPTION
adds optional filtering for the `--list` argument to only display tasks that match a supplied regex.

to demonstrate,
```
➜ task -l=test
task: Available tasks for this project:
* test: 	Runs test suite
* test-release: Tests release process without publishing
* test:signals: Runs test suite with signals tests included
```

if you omit the argument to -l/--list, you get the existing behavior,
```
➜ task -l | wc -l
      17
```

for some context around why this is useful for me, at [Optic](https://useoptic.com) we're using Task to manage our internal monorepo. we have quite a few different services and tools and lean heavily on included Taskfiles. we wind up with lots of tasks like, `foo:build`, `foo:deploy`, `bar:build`, etc. long story short, you could say we've got a few tasks,

```
➜ task -l | wc -l
     107
```

shell completions make it somewhat manageable for us to discover and find the tasks we're after, but frequently we wind up running `task -l | grep foo` to view a subset of the output. piping to grep isn't really a problem, but I like not having to do it :) 