### PR TITLE
fix: watch interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Small bug fix: closing "Taskfile.yml" once we're done reading it
   ([#963](https://github.com/go-task/task/issues/963), [#964](https://github.com/go-task/task/pull/964) by @HeCorr).
+- Fixed a bug where watch intervals set in the Taskfile were not being respected ([#969](https://github.com/go-task/task/pull/969), [#970](https://github.com/go-task/task/pull/970) by @pd93)
 - Add `--json` flag (alias `-j`) with the intent to improve support for code
   editors and add room to other possible integrations. This is basic for now,
   but we plan to add more info in the near future

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/spf13/pflag"
 	"mvdan.cc/sh/v3/syntax"
@@ -74,7 +75,7 @@ func main() {
 		entrypoint  string
 		output      taskfile.Output
 		color       bool
-		interval    string
+		interval    time.Duration
 	)
 
 	pflag.BoolVar(&versionFlag, "version", false, "show Task version")
@@ -99,7 +100,7 @@ func main() {
 	pflag.StringVar(&output.Group.End, "output-group-end", "", "message template to print after a task's grouped output")
 	pflag.BoolVarP(&color, "color", "c", true, "colored output. Enabled by default. Set flag to false or use NO_COLOR=1 to disable")
 	pflag.IntVarP(&concurrency, "concurrency", "C", 0, "limit number tasks to run concurrently")
-	pflag.StringVarP(&interval, "interval", "I", "5s", "interval to watch for changes")
+	pflag.DurationVarP(&interval, "interval", "I", 0, "interval to watch for changes")
 	pflag.Parse()
 
 	if versionFlag {

--- a/task.go
+++ b/task.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/go-task/task/v3/internal/compiler"
 	"github.com/go-task/task/v3/internal/execext"
@@ -45,7 +46,7 @@ type Executor struct {
 	Parallel    bool
 	Color       bool
 	Concurrency int
-	Interval    string
+	Interval    time.Duration
 
 	Stdin  io.Reader
 	Stdout io.Writer

--- a/taskfile/taskfile.go
+++ b/taskfile/taskfile.go
@@ -3,6 +3,7 @@ package taskfile
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -20,7 +21,7 @@ type Taskfile struct {
 	Silent     bool
 	Dotenv     []string
 	Run        string
-	Interval   string
+	Interval   time.Duration
 }
 
 func (tf *Taskfile) UnmarshalYAML(node *yaml.Node) error {
@@ -39,7 +40,7 @@ func (tf *Taskfile) UnmarshalYAML(node *yaml.Node) error {
 			Silent     bool
 			Dotenv     []string
 			Run        string
-			Interval   string
+			Interval   time.Duration
 		}
 		if err := node.Decode(&taskfile); err != nil {
 			return err

--- a/watch.go
+++ b/watch.go
@@ -38,23 +38,14 @@ func (e *Executor) watchTasks(calls ...taskfile.Call) error {
 		}()
 	}
 
-	var watchIntervalString string
-
-	if e.Interval != "" {
-		watchIntervalString = e.Interval
-	} else if e.Taskfile.Interval != "" {
-		watchIntervalString = e.Taskfile.Interval
-	}
-
-	watchInterval := defaultWatchInterval
-
-	if watchIntervalString != "" {
-		var err error
-		watchInterval, err = parseWatchInterval(watchIntervalString)
-		if err != nil {
-			cancel()
-			return err
-		}
+	var watchInterval time.Duration
+	switch {
+	case e.Interval != 0:
+		watchInterval = e.Interval
+	case e.Taskfile.Interval != 0:
+		watchInterval = e.Taskfile.Interval
+	default:
+		watchInterval = defaultWatchInterval
 	}
 
 	e.Logger.VerboseOutf(logger.Green, "task: Watching for changes every %v", watchInterval)
@@ -185,12 +176,4 @@ func (e *Executor) registerWatchedFiles(w *watcher.Watcher, calls ...taskfile.Ca
 
 func shouldIgnoreFile(path string) bool {
 	return strings.Contains(path, "/.git") || strings.Contains(path, "/.task") || strings.Contains(path, "/node_modules")
-}
-
-func parseWatchInterval(watchInterval string) (time.Duration, error) {
-	v, err := time.ParseDuration(watchInterval)
-	if err != nil {
-		return 0, fmt.Errorf(`task: Could not parse watch interval "%s": %v`, watchInterval, err)
-	}
-	return v, nil
 }


### PR DESCRIPTION
Fixes #969 by setting the default value of the pflag to 0 instead of "5s".

Additionally, this PR changes both the `Taskfile` struct and the `interval` flag variable to use `time.Duration` directly rather than a string. This still allows the user to pass values using "5s" or "500ms" etc, but defers the passing of the value to the yaml and pflag libraries respectively. This slightly simplifies the `watch.go` file.