### PR TITLE
fix: add missing nil check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Small bug fix: closing "Taskfile.yml" once we're done reading it
   ([#963](https://github.com/go-task/task/issues/963), [#964](https://github.com/go-task/task/pull/964) by @HeCorr).
+- Fixes a bug in v2 that caused a panic when using a `Taskfile_{{OS}}.yml` file
+  ([#961](https://github.com/go-task/task/issues/961), [#971](https://github.com/go-task/task/pull/971) by @pd93).
 - Add `--json` flag (alias `-j`) with the intent to improve support for code
   editors and add room to other possible integrations. This is basic for now,
   but we plan to add more info in the near future

--- a/taskfile/merge.go
+++ b/taskfile/merge.go
@@ -45,7 +45,7 @@ func Merge(t1, t2 *Taskfile, includedTaskfile *IncludedTaskfile, namespaces ...s
 
 		// Set the task to internal if EITHER the included task or the included
 		// taskfile are marked as internal
-		task.Internal = task.Internal || includedTaskfile.Internal
+		task.Internal = task.Internal || (includedTaskfile != nil && includedTaskfile.Internal)
 
 		// Add namespaces to dependencies, commands and aliases
 		for _, dep := range task.Deps {


### PR DESCRIPTION
Fixes #961.

This problem occurs when a user uses `version: '2'` in their Taskfile in combination with a `Taskfile_{{OS}}.yml` file. In the case of #961, I'm guessing there was only a `Taskfile_windows.yml` file which is why the issue doesn't repro on Linux.

This happens because the `Merge` function is called with `includedTaskfile` set to `nil`:

https://github.com/go-task/task/blob/5be1f6bb2b612eeeae21a1c5bea6e7cd0e0f852e/taskfile/read/taskfile.go#L171-L182

This value is then not being nil checked in the `Merge` function here:

https://github.com/go-task/task/blob/5be1f6bb2b612eeeae21a1c5bea6e7cd0e0f852e/taskfile/merge.go#L48

The fix simply adds a nil check to this line.
