### PR TITLE
feat(logger): add FORCE_COLOR environment variable support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fixed a bug where tasks were sometimes incorrectly marked as internal ([#1007](https://github.com/go-task/task/pull/1007) by @pd93).
 - Update to Go 1.20 (bump minimum version to 1.19) ([#1010](https://github.com/go-task/task/pull/1010) by @pd93)
-- Added environment variable `FORCE_COLOR` support to force color output. Usefull for environments without TTY. ([#1003](https://github.com/go-task/task/pull/1003) by @automation-stack)
+- Added environment variable `FORCE_COLOR` support to force color output. Usefull for environments without TTY ([#1003](https://github.com/go-task/task/pull/1003) by @automation-stack)
 
 ## v3.20.0 - 2023-01-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed a bug where tasks were sometimes incorrectly marked as internal ([#1007](https://github.com/go-task/task/pull/1007) by @pd93).
 - Update to Go 1.20 (bump minimum version to 1.19) ([#1010](https://github.com/go-task/task/pull/1010) by @pd93)
+- Added environment variable `FORCE_COLOR` support to force color output. Usefull for environments without TTY. ([#1003](https://github.com/go-task/task/pull/1003) by @automation-stack)
 
 ## v3.20.0 - 2023-01-14
 

--- a/docs/docs/api_reference.md
+++ b/docs/docs/api_reference.md
@@ -73,6 +73,7 @@ Some environment variables can be overriden to adjust Task behavior.
 | `TASK_COLOR_YELLOW` | `33` | Color used for yellow. |
 | `TASK_COLOR_MAGENTA` | `35` | Color used for magenta. |
 | `TASK_COLOR_RED` | `31` | Color used for red. |
+| `FORCE_COLOR` | `undefined` | Force color output usage. |
 
 ## Schema
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -34,6 +34,11 @@ func Red() PrintFunc {
 }
 
 func envColor(env string, defaultColor color.Attribute) color.Attribute {
+	_, err := strconv.Atoi(os.Getenv("FORCE_COLOR"))
+	if err == nil {
+		color.NoColor = false
+	}
+
 	override, err := strconv.Atoi(os.Getenv(env))
 	if err == nil {
 		return color.Attribute(override)

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -34,8 +34,7 @@ func Red() PrintFunc {
 }
 
 func envColor(env string, defaultColor color.Attribute) color.Attribute {
-	_, err := strconv.Atoi(os.Getenv("FORCE_COLOR"))
-	if err == nil {
+	if os.Getenv("FORCE_COLOR") != "" {
 		color.NoColor = false
 	}
 


### PR DESCRIPTION
## Motivation

- We now all use CI-solutions and many of them supports terminal colors in browser (logs, web-terminal and others)
- All CI processes are no-tty and can't pass check `isatty.IsTerminal` (`fatih/color` forces `nocolor` for all CI jobs  with condition `!isatty.IsTerminal(os.Stdout.Fd())`)
- CI jobs without colored logs extremely inconvenient for debugging and evaluating results

Now, we can force colored output with `FORCE_COLOR` environment variable and ignore all shortsighted restrictions and efficiently use the awesome `go-task/task` in CI jobs.

## Why PR suggested to go-task/task?

Maintainer of [fatih/color](https://github.com/fatih/color/issues/155) rejected PR with `FORCE_COLOR` support with unconvincing arguments