### PR TITLE
feat: include aliases in --list --silent output

### DIFF
--- a/help.go
+++ b/help.go
@@ -102,6 +102,9 @@ func (e *Executor) ListTaskNames(allTasks bool) {
 	for _, t := range e.Taskfile.Tasks {
 		if (allTasks || t.Desc != "") && !t.Internal {
 			s = append(s, strings.TrimRight(t.Task, ":"))
+			for _, alias := range t.Aliases {
+				s = append(s, strings.TrimRight(alias, ":"))
+			}
 		}
 	}
 	// sort and print all task names


### PR DESCRIPTION
This PR adds aliases to the `--list`/`--list-all` flags when combined with `--silent`.

I wasn't 100% sure about this one, but I tried to tab-complete an aliased task today and it didn't work. Do we think that users should be able to tab complete aliased tasks or is this not needed because tab-completion will fill in the long name anyway? Thoughts appreciated.

![image](https://user-images.githubusercontent.com/9294862/199069561-77254bbd-4345-420f-8a7c-b683fad22b65.png)
