### PR TITLE
refactor: implement task list filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Tasks in the root Taskfile will now be displayed first in `--list`/`--list-all`
+  output ([#806](https://github.com/go-task/task/pull/806), [#890](https://github.com/go-task/task/pull/890)).
 - It's now possible to call a `default` task in an included Taskfile by using
   just the namespace. For example: `docs:default` is now automatically
   aliased to `docs`

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -177,12 +177,16 @@ func main() {
 	}
 
 	if list {
-		e.ListTasksWithDesc()
+		if ok := e.ListTasks(task.FilterOutInternal(), task.FilterOutNoDesc()); !ok {
+			e.Logger.Outf(logger.Yellow, "task: No tasks with description available. Try --list-all to list all tasks")
+		}
 		return
 	}
 
 	if listAll {
-		e.ListAllTasks()
+		if ok := e.ListTasks(task.FilterOutInternal()); !ok {
+			e.Logger.Outf(logger.Yellow, "task: No tasks available")
+		}
 		return
 	}
 

--- a/task_test.go
+++ b/task_test.go
@@ -497,9 +497,6 @@ func TestAlias(t *testing.T) {
 func TestDuplicateAlias(t *testing.T) {
 	const dir = "testdata/alias"
 
-	data, err := os.ReadFile(filepathext.SmartJoin(dir, "alias-duplicate.txt"))
-	assert.NoError(t, err)
-
 	var buff bytes.Buffer
 	e := task.Executor{
 		Dir:    dir,
@@ -508,7 +505,7 @@ func TestDuplicateAlias(t *testing.T) {
 	}
 	assert.NoError(t, e.Setup())
 	assert.Error(t, e.Run(context.Background(), taskfile.Call{Task: "x"}))
-	assert.Equal(t, string(data), buff.String())
+	assert.Equal(t, "", buff.String())
 }
 
 func TestAliasSummary(t *testing.T) {
@@ -609,7 +606,7 @@ func TestNoLabelInList(t *testing.T) {
 		Stderr: &buff,
 	}
 	assert.NoError(t, e.Setup())
-	e.ListTasksWithDesc()
+	e.ListTasks(task.FilterOutInternal(), task.FilterOutNoDesc())
 	assert.Contains(t, buff.String(), "foo")
 }
 
@@ -627,7 +624,7 @@ func TestListAllShowsNoDesc(t *testing.T) {
 	assert.NoError(t, e.Setup())
 
 	var title string
-	e.ListAllTasks()
+	e.ListTasks(task.FilterOutInternal())
 	for _, title = range []string{
 		"foo",
 		"voo",
@@ -649,7 +646,7 @@ func TestListCanListDescOnly(t *testing.T) {
 	}
 
 	assert.NoError(t, e.Setup())
-	e.ListTasksWithDesc()
+	e.ListTasks(task.FilterOutInternal(), task.FilterOutNoDesc())
 
 	var title string
 	assert.Contains(t, buff.String(), "foo")
@@ -1037,12 +1034,7 @@ func TestIncludesInternal(t *testing.T) {
 	}{
 		{"included internal task via task", "task-1", false, "Hello, World!\n"},
 		{"included internal task via dep", "task-2", false, "Hello, World!\n"},
-		{
-			"included internal direct",
-			"included:task-3",
-			true,
-			"task: No tasks with description available. Try --list-all to list all tasks\n",
-		},
+		{"included internal direct", "included:task-3", true, ""},
 	}
 
 	for _, test := range tests {
@@ -1077,12 +1069,7 @@ func TestInternalTask(t *testing.T) {
 	}{
 		{"internal task via task", "task-1", false, "Hello, World!\n"},
 		{"internal task via dep", "task-2", false, "Hello, World!\n"},
-		{
-			"internal direct",
-			"task-3",
-			true,
-			"task: No tasks with description available. Try --list-all to list all tasks\n",
-		},
+		{"internal direct", "task-3", true, ""},
 	}
 
 	for _, test := range tests {

--- a/testdata/alias/alias-duplicate.txt
+++ b/testdata/alias/alias-duplicate.txt
@@ -1,1 +1,0 @@
-task: No tasks with description available. Try --list-all to list all tasks


### PR DESCRIPTION
This PR refactors the code used to fetch the list of tasks when outputting them to the CLI. This is used for the `--list` and `--list-all` flags as well as when any errors are displayed to the user.

## Why?

This code has a lot of duplication in it and isn't very extensible. i.e. it requires a lot of custom code and bloat to add new features.

## Shiny things

I've added a `GetTaskList` function to the executor (this nicely matches the new `GetTask` function in #879). This function will return a sorted list of tasks from the task map and filter any tasks according to the list of given filters. These filters can be any function that matches the new `FilterFunc` type. 

I have implemented the two filter functions that are currently required in the codebase: 

- `FilterNoDesc` - Removes tasks with no description
- `FilterInternal` - Removes tasks that are marked as internal

To add a new filter, all you'd need to do is create a function that takes a single task, decides if it should be filtered or not and return true/false accordingly. This function should then be wrapped with the `Filter` helper function which does all the actual filtering for you.

Note: The `Filter` function uses an in-place, zero-allocation method for filtering. This is much more efficient than creating a new slice for each filter and using `append` many times. See [this StackOverflow post](https://stackoverflow.com/a/20551116/1599633) for details.

## Sorting

This PR also happens to fix #806. The duplication of the task list sorting was what led me down this path in the first place. The sort function has been replaced with something that will put tasks without a `:` first.

It's worth noting that #806 requested that the tasks in the root Taskfile get sorted at the top of the list. This will not necessarily happen as if you create a task called `foo:bar` in your root Taskfile, it will see it as a namespace. However, I think this behaviour is fine (good, even).

## Other

Worth noting that the error handling for there being no tasks has moved from `help.go` into the `cmd/task.go` file. This is because functions aren't comparable and therefore `ListTasks` can't check if the `FilterNoDesc` function was given or not and decide which error to show.

This has the knock-on effect that the `task: No tasks with description available. Try --list-all to list all tasks` error message will no longer display when an error occurs and there are no tasks with descriptions. I personally don't mind this as it felt like a side-effect anyway, but I wanted to gather thoughts from others.