### PR TITLE
feat: Out-of-date dependency to force execution of an up-to-date task

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -69,6 +69,7 @@ func main() {
 		summary     bool
 		exitCode    bool
 		parallel    bool
+		propStatus  bool
 		concurrency int
 		dir         string
 		entrypoint  string
@@ -89,6 +90,7 @@ func main() {
 	pflag.BoolVarP(&verbose, "verbose", "v", false, "enables verbose mode")
 	pflag.BoolVarP(&silent, "silent", "s", false, "disables echoing")
 	pflag.BoolVarP(&parallel, "parallel", "p", false, "executes tasks provided on command line in parallel")
+	pflag.BoolVar(&propStatus, "propagate-status", false, "propagates out of date status from dependencies to dependents")
 	pflag.BoolVarP(&dry, "dry", "n", false, "compiles and prints tasks in the order that they would be run, without executing them")
 	pflag.BoolVar(&summary, "summary", false, "show summary about a task")
 	pflag.BoolVarP(&exitCode, "exit-code", "x", false, "pass-through the exit code of the task command")
@@ -145,6 +147,8 @@ func main() {
 
 	e := task.Executor{
 		Force:       force,
+		PropStatus:  propStatus,
+		OutOfDate:   false,
 		Watch:       watch,
 		Verbose:     verbose,
 		Silent:      silent,

--- a/task_test.go
+++ b/task_test.go
@@ -1696,3 +1696,19 @@ func TestUserWorkingDirectory(t *testing.T) {
 	assert.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "default"}))
 	assert.Equal(t, fmt.Sprintf("%s\n", wd), buff.String())
 }
+
+func TestPropagateStatus(t *testing.T) {
+	const dir = "testdata/out_of_date_dependency"
+	var buff bytes.Buffer
+	e := &task.Executor{
+		Dir:        dir,
+		Stdout:     &buff,
+		Stderr:     &buff,
+		Silent:     false,
+		PropStatus: true,
+	}
+	assert.NoError(t, e.Setup())
+	err := e.Run(context.Background(), taskfile.Call{Task: "target"})
+	assert.NoError(t, err)
+	assert.Equal(t, "task: Task \"second-dep\" is up to date\ntask: [first-dep] echo First\nFirst\ntask: [target] echo Target\nTarget", strings.TrimSpace(buff.String()))
+}

--- a/testdata/out_of_date_dependency/Taskfile.yml
+++ b/testdata/out_of_date_dependency/Taskfile.yml
@@ -1,0 +1,23 @@
+version: "3"
+
+tasks:
+  first-dep:
+    cmds:
+      - echo First
+    status:
+      - "exit 1"
+
+  second-dep:
+    cmds:
+      - echo Second
+    status:
+      - "exit 0"
+
+  target:
+    cmds:
+      - "echo Target"
+    deps:
+      - first-dep
+      - second-dep
+    status:
+      - "exit 0"


### PR DESCRIPTION
This is meant to be a transitioning implementation for #681 before it becomes the default behavior on a later version. When reviewing this PR, please take into consideration that I don't have much of an experience writing in Go.

The optional command line flag for this feature "--propagate-status," without a shortcut.
