### PR TITLE
BASH: Also complete with task aliases

### DIFF
--- a/completion/bash/task.bash
+++ b/completion/bash/task.bash
@@ -56,7 +56,7 @@ function _task()
   done < <( "${words[@]}" $_GO_TASK_COMPLETION_LIST_OPTION 2> /dev/null )
 
   # Prepare task name proposals.
-  COMPREPLY=( $( compgen -W "${tasks[*]}" -- "$cur" ) )
+  COMPREPLY=( $( compgen -W "${tasks[*]%,}" -- "$cur" ) )
 
   # Post-process proposals because task names might contain colons.
   __ltrim_colon_completions "$cur"


### PR DESCRIPTION
A minor update for the new alias feature as of task 3.17.0:
- Also propose task aliases next to task names.

Note: A better approach might be to include aliases in the output of `task --list --silent` on extra lines.
