### PR TITLE
global variables, as well as task level variable can now be exported, (closes #181)

### DIFF
--- a/task.go
+++ b/task.go
@@ -65,6 +65,25 @@ func (e *Executor) Run(ctx context.Context, calls ...taskfile.Call) error {
 	// check if given tasks exist
 	for _, c := range calls {
 		t, ok := e.Taskfile.Tasks[c.Task]
+
+		if e.Taskfile.ExportVars && e.Taskfile.Vars != nil {
+			for k, v := range e.Taskfile.Vars.Mapping {
+				if t.Env == nil {
+					t.Env = &taskfile.Vars{}
+				}
+				t.Env.Set(k, v)
+			}
+		}
+
+		if (e.Taskfile.ExportVars || t.ExportVars) && t.Vars != nil {
+			for k, v := range t.Vars.Mapping {
+				if t.Env == nil {
+					t.Env = &taskfile.Vars{}
+				}
+				t.Env.Set(k, v)
+			}
+		}
+
 		if !ok {
 			// FIXME: move to the main package
 			e.ListTasksWithDesc()

--- a/task.go
+++ b/task.go
@@ -66,21 +66,23 @@ func (e *Executor) Run(ctx context.Context, calls ...taskfile.Call) error {
 	for _, c := range calls {
 		t, ok := e.Taskfile.Tasks[c.Task]
 
-		if e.Taskfile.ExportVars && e.Taskfile.Vars != nil {
-			for k, v := range e.Taskfile.Vars.Mapping {
-				if t.Env == nil {
-					t.Env = &taskfile.Vars{}
+		if t != nil {
+			if e.Taskfile.ExportVars && e.Taskfile.Vars != nil {
+				for k, v := range e.Taskfile.Vars.Mapping {
+					if t.Env == nil {
+						t.Env = &taskfile.Vars{}
+					}
+					t.Env.Set(k, v)
 				}
-				t.Env.Set(k, v)
 			}
-		}
 
-		if (e.Taskfile.ExportVars || t.ExportVars) && t.Vars != nil {
-			for k, v := range t.Vars.Mapping {
-				if t.Env == nil {
-					t.Env = &taskfile.Vars{}
+			if (e.Taskfile.ExportVars || t.ExportVars) && t.Vars != nil {
+				for k, v := range t.Vars.Mapping {
+					if t.Env == nil {
+						t.Env = &taskfile.Vars{}
+					}
+					t.Env.Set(k, v)
 				}
-				t.Env.Set(k, v)
 			}
 		}
 

--- a/taskfile/task.go
+++ b/taskfile/task.go
@@ -28,6 +28,7 @@ type Task struct {
 	IncludeVars          *Vars
 	IncludedTaskfileVars *Vars
 	IncludedTaskfile     *IncludedTaskfile
+	ExportVars           bool
 }
 
 func (t *Task) Name() string {
@@ -70,6 +71,7 @@ func (t *Task) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		Prefix        string
 		IgnoreError   bool `yaml:"ignore_error"`
 		Run           string
+		ExportVars		bool `yaml:"exportVars"`
 	}
 	if err := unmarshal(&task); err != nil {
 		return err
@@ -93,5 +95,6 @@ func (t *Task) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	t.Prefix = task.Prefix
 	t.IgnoreError = task.IgnoreError
 	t.Run = task.Run
+	t.ExportVars = task.ExportVars
 	return nil
 }

--- a/taskfile/taskfile.go
+++ b/taskfile/taskfile.go
@@ -18,6 +18,7 @@ type Taskfile struct {
 	Silent     bool
 	Dotenv     []string
 	Run        string
+	ExportVars bool
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler interface
@@ -34,6 +35,7 @@ func (tf *Taskfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		Silent     bool
 		Dotenv     []string
 		Run        string
+		ExportVars bool `yaml:"exportVars"`
 	}
 	if err := unmarshal(&taskfile); err != nil {
 		return err
@@ -49,6 +51,7 @@ func (tf *Taskfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	tf.Silent = taskfile.Silent
 	tf.Dotenv = taskfile.Dotenv
 	tf.Run = taskfile.Run
+	tf.ExportVars = taskfile.ExportVars
 	if tf.Expansions <= 0 {
 		tf.Expansions = 2
 	}


### PR DESCRIPTION
I have added the ability to export task vars into Env for the subsequent commands. I needed this feature, while building kubernetes operators with make, as it expects values from Env

It works like this
![screenshot-14316](https://user-images.githubusercontent.com/22402557/194385718-defed25f-9fd8-4e49-ab00-e1f3173be4a0.png)

- export global variables and task variables to all tasks, by setting `exportVars: true` globally
- export only task variables, by setting `exportVars: true` on individual task