### PR TITLE
fix: avoid reruns when the timestamp method is used

### DIFF
--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -595,9 +595,9 @@ The method `none` skips any validation and always run the task.
 
 :::info
 
-For the `checksum` (default) method to work, it is only necessary to
-inform the source files, but if you want to use the `timestamp` method, you
-also need to inform the generated files with `generates`.
+For the `checksum` (default) or `timestamp` method to work, it is only necessary to
+inform the source files.
+When the `timestamp` method is used, the last time of the running the task is considered as a generate.
 
 :::
 

--- a/internal/status/checksum.go
+++ b/internal/status/checksum.go
@@ -109,12 +109,12 @@ func (*Checksum) Kind() string {
 }
 
 func (c *Checksum) checksumFilePath() string {
-	return filepath.Join(c.TempDir, "checksum", c.normalizeFilename(c.Task))
+	return filepath.Join(c.TempDir, "checksum", NormalizeFilename(c.Task))
 }
 
 var checksumFilenameRegexp = regexp.MustCompile("[^A-z0-9]")
 
 // replaces invalid caracters on filenames with "-"
-func (*Checksum) normalizeFilename(f string) string {
+func NormalizeFilename(f string) string {
 	return checksumFilenameRegexp.ReplaceAllString(f, "-")
 }

--- a/internal/status/checksum_test.go
+++ b/internal/status/checksum_test.go
@@ -16,6 +16,6 @@ func TestNormalizeFilename(t *testing.T) {
 		{"foo1bar2baz3", "foo1bar2baz3"},
 	}
 	for _, test := range tests {
-		assert.Equal(t, test.Out, (&Checksum{}).normalizeFilename(test.In))
+		assert.Equal(t, test.Out, NormalizeFilename(test.In))
 	}
 }

--- a/internal/status/timestamp.go
+++ b/internal/status/timestamp.go
@@ -19,7 +19,7 @@ type Timestamp struct {
 
 // IsUpToDate implements the Checker interface
 func (t *Timestamp) IsUpToDate() (bool, error) {
-	if len(t.Sources) == 0 || len(t.Generates) == 0 {
+	if len(t.Sources) == 0 {
 		return false, nil
 	}
 

--- a/internal/status/timestamp.go
+++ b/internal/status/timestamp.go
@@ -47,6 +47,8 @@ func (t *Timestamp) IsUpToDate() (bool, error) {
 		}
 	}
 
+	taskTime := time.Now()
+
 	// compare the time of the generates and sources. If the generates are old, the task will be executed
 
 	// get the max time of the generates
@@ -63,7 +65,7 @@ func (t *Timestamp) IsUpToDate() (bool, error) {
 
 	// modify the metadata of the file to the the current time
 	if !t.Dry {
-		_ = os.Chtimes(timestampFile, time.Now(), time.Now())
+		_ = os.Chtimes(timestampFile, taskTime, taskTime)
 	}
 
 	return !shouldUpdate, nil

--- a/internal/status/timestamp.go
+++ b/internal/status/timestamp.go
@@ -2,15 +2,19 @@ package status
 
 import (
 	"os"
+	"path/filepath"
 	"time"
 )
 
 // Timestamp checks if any source change compared with the generated files,
 // using file modifications timestamps.
 type Timestamp struct {
+	TempDir   string
+	Task      string
 	Dir       string
 	Sources   []string
 	Generates []string
+	Dry       bool
 }
 
 // IsUpToDate implements the Checker interface
@@ -28,17 +32,37 @@ func (t *Timestamp) IsUpToDate() (bool, error) {
 		return false, nil
 	}
 
+	timestampFile := t.timestampFilePath()
+
+	// if the file exists, add the file path to the generates
+	// if the generate file is old, the task will be executed
+	_, err = os.Stat(timestampFile)
+	if err == nil {
+		generates = append(generates, timestampFile)
+	}
+
+	// compare the time of the generates and sources. If the generates are old, the task will be executed
+
 	sourcesMaxTime, err := getMaxTime(sources...)
 	if err != nil || sourcesMaxTime.IsZero() {
 		return false, nil
 	}
 
-	generatesMinTime, err := getMinTime(generates...)
-	if err != nil || generatesMinTime.IsZero() {
+	generateMaxTime, err := getMaxTime(generates...)
+	if err != nil || generateMaxTime.IsZero() {
 		return false, nil
 	}
 
-	return !generatesMinTime.Before(sourcesMaxTime), nil
+	// create the timestamp file for the next execution
+	if !t.Dry {
+		_ = os.MkdirAll(filepath.Dir(timestampFile), 0o755)
+		_, err = os.Create(timestampFile)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return !generateMaxTime.Before(sourcesMaxTime), nil
 }
 
 func (t *Timestamp) Kind() string {
@@ -64,18 +88,6 @@ func (t *Timestamp) Value() (interface{}, error) {
 	return sourcesMaxTime, nil
 }
 
-func getMinTime(files ...string) (time.Time, error) {
-	var t time.Time
-	for _, f := range files {
-		info, err := os.Stat(f)
-		if err != nil {
-			return time.Time{}, err
-		}
-		t = minTime(t, info.ModTime())
-	}
-	return t, nil
-}
-
 func getMaxTime(files ...string) (time.Time, error) {
 	var t time.Time
 	for _, f := range files {
@@ -88,13 +100,6 @@ func getMaxTime(files ...string) (time.Time, error) {
 	return t, nil
 }
 
-func minTime(a, b time.Time) time.Time {
-	if !a.IsZero() && a.Before(b) {
-		return a
-	}
-	return b
-}
-
 func maxTime(a, b time.Time) time.Time {
 	if a.After(b) {
 		return a
@@ -105,4 +110,8 @@ func maxTime(a, b time.Time) time.Time {
 // OnError implements the Checker interface
 func (*Timestamp) OnError() error {
 	return nil
+}
+
+func (t *Timestamp) timestampFilePath() string {
+	return filepath.Join(t.TempDir, "timestamp", NormalizeFilename(t.Task))
 }

--- a/status.go
+++ b/status.go
@@ -87,9 +87,12 @@ func (e *Executor) getStatusChecker(t *taskfile.Task) (status.Checker, error) {
 
 func (e *Executor) timestampChecker(t *taskfile.Task) status.Checker {
 	return &status.Timestamp{
+		TempDir:   e.TempDir,
+		Task:      t.Name(),
 		Dir:       t.Dir,
 		Sources:   t.Sources,
 		Generates: t.Generates,
+		Dry:       e.Dry,
 	}
 }
 


### PR DESCRIPTION
Fixes #976 

> I noticed that the `timestamp` method doesn't seem to work. It reruns the tasks all the time even though nothing has changed. 
> 
> This happens when the task generates some artifacts in the first run and doesn't re-generate them in the subsequent runs. This causes the following run to return `false`.
> https://github.com/go-task/task/blob/63c50d13eec142694ff5a074c3f9cda6c53d8be3/internal/status/timestamp.go#L41
> 
> To fix this issue, `task` should include the last run time in the `generates`. This way, the time of the generates will be newer than the sources, and so there is no need for rerunning. 
> 
> 
> This solution
> - would also fix the issue with an empty `generates` array. 
> - is consistent with the `checksum` method, and these two should work the same in most cases. 
> - is way faster than the checksum method because the source times are checked lazily and getting the metadata of a file is faster.
