### PR TITLE
feat: add --json flag to be used by editor extensions

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -184,8 +184,10 @@ func main() {
 	}
 
 	if listOptions.ShouldListTasks() {
-		_ = e.ListTasks(listOptions)
-		return // if we are listing tasks, we don't expect a task to run
+		if foundTasks, err := e.ListTasks(listOptions); !foundTasks || err != nil {
+			os.Exit(1)
+		}
+		return
 	}
 
 	var (

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -59,6 +59,7 @@ func main() {
 		init        bool
 		list        bool
 		listAll     bool
+		listJson    bool
 		status      bool
 		force       bool
 		watch       bool
@@ -81,6 +82,7 @@ func main() {
 	pflag.BoolVarP(&init, "init", "i", false, "creates a new Taskfile.yaml in the current folder")
 	pflag.BoolVarP(&list, "list", "l", false, "lists tasks with description of current Taskfile")
 	pflag.BoolVarP(&listAll, "list-all", "a", false, "lists tasks with or without a description")
+	pflag.BoolVarP(&listJson, "json", "j", false, "formats task list as json")
 	pflag.BoolVar(&status, "status", false, "exits with non-zero exit code if any of the given tasks is not up-to-date")
 	pflag.BoolVarP(&force, "force", "f", false, "forces execution even when the task is up-to-date")
 	pflag.BoolVarP(&watch, "watch", "w", false, "enables watch of the given task")
@@ -162,7 +164,12 @@ func main() {
 		OutputStyle: output,
 	}
 
-	if (list || listAll) && silent {
+	var listOptions = task.NewListOptions(list, listAll, listJson)
+	if err := listOptions.Validate(); err != nil {
+		log.Fatal(err)
+	}
+
+	if (listOptions.ShouldListTasks()) && silent {
 		e.ListTaskNames(listAll)
 		return
 	}
@@ -176,18 +183,9 @@ func main() {
 		return
 	}
 
-	if list {
-		if ok := e.ListTasks(task.FilterOutInternal(), task.FilterOutNoDesc()); !ok {
-			e.Logger.Outf(logger.Yellow, "task: No tasks with description available. Try --list-all to list all tasks")
-		}
-		return
-	}
-
-	if listAll {
-		if ok := e.ListTasks(task.FilterOutInternal()); !ok {
-			e.Logger.Outf(logger.Yellow, "task: No tasks available")
-		}
-		return
+	if listOptions.ShouldListTasks() {
+		_ = e.ListTasks(listOptions)
+		return // if we are listing tasks, we don't expect a task to run
 	}
 
 	var (

--- a/internal/editors/output.go
+++ b/internal/editors/output.go
@@ -9,17 +9,10 @@ type Output struct {
 
 // Task describes a single task
 type Task struct {
-	Name    string `json:"name"`
-	Desc    string `json:"desc"`
-	Summary string `json:"summary"`
-
-	// "up-to-date" vs. "out-of-date"? Alternatively could be a "UpToDate bool"
-	//Status string `json:"status"`
-	UpToDate bool `json:"up_to_date"`
-
-	//// These could be added on the future. Don't need to be on the MVP
-	//Env map[string]string `json:"env"`
-	//Vars map[string]string `json:"vars"`
+	Name     string `json:"name"`
+	Desc     string `json:"desc"`
+	Summary  string `json:"summary"`
+	UpToDate bool   `json:"up_to_date"`
 }
 
 func ToOutput(tasks []*taskfile.Task) *Output {

--- a/internal/editors/output.go
+++ b/internal/editors/output.go
@@ -1,7 +1,5 @@
 package editors
 
-import "github.com/go-task/task/v3/taskfile"
-
 // Output wraps task list output for use in editor integrations (e.g. VSCode, etc)
 type Output struct {
 	Tasks []Task `json:"tasks"`
@@ -13,19 +11,4 @@ type Task struct {
 	Desc     string `json:"desc"`
 	Summary  string `json:"summary"`
 	UpToDate bool   `json:"up_to_date"`
-}
-
-func ToOutput(tasks []*taskfile.Task) *Output {
-	o := &Output{
-		Tasks: make([]Task, len(tasks)),
-	}
-	for i, t := range tasks {
-		o.Tasks[i] = Task{
-			Name:     t.Name(),
-			Desc:     t.Desc,
-			Summary:  t.Summary,
-			UpToDate: false, // TODO
-		}
-	}
-	return o
 }

--- a/internal/editors/output.go
+++ b/internal/editors/output.go
@@ -1,0 +1,38 @@
+package editors
+
+import "github.com/go-task/task/v3/taskfile"
+
+// Output wraps task list output for use in editor integrations (e.g. VSCode, etc)
+type Output struct {
+	Tasks []Task `json:"tasks"`
+}
+
+// Task describes a single task
+type Task struct {
+	Name    string `json:"name"`
+	Desc    string `json:"desc"`
+	Summary string `json:"summary"`
+
+	// "up-to-date" vs. "out-of-date"? Alternatively could be a "UpToDate bool"
+	//Status string `json:"status"`
+	UpToDate bool `json:"up_to_date"`
+
+	//// These could be added on the future. Don't need to be on the MVP
+	//Env map[string]string `json:"env"`
+	//Vars map[string]string `json:"vars"`
+}
+
+func ToOutput(tasks []*taskfile.Task) *Output {
+	o := &Output{
+		Tasks: make([]Task, len(tasks)),
+	}
+	for i, t := range tasks {
+		o.Tasks[i] = Task{
+			Name:     t.Name(),
+			Desc:     t.Desc,
+			Summary:  t.Summary,
+			UpToDate: false, // TODO
+		}
+	}
+	return o
+}

--- a/task.go
+++ b/task.go
@@ -72,13 +72,11 @@ func (e *Executor) Run(ctx context.Context, calls ...taskfile.Call) error {
 	for _, call := range calls {
 		task, err := e.GetTask(call)
 		if err != nil {
-			e.ListTasks(FilterOutInternal(), FilterOutNoDesc())
-			return err
+			return fmt.Errorf("task: executor.Run(): executor.GetTask(): %v", err)
 		}
 
 		if task.Internal {
-			e.ListTasks(FilterOutInternal(), FilterOutNoDesc())
-			return &taskInternalError{taskName: call.Task}
+			return fmt.Errorf("task: executor.Run(): %v", &taskInternalError{taskName: call.Task})
 		}
 	}
 
@@ -396,7 +394,7 @@ func (e *Executor) GetTaskList(filters ...FilterFunc) []*taskfile.Task {
 		tasks = filter(tasks)
 	}
 
-	// Sort the tasks
+	// Sort the tasks.
 	// Tasks that are not namespaced should be listed before tasks that are.
 	// We detect this by searching for a ':' in the task name.
 	sort.Slice(tasks, func(i, j int) bool {

--- a/task.go
+++ b/task.go
@@ -72,11 +72,11 @@ func (e *Executor) Run(ctx context.Context, calls ...taskfile.Call) error {
 	for _, call := range calls {
 		task, err := e.GetTask(call)
 		if err != nil {
-			return fmt.Errorf("task: executor.Run(): executor.GetTask(): %v", err)
+			return err
 		}
 
 		if task.Internal {
-			return fmt.Errorf("task: executor.Run(): %v", &taskInternalError{taskName: call.Task})
+			return &taskInternalError{taskName: call.Task}
 		}
 	}
 

--- a/task_test.go
+++ b/task_test.go
@@ -606,7 +606,7 @@ func TestNoLabelInList(t *testing.T) {
 		Stderr: &buff,
 	}
 	assert.NoError(t, e.Setup())
-	e.ListTasks(task.FilterOutInternal(), task.FilterOutNoDesc())
+	e.ListTasks(task.ListOptions{ListOnlyTasksWithDescriptions: true})
 	assert.Contains(t, buff.String(), "foo")
 }
 
@@ -624,7 +624,7 @@ func TestListAllShowsNoDesc(t *testing.T) {
 	assert.NoError(t, e.Setup())
 
 	var title string
-	e.ListTasks(task.FilterOutInternal())
+	e.ListTasks(task.ListOptions{ListAllTasks: true})
 	for _, title = range []string{
 		"foo",
 		"voo",
@@ -646,7 +646,7 @@ func TestListCanListDescOnly(t *testing.T) {
 	}
 
 	assert.NoError(t, e.Setup())
-	e.ListTasks(task.FilterOutInternal(), task.FilterOutNoDesc())
+	e.ListTasks(task.ListOptions{ListOnlyTasksWithDescriptions: true})
 
 	var title string
 	assert.Contains(t, buff.String(), "foo")

--- a/task_test.go
+++ b/task_test.go
@@ -606,7 +606,9 @@ func TestNoLabelInList(t *testing.T) {
 		Stderr: &buff,
 	}
 	assert.NoError(t, e.Setup())
-	e.ListTasks(task.ListOptions{ListOnlyTasksWithDescriptions: true})
+	if _, err := e.ListTasks(task.ListOptions{ListOnlyTasksWithDescriptions: true}); err != nil {
+		t.Error(err)
+	}
 	assert.Contains(t, buff.String(), "foo")
 }
 
@@ -624,7 +626,9 @@ func TestListAllShowsNoDesc(t *testing.T) {
 	assert.NoError(t, e.Setup())
 
 	var title string
-	e.ListTasks(task.ListOptions{ListAllTasks: true})
+	if _, err := e.ListTasks(task.ListOptions{ListAllTasks: true}); err != nil {
+		t.Error(err)
+	}
 	for _, title = range []string{
 		"foo",
 		"voo",
@@ -646,7 +650,9 @@ func TestListCanListDescOnly(t *testing.T) {
 	}
 
 	assert.NoError(t, e.Setup())
-	e.ListTasks(task.ListOptions{ListOnlyTasksWithDescriptions: true})
+	if _, err := e.ListTasks(task.ListOptions{ListOnlyTasksWithDescriptions: true}); err != nil {
+		t.Error(err)
+	}
 
 	var title string
 	assert.Contains(t, buff.String(), "foo")


### PR DESCRIPTION
a new `--json` flag works only with the `--list` and `--list-all` flags to format those task lists as JSON output.

- can't use `--json` by itself:
```
go run ./cmd/task --taskfile ./testdata/output_group/Taskfile.yml hello --json | jq .
task: --json only applies to --list or --list-all
exit status 1
```
- `--json --list` ignores tasks that are missing descriptions:
```
go run ./cmd/task --taskfile ./testdata/output_group/Taskfile.yml hello --json --list | jq .
{
  "tasks": []
}
```
- `--json --list-all` includes all tasks
```
go run ./cmd/task --taskfile ./testdata/output_group/Taskfile.yml hello --json --list-all | jq .
{
  "tasks": [
    {
      "name": "bye",
      "desc": "",
      "summary": "",
      "up_to_date": false
    },
    {
      "name": "hello",
      "desc": "",
      "summary": "",
      "up_to_date": false
    }
  ]
}
```

this PR includes a temporary WIP (work in progress) commit with additional detail printed to the console around the three failing tests; this commit is intended to help illustrate what is happening when these tests expect that we print nothing to the console so that we can review and confirm that we want to fix the code to maintain that expectation or perhaps update the expectation to provide more detailed output to clients and users.

may resolve #764 