### PR TITLE
Ignore fleet configuration directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ dist/
 # editors
 .idea/
 .vscode/
+.fleet/
 
 # exuberant ctags
 tags


### PR DESCRIPTION
Now that [Fleet is in open preview](https://blog.jetbrains.com/fleet/2022/10/introducing-the-fleet-public-preview/), just pre-empting the inevitable and adding the fleet config directory to the `.gitignore`.

Sidenote: To anyone who hasn't tried it, I recommend giving it a go. I'm a long time VSCode user (and I'm not the biggest fan of JetBrain's IDEs for Golang development). However, this looks like a very strong start, despite lacking a lot of functionality today (plugins, split panes, auto-imports etc). Hopefully, with time, this will become a viable alternative to VSCode.