### PR TITLE
Close Taskfile after reading it

### DIFF
--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -197,6 +197,7 @@ func readTaskfile(file string) (*taskfile.Taskfile, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 	var t taskfile.Taskfile
 	if err := yaml.NewDecoder(f).Decode(&t); err != nil {
 		return nil, fmt.Errorf("task: Failed to parse %s:\n%w", filepathext.TryAbsToRel(file), err)


### PR DESCRIPTION
Properly close `Taskfile.yml` after reading it.

This should fix issues preventing modifications to the Taskfile while tasks are still running, like switching git branches for example.

Fixes #963