### PR TITLE
feat: add action for when an issue is closed

### DIFF
--- a/.github/workflows/issue-awaiting-response.yml
+++ b/.github/workflows/issue-awaiting-response.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
       - uses: actions/github-script@v6
         with:
+          github-token: ${{secrets.GH_PAT}}
           script: |
             const issue = await github.rest.issues.get({
               owner: context.repo.owner,

--- a/.github/workflows/issue-closed.yml
+++ b/.github/workflows/issue-closed.yml
@@ -1,11 +1,11 @@
-name: issue needs triage
+name: issue closed
 
 on:
   issues:
-    types: [opened]
+    types: [closed]
 
 jobs:
-  issue-needs-triage:
+  issue-closed:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6
@@ -19,11 +19,11 @@ jobs:
                 repo: context.repo.repo,
               }
             )
-            if (labels.length === 0) {
-              github.rest.issues.addLabels({
-                issue_number: context.issue.number,
+            if (labels.find(label => label.name === 'needs triage')) {
+              github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                labels: ['needs triage']
+                issue_number: context.issue.number,
+                name: 'needs triage'
               })
             }


### PR DESCRIPTION
Small addition to the GitHub actions to tidy up `needs triage` labels if someone closes an issue before it is triaged.

Screenshot from my test repo below:

![image](https://user-images.githubusercontent.com/9294862/209398262-6ffeb225-aa9b-48a9-8e3b-48d8ddb74daa.png)

No change if issue has already had the `needs triage` label removed:

![image](https://user-images.githubusercontent.com/9294862/209398609-f02a81ae-2ddd-4263-a2b2-0cd055fefc4f.png)
