### PR TITLE
feat: add actions to auto label issues

### DIFF
--- a/.github/workflows/issue-awaiting-response.yml
+++ b/.github/workflows/issue-awaiting-response.yml
@@ -1,0 +1,42 @@
+name: issue awaiting response
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  issue-awaiting-response:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const issue = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const comments = await github.paginate(
+              github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              }
+            )
+            const labels = await github.paginate(
+              github.rest.issues.listLabelsOnIssue, {
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              }
+            )
+            if (labels.find(label => label.name === 'awaiting response')) {
+              if (comments[comments.length-1].user?.login === issue.data.user?.login) {
+                github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: 'awaiting response'
+                })
+              }
+            }

--- a/.github/workflows/issue-needs-triage.yml
+++ b/.github/workflows/issue-needs-triage.yml
@@ -1,0 +1,28 @@
+name: issue needs triage
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  needs-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const labels = await github.paginate(
+              github.rest.issues.listLabelsOnIssue, {
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              }
+            )
+            if (labels.length === 0) {
+              github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['needs triage']
+              })
+            }


### PR DESCRIPTION
This is a first attempt to take some of the burden off managing issues/labels with a bit of automation. This PR adds 2 simple workflows:

- `issue-needs-triage` - Adds a `needs-triage` label to new issues so that we can track issues that haven't been reviewed/labelled by a maintainer yet.
- `issue-awaiting-response` - Will automatically remove the `awaiting response` label when the issue author responds.

Screenshot below from my private test repo

![image](https://user-images.githubusercontent.com/9294862/196000399-2103469c-1046-4095-a58b-3d18d320ca62.png)
