### PR TITLE
fix: log the checked files if verbose

### DIFF
--- a/internal/status/checksum.go
+++ b/internal/status/checksum.go
@@ -34,7 +34,7 @@ func (c *Checksum) IsUpToDate() (bool, error) {
 	data, _ := os.ReadFile(checksumFile)
 	oldMd5 := strings.TrimSpace(string(data))
 
-	sources, err := globs(c.TaskDir, c.Sources)
+	sources, err := Globs(c.TaskDir, c.Sources)
 	if err != nil {
 		return false, err
 	}

--- a/internal/status/glob.go
+++ b/internal/status/glob.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-task/task/v3/internal/filepathext"
 )
 
-func globs(dir string, globs []string) ([]string, error) {
+func Globs(dir string, globs []string) ([]string, error) {
 	files := make([]string, 0)
 	for _, g := range globs {
 		f, err := Glob(dir, g)

--- a/internal/status/timestamp.go
+++ b/internal/status/timestamp.go
@@ -19,11 +19,11 @@ func (t *Timestamp) IsUpToDate() (bool, error) {
 		return false, nil
 	}
 
-	sources, err := globs(t.Dir, t.Sources)
+	sources, err := Globs(t.Dir, t.Sources)
 	if err != nil {
 		return false, nil
 	}
-	generates, err := globs(t.Dir, t.Generates)
+	generates, err := Globs(t.Dir, t.Generates)
 	if err != nil {
 		return false, nil
 	}
@@ -47,7 +47,7 @@ func (t *Timestamp) Kind() string {
 
 // Value implements the Checker Interface
 func (t *Timestamp) Value() (interface{}, error) {
-	sources, err := globs(t.Dir, t.Sources)
+	sources, err := Globs(t.Dir, t.Sources)
 	if err != nil {
 		return time.Now(), err
 	}

--- a/status.go
+++ b/status.go
@@ -3,6 +3,7 @@ package task
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/logger"
@@ -48,6 +49,9 @@ func (e *Executor) isTaskUpToDate(ctx context.Context, t *taskfile.Task) (bool, 
 		if err != nil {
 			return false, err
 		}
+
+		logInputsGenerates(e, t)
+
 		isUpToDate, err := checker.IsUpToDate()
 		if err != nil {
 			return false, err
@@ -58,6 +62,20 @@ func (e *Executor) isTaskUpToDate(ctx context.Context, t *taskfile.Task) (bool, 
 	}
 
 	return true, nil
+}
+
+// print the sources and generates that are checked if verbose
+func logInputsGenerates(e *Executor, t *taskfile.Task) {
+	if e.Logger.Verbose {
+		sources, err := status.Globs(t.Dir, t.Sources)
+		if err == nil {
+			e.Logger.VerboseOutf(logger.Cyan, "task: sources: [\"%s\"]\n", strings.Join(sources, `", "`))
+		}
+		generates, err := status.Globs(t.Dir, t.Generates)
+		if err == nil {
+			e.Logger.VerboseOutf(logger.Cyan, "task: generates: [\"%s\"]\n", strings.Join(generates, `", "`))
+		}
+	}
 }
 
 func (e *Executor) statusOnError(t *taskfile.Task) error {


### PR DESCRIPTION
This adds a logging step to the function that checks if the inputs/generates are up to date. After hours of debugging, It helped me to finally detect that the globbing library that `task` uses [fails to check some patterns](https://github.com/mattn/go-zglob/issues/38#issuecomment-1302839605).

The following checks the files inside the `dev` folder
```
"{dev/**/*,something}"
```

But this doesn't!
```
"{something,dev/**/*}"
```

Or for example, `**` doesn't check all the files of the current project.

Performance-wise, this is not a good solution because it calls the glob outside the ` checker.IsUpToDate` function. I did this because that was the only way I could access the logger without changing the checker API. If you are OK with the API change, we can remove the duplicate glob calls.