### PR TITLE
make powershell completion works to fill task name

### DIFF
--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -1,10 +1,8 @@
 $scriptBlock = {
-	param($commandName, $wordToComplete, $cursorPosition)
-	$curReg = "task{.exe}? (.*?)$"
-	$startsWith = $wordToComplete | Select-String $curReg -AllMatches | ForEach-Object { $_.Matches.Groups[1].Value }
-	$reg = "\* ($startsWith.+?):"
+	param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters )
+	$reg = "\* ($commandName.+?):"
 	$listOutput = $(task --list-all)
 	$listOutput | Select-String $reg -AllMatches | ForEach-Object { $_.Matches.Groups[1].Value + " " }
 }
 
-Register-ArgumentCompleter -Native -CommandName task -ScriptBlock $scriptBlock
+Register-ArgumentCompleter -CommandName task -ScriptBlock $scriptBlock

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -2,7 +2,7 @@ $scriptBlock = {
 	param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters )
 	$reg = "\* ($commandName.+?):"
 	$listOutput = $(task --list-all)
-	$listOutput | Select-String $reg -AllMatches | ForEach-Object { $_.Matches.Groups[1].Value + " " }
+	$listOutput | Select-String $reg -AllMatches | ForEach-Object { $_.Matches.Groups[1].Value }
 }
 
 Register-ArgumentCompleter -CommandName task -ScriptBlock $scriptBlock


### PR DESCRIPTION
this is a completion script only change, you can copy the powershell script to local to use it get merged and released

( `<tab>` is for <kbd>Tab</kbd> input)

## before:

```
❯❯ ~\..\..\task git:(master) task l<tab>
clean          docs           lint           npm            sleepit        test-release
default        install        mod            packages       test
```


## after:

`task l<tab>` -> `task lint`


OR show prefix matches

```
❯❯ ~\..\..\task git:(master) task d<tab>
default   docs
```


as for `:` splited sub task


`task do<tab>` -> `task docs`

`task docs<tab>` -> `task docs:`

then

```
❯❯ ~\..\..\task git:(master) task docs:<tab>
docs:build       docs:changelog   docs:clean       docs:deploy      docs:setup       docs:start
```


and current output format of `--list-all` make it hard to support sub task like `docs:clean` or `bu ild`, so just make current script works and ignore these cases.