### PR TITLE
feat: add local-prefixes flag to goimports linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,3 +6,7 @@
 linters:
   enable:
     - goimports
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/go-task/task

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -6,11 +6,11 @@ import (
 	"io"
 	"testing"
 
-	"github.com/go-task/task/v3/internal/templater"
-	"github.com/go-task/task/v3/taskfile"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/go-task/task/v3/internal/output"
+	"github.com/go-task/task/v3/internal/templater"
+	"github.com/go-task/task/v3/taskfile"
 )
 
 func TestInterleaved(t *testing.T) {

--- a/watch.go
+++ b/watch.go
@@ -10,10 +10,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/radovskyb/watcher"
+
 	"github.com/go-task/task/v3/internal/logger"
 	"github.com/go-task/task/v3/internal/status"
 	"github.com/go-task/task/v3/taskfile"
-	"github.com/radovskyb/watcher"
 )
 
 const defaultWatchInterval = 5 * time.Second


### PR DESCRIPTION
I noticed that you added `goimports` as a linter. This change extends that by forcing users to separate internal imports (ones starting with `github.com/go-task/task`) from other non standard lib imports. This is a pattern followed elsewhere in the project, but not currently enforced.

VSCode users can add this to their settings to do this formatting automatically:

```jsonc
{
    "gopls": {
        "formatting.local": "github.com/go-task/task",
    }
    ...
}
```