### PR TITLE
feat: improve unmarshal error handling and use v3 yaml interface ever…

### DIFF
--- a/taskfile/output.go
+++ b/taskfile/output.go
@@ -2,6 +2,8 @@ package taskfile
 
 import (
 	"fmt"
+
+	"gopkg.in/yaml.v3"
 )
 
 // Output of the Task output
@@ -17,28 +19,35 @@ func (s *Output) IsSet() bool {
 	return s.Name != ""
 }
 
-// UnmarshalYAML implements yaml.Unmarshaler
-// It accepts a scalar node representing the Output.Name or a mapping node representing the OutputGroup.
-func (s *Output) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var name string
-	if err := unmarshal(&name); err == nil {
+func (s *Output) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+
+	case yaml.ScalarNode:
+		var name string
+		if err := node.Decode(&name); err != nil {
+			return err
+		}
 		s.Name = name
 		return nil
+
+	case yaml.MappingNode:
+		var tmp struct {
+			Group *OutputGroup
+		}
+		if err := node.Decode(&tmp); err != nil {
+			return fmt.Errorf("task: output style must be a string or mapping with a \"group\" key: %w", err)
+		}
+		if tmp.Group == nil {
+			return fmt.Errorf("task: output style must have the \"group\" key when in mapping form")
+		}
+		*s = Output{
+			Name:  "group",
+			Group: *tmp.Group,
+		}
+		return nil
 	}
-	var tmp struct {
-		Group *OutputGroup
-	}
-	if err := unmarshal(&tmp); err != nil {
-		return fmt.Errorf("task: output style must be a string or mapping with a \"group\" key: %w", err)
-	}
-	if tmp.Group == nil {
-		return fmt.Errorf("task: output style must have the \"group\" key when in mapping form")
-	}
-	*s = Output{
-		Name:  "group",
-		Group: *tmp.Group,
-	}
-	return nil
+
+	return fmt.Errorf("yaml: line %d: cannot unmarshal %s into output", node.Line, node.ShortTag())
 }
 
 // OutputGroup is the style options specific to the Group style.

--- a/taskfile/task.go
+++ b/taskfile/task.go
@@ -1,5 +1,11 @@
 package taskfile
 
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
 // Tasks represents a group of tasks
 type Tasks map[string]*Task
 
@@ -39,67 +45,80 @@ func (t *Task) Name() string {
 	return t.Task
 }
 
-func (t *Task) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var cmd Cmd
-	if err := unmarshal(&cmd); err == nil && cmd.Cmd != "" {
+func (t *Task) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+
+	// Shortcut syntax for a task with a single command
+	case yaml.ScalarNode:
+		var cmd Cmd
+		if err := node.Decode(&cmd); err != nil {
+			return err
+		}
 		t.Cmds = append(t.Cmds, &cmd)
 		return nil
-	}
 
-	var cmds []*Cmd
-	if err := unmarshal(&cmds); err == nil && len(cmds) > 0 {
+	// Shortcut syntax for a simple task with a list of commands
+	case yaml.SequenceNode:
+		var cmds []*Cmd
+		if err := node.Decode(&cmds); err != nil {
+			return err
+		}
 		t.Cmds = cmds
+		return nil
+
+	// Full task object
+	case yaml.MappingNode:
+		var task struct {
+			Cmds          []*Cmd
+			Deps          []*Dep
+			Label         string
+			Desc          string
+			Summary       string
+			Aliases       []string
+			Sources       []string
+			Generates     []string
+			Status        []string
+			Preconditions []*Precondition
+			Dir           string
+			Vars          *Vars
+			Env           *Vars
+			Dotenv        []string
+			Silent        bool
+			Interactive   bool
+			Internal      bool
+			Method        string
+			Prefix        string
+			IgnoreError   bool `yaml:"ignore_error"`
+			Run           string
+		}
+		if err := node.Decode(&task); err != nil {
+			return err
+		}
+		t.Cmds = task.Cmds
+		t.Deps = task.Deps
+		t.Label = task.Label
+		t.Desc = task.Desc
+		t.Summary = task.Summary
+		t.Aliases = task.Aliases
+		t.Sources = task.Sources
+		t.Generates = task.Generates
+		t.Status = task.Status
+		t.Preconditions = task.Preconditions
+		t.Dir = task.Dir
+		t.Vars = task.Vars
+		t.Env = task.Env
+		t.Dotenv = task.Dotenv
+		t.Silent = task.Silent
+		t.Interactive = task.Interactive
+		t.Internal = task.Internal
+		t.Method = task.Method
+		t.Prefix = task.Prefix
+		t.IgnoreError = task.IgnoreError
+		t.Run = task.Run
 		return nil
 	}
 
-	var task struct {
-		Cmds          []*Cmd
-		Deps          []*Dep
-		Label         string
-		Desc          string
-		Summary       string
-		Aliases       []string
-		Sources       []string
-		Generates     []string
-		Status        []string
-		Preconditions []*Precondition
-		Dir           string
-		Vars          *Vars
-		Env           *Vars
-		Dotenv        []string
-		Silent        bool
-		Interactive   bool
-		Internal      bool
-		Method        string
-		Prefix        string
-		IgnoreError   bool `yaml:"ignore_error"`
-		Run           string
-	}
-	if err := unmarshal(&task); err != nil {
-		return err
-	}
-	t.Cmds = task.Cmds
-	t.Deps = task.Deps
-	t.Label = task.Label
-	t.Desc = task.Desc
-	t.Aliases = task.Aliases
-	t.Summary = task.Summary
-	t.Sources = task.Sources
-	t.Generates = task.Generates
-	t.Status = task.Status
-	t.Preconditions = task.Preconditions
-	t.Dir = task.Dir
-	t.Vars = task.Vars
-	t.Env = task.Env
-	t.Dotenv = task.Dotenv
-	t.Silent = task.Silent
-	t.Interactive = task.Interactive
-	t.Internal = task.Internal
-	t.Method = task.Method
-	t.Prefix = task.Prefix
-	t.IgnoreError = task.IgnoreError
-	t.Run = task.Run
-	return nil
+	return fmt.Errorf("yaml: line %d: cannot unmarshal %s into task", node.Line, node.ShortTag())
 }
 
 // DeepCopy creates a new instance of Task and copies

--- a/taskfile/taskfile.go
+++ b/taskfile/taskfile.go
@@ -3,6 +3,8 @@ package taskfile
 import (
 	"fmt"
 	"strconv"
+
+	"gopkg.in/yaml.v3"
 )
 
 // Taskfile represents a Taskfile.yml
@@ -21,50 +23,52 @@ type Taskfile struct {
 	Interval   string
 }
 
-// UnmarshalYAML implements yaml.Unmarshaler interface
-func (tf *Taskfile) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var taskfile struct {
-		Version    string
-		Expansions int
-		Output     Output
-		Method     string
-		Includes   *IncludedTaskfiles
-		Vars       *Vars
-		Env        *Vars
-		Tasks      Tasks
-		Silent     bool
-		Dotenv     []string
-		Run        string
-		Interval   string
+func (tf *Taskfile) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+
+	case yaml.MappingNode:
+		var taskfile struct {
+			Version    string
+			Expansions int
+			Output     Output
+			Method     string
+			Includes   *IncludedTaskfiles
+			Vars       *Vars
+			Env        *Vars
+			Tasks      Tasks
+			Silent     bool
+			Dotenv     []string
+			Run        string
+			Interval   string
+		}
+		if err := node.Decode(&taskfile); err != nil {
+			return err
+		}
+		tf.Version = taskfile.Version
+		tf.Expansions = taskfile.Expansions
+		tf.Output = taskfile.Output
+		tf.Method = taskfile.Method
+		tf.Includes = taskfile.Includes
+		tf.Vars = taskfile.Vars
+		tf.Env = taskfile.Env
+		tf.Tasks = taskfile.Tasks
+		tf.Silent = taskfile.Silent
+		tf.Dotenv = taskfile.Dotenv
+		tf.Run = taskfile.Run
+		tf.Interval = taskfile.Interval
+		if tf.Expansions <= 0 {
+			tf.Expansions = 2
+		}
+		if tf.Vars == nil {
+			tf.Vars = &Vars{}
+		}
+		if tf.Env == nil {
+			tf.Env = &Vars{}
+		}
+		return nil
 	}
 
-	if err := unmarshal(&taskfile); err != nil {
-		return err
-	}
-
-	tf.Version = taskfile.Version
-	tf.Expansions = taskfile.Expansions
-	tf.Output = taskfile.Output
-	tf.Method = taskfile.Method
-	tf.Includes = taskfile.Includes
-	tf.Vars = taskfile.Vars
-	tf.Env = taskfile.Env
-	tf.Tasks = taskfile.Tasks
-	tf.Silent = taskfile.Silent
-	tf.Dotenv = taskfile.Dotenv
-	tf.Run = taskfile.Run
-	tf.Interval = taskfile.Interval
-
-	if tf.Expansions <= 0 {
-		tf.Expansions = 2
-	}
-	if tf.Vars == nil {
-		tf.Vars = &Vars{}
-	}
-	if tf.Env == nil {
-		tf.Env = &Vars{}
-	}
-	return nil
+	return fmt.Errorf("yaml: line %d: cannot unmarshal %s into taskfile", node.Line, node.ShortTag())
 }
 
 // ParsedVersion returns the version as a float64


### PR DESCRIPTION
Small changes to the Unmarshal functions to make them all use the newer v3 YAML interface. The flow of these functions has changed in a couple of places (e.g. `task.go`) since we can now tell the type of the `Node` ahead of unmarshalling. We can rely on error handling instead of having to check the state of the unmarshalled object.