### PR TITLE
JetBrains JSON Schema Validator Error Workaround

### DIFF
--- a/docs/static/schema.json
+++ b/docs/static/schema.json
@@ -260,7 +260,7 @@
       }
     }
   },
-  "oneOf": [
+  "allOf": [
     {
       "type": "object",
       "properties": {


### PR DESCRIPTION
`schema.json` Workaround for these two JetBrains issues:

- [IDEA-236928 json schema: False positive "Schema validation: Validates to more than one variant" with "oneOf"](https://youtrack.jetbrains.com/issue/IDEA-236928)
- [IDEA-265710 JSON schema validation fails if anyOf is nested in oneOf](https://youtrack.jetbrains.com/issue/IDEA-265710)

There is no material effect on the actual schema validation, as the `oneOf`/`allOf` evaluates only one list entry.

`allOf([1])` is `1`, and `oneOf([1])` is also `1`.

Fixes #847