### PR TITLE
Docker Proof-of-Concept

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -107,3 +107,14 @@ tasks:
     cmds:
       - echo '{{.GO_PACKAGES}}'
     silent: true
+
+  d:
+    container:
+      image: alpine
+      flags: [--cpus=1]
+    env:
+      MESSAGE: Hello
+    cmds:
+      - echo $MESSAGE 1
+      - echo $MESSAGE 2
+      - echo $MESSAGE 3

--- a/internal/container/docker/docker.go
+++ b/internal/container/docker/docker.go
@@ -1,0 +1,53 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/go-task/task/v3/internal/execext"
+)
+
+type Docker struct {
+	DockerCli string
+	Image     string
+	Flags     []string
+	Env       map[string]string
+
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+func (d *Docker) Setup() error {
+	if d.DockerCli == "" {
+		d.DockerCli = "docker"
+	}
+	return nil
+}
+
+func (d *Docker) Exec(ctx context.Context, cmd string) error {
+	dockerArgs := []string{"run"}
+
+	for k, v := range d.Env {
+		dockerArgs = append(dockerArgs, "--env", fmt.Sprintf("%s=%s", k, v))
+	}
+
+	dockerArgs = append(dockerArgs, d.Flags...)
+	dockerArgs = append(dockerArgs, d.Image, "sh", "-c", cmd)
+
+	shCmd, err := execext.Build(d.DockerCli, dockerArgs...)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("DOCKER: %s\n", shCmd)
+
+	return execext.RunCommand(ctx, &execext.RunCommandOptions{
+		Command: shCmd,
+		Dir:     "", // TODO(@andreynering): Implement this
+		Stdin:   d.Stdin,
+		Stdout:  d.Stdout,
+		Stderr:  d.Stderr,
+	})
+}

--- a/internal/execext/builder.go
+++ b/internal/execext/builder.go
@@ -1,0 +1,22 @@
+package execext
+
+import (
+	"fmt"
+	"strings"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func Build(cmd string, args ...string) (string, error) {
+	quotedArgs := make([]string, 0, len(args))
+
+	for _, arg := range args {
+		quoted, err := syntax.Quote(arg, syntax.LangBash)
+		if err != nil {
+			return "", err
+		}
+		quotedArgs = append(quotedArgs, quoted)
+	}
+
+	return fmt.Sprintf("%s %s", cmd, strings.Join(quotedArgs, " ")), nil
+}

--- a/taskfile/container.go
+++ b/taskfile/container.go
@@ -1,0 +1,7 @@
+package taskfile
+
+type Container struct {
+	Type  string
+	Image string
+	Flags []string
+}

--- a/taskfile/task.go
+++ b/taskfile/task.go
@@ -33,6 +33,7 @@ type Task struct {
 	Prefix               string
 	IgnoreError          bool
 	Run                  string
+	Container            *Container
 	IncludeVars          *Vars
 	IncludedTaskfileVars *Vars
 	IncludedTaskfile     *IncludedTaskfile
@@ -90,6 +91,7 @@ func (t *Task) UnmarshalYAML(node *yaml.Node) error {
 			Prefix        string
 			IgnoreError   bool `yaml:"ignore_error"`
 			Run           string
+			Container     *Container
 		}
 		if err := node.Decode(&task); err != nil {
 			return err
@@ -115,6 +117,7 @@ func (t *Task) UnmarshalYAML(node *yaml.Node) error {
 		t.Prefix = task.Prefix
 		t.IgnoreError = task.IgnoreError
 		t.Run = task.Run
+		t.Container = task.Container
 		return nil
 	}
 

--- a/taskfile/taskfile.go
+++ b/taskfile/taskfile.go
@@ -22,6 +22,7 @@ type Taskfile struct {
 	Dotenv     []string
 	Run        string
 	Interval   time.Duration
+	Container  *Container
 }
 
 func (tf *Taskfile) UnmarshalYAML(node *yaml.Node) error {
@@ -41,6 +42,7 @@ func (tf *Taskfile) UnmarshalYAML(node *yaml.Node) error {
 			Dotenv     []string
 			Run        string
 			Interval   time.Duration
+			Container  *Container
 		}
 		if err := node.Decode(&taskfile); err != nil {
 			return err
@@ -57,6 +59,7 @@ func (tf *Taskfile) UnmarshalYAML(node *yaml.Node) error {
 		tf.Dotenv = taskfile.Dotenv
 		tf.Run = taskfile.Run
 		tf.Interval = taskfile.Interval
+		tf.Container = taskfile.Container
 		if tf.Expansions <= 0 {
 			tf.Expansions = 2
 		}

--- a/taskfile/var.go
+++ b/taskfile/var.go
@@ -84,6 +84,7 @@ func (vs *Vars) Range(yield func(key string, value Var) error) error {
 // variables
 func (vs *Vars) ToCacheMap() (m map[string]interface{}) {
 	m = make(map[string]interface{}, vs.Len())
+
 	_ = vs.Range(func(k string, v Var) error {
 		if v.Sh != "" {
 			// Dynamic variable is not yet resolved; trigger
@@ -98,6 +99,20 @@ func (vs *Vars) ToCacheMap() (m map[string]interface{}) {
 		}
 		return nil
 	})
+
+	return
+}
+
+func (vs *Vars) ToStringMap() (m map[string]string) {
+	m = make(map[string]string, vs.Len())
+
+	_ = vs.Range(func(k string, v Var) error {
+		if v.Static != "" {
+			m[k] = v.Static
+		}
+		return nil
+	})
+
 	return
 }
 

--- a/variables.go
+++ b/variables.go
@@ -68,6 +68,7 @@ func (e *Executor) compiledTask(call taskfile.Call, evaluateShVars bool) (*taskf
 		Run:                  r.Replace(origTask.Run),
 		IncludeVars:          origTask.IncludeVars,
 		IncludedTaskfileVars: origTask.IncludedTaskfileVars,
+		Container:            origTask.Container,
 	}
 	new.Dir, err = execext.Expand(new.Dir)
 	if err != nil {


### PR DESCRIPTION
NOTE: This is incomplete work. It's a proof-of-concept that is going well, but the actual behavior and schema will change until it reaches `master`, so avoid using this unless for testing purposes.

Feedback is welcome on how you expect this to work 🙂.

## Implementation

Credits given to @no0dles for the first PoC on #285 and its our tool [hammerkit](https://github.com/no0dles/hammerkit).

On his implementation, @no0dles used the [official Docker client library for Go](https://pkg.go.dev/github.com/docker/docker/client). Sounds reasonable, but I decided to try a different approach: I'm calling `docker run ...` directly. There's a couple of reasons this may be interesting:

1) It requires no additional dependencies to the tool.
2) It allow us to add a `flags` prop on the YAML to allow the user to set specific Docker flags (`flags: [--cpus=1, --pull=always]`). This would be harder to implement if using the Go client, would potentially require a prop to each setting. [List of flags available here](https://docs.docker.com/engine/reference/commandline/run/#options).
3) The idea of avoiding using libraries make the implementation a bit more generic, opening room to potentially adding support to other container systems in the future, like Podman, without too much additional work.

## TODO

- [ ] Add props to highly common settings.
  - Mounting directories?
  - Exposing ports?
  - We don't need to do all because with the generic `flags` it's also possible to do this.
- [ ] Think about how to handle the `dir` prop and its relation with the `mounts` prop.
- [ ] What do you about `method/sources/generates`? Try to run them inside the container? Run outside? Forbid usage on when task is a container?
  - We could maybe forbid usage on the first release and figure it out the best behavior later.
- [ ] Dynamic variables are still being computed outside the container. Is that OK?
- [ ] Make implementation more generic (change to a interface) to allow Podman/others in the future?
- [ ] Add global `container` prop, so it's possible to set _all_ tasks on run in a given container?
  - Not sure how useful that would be. It's probably better to wait for feedback before doing this.
- [ ] Write tests
  - These tests should be behind a Go flag so they _won't_ run by default (but should ideally run on CI).
- [ ] Write documentation
  - Usage
  - API
  - JSON Schema 