### PR TITLE
Update prefixed output to use the label, not name (if set)

### DIFF
--- a/task.go
+++ b/task.go
@@ -254,7 +254,7 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 		if err != nil {
 			return fmt.Errorf("task: failed to get variables: %w", err)
 		}
-		stdOut, stdErr, close := outputWrapper.WrapWriter(e.Stdout, e.Stderr, t.Prefix, outputTemplater)
+		stdOut, stdErr, close := outputWrapper.WrapWriter(e.Stdout, e.Stderr, t.Name(), outputTemplater)
 		defer func() {
 			if err := close(); err != nil {
 				e.Logger.Errf(logger.Red, "task: unable to close writter: %v", err)

--- a/task_test.go
+++ b/task_test.go
@@ -481,13 +481,19 @@ func TestLabelUpToDate(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
+		Dir:         dir,
+		Stdout:      &buff,
+		Stderr:      &buff,
+		OutputStyle: taskfile.Output{Name: "prefixed"},
 	}
 	assert.NoError(t, e.Setup())
 	assert.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "foo"}))
-	assert.Contains(t, buff.String(), "foobar")
+	assert.Contains(t, buff.String(), "task: [foobar] echo")
+	assert.Contains(t, buff.String(), "[foobar] I'm ok")
+	assert.NotContains(t, buff.String(), "[foo] I'm ok")
+	assert.Contains(t, buff.String(), "task: [bar] echo")
+	assert.Contains(t, buff.String(), "[bar] I'm good")
+	assert.NotContains(t, buff.String(), "[foobar] I'm good")
 }
 
 func TestLabelSummary(t *testing.T) {

--- a/testdata/label_uptodate/Taskfile.yml
+++ b/testdata/label_uptodate/Taskfile.yml
@@ -3,5 +3,9 @@ version: '3'
 tasks:
   foo:
     label: "foobar"
-    status:
+    cmds:
       - echo "I'm ok"
+      - task: bar
+  bar:
+    cmds:
+      - echo "I'm good"


### PR DESCRIPTION
Although the `--list` and `task: ...` output from `task` use the `label:` argument for the task itself (if present), the prefixed output from each of the `cmds` uses the original name of the task rather than the label. As such, when running multiple tasks (especially in parallel) it can be challenging to know which version of the task the output belongs to.

This change allows the prefixed output to use the task's `label:` argument instead if it's been provided.