### PR TITLE
feat: use semver package for taskfile schema version

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -178,11 +178,6 @@ func main() {
 	if err := e.Setup(); err != nil {
 		log.Fatal(err)
 	}
-	v, err := e.Taskfile.ParsedVersion()
-	if err != nil {
-		log.Fatal(err)
-		return
-	}
 
 	if listOptions.ShouldListTasks() {
 		if foundTasks, err := e.ListTasks(listOptions); !foundTasks || err != nil {
@@ -201,7 +196,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if v >= 3.0 {
+	if e.Taskfile.Version.Compare(taskfile.V3) >= 0 {
 		calls, globals = args.ParseV3(tasksAndVars...)
 	} else {
 		calls, globals = args.ParseV2(tasksAndVars...)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/go-task/task/v3
 
 require (
+	github.com/Masterminds/semver/v3 v3.2.0
 	github.com/fatih/color v1.14.1
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=
+github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/task_test.go
+++ b/task_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/go-task/task/v3"
@@ -726,9 +727,9 @@ func TestCyclicDep(t *testing.T) {
 func TestTaskVersion(t *testing.T) {
 	tests := []struct {
 		Dir     string
-		Version string
+		Version *semver.Version
 	}{
-		{"testdata/version/v2", "2"},
+		{"testdata/version/v2", semver.MustParse("2")},
 	}
 
 	for _, test := range tests {

--- a/taskfile/merge.go
+++ b/taskfile/merge.go
@@ -10,7 +10,7 @@ const NamespaceSeparator = ":"
 
 // Merge merges the second Taskfile into the first
 func Merge(t1, t2 *Taskfile, includedTaskfile *IncludedTaskfile, namespaces ...string) error {
-	if t1.Version != t2.Version {
+	if !t1.Version.Equal(t2.Version) {
 		return fmt.Errorf(`task: Taskfiles versions should match. First is "%s" but second is "%s"`, t1.Version, t2.Version)
 	}
 

--- a/taskfile/taskfile.go
+++ b/taskfile/taskfile.go
@@ -2,15 +2,20 @@ package taskfile
 
 import (
 	"fmt"
-	"strconv"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"gopkg.in/yaml.v3"
+)
+
+var (
+	V3 = semver.MustParse("3")
+	V2 = semver.MustParse("2")
 )
 
 // Taskfile represents a Taskfile.yml
 type Taskfile struct {
-	Version    string
+	Version    *semver.Version
 	Expansions int
 	Output     Output
 	Method     string
@@ -31,7 +36,7 @@ func (tf *Taskfile) UnmarshalYAML(node *yaml.Node) error {
 
 	case yaml.MappingNode:
 		var taskfile struct {
-			Version    string
+			Version    *semver.Version
 			Expansions int
 			Output     Output
 			Method     string
@@ -76,13 +81,4 @@ func (tf *Taskfile) UnmarshalYAML(node *yaml.Node) error {
 	}
 
 	return fmt.Errorf("yaml: line %d: cannot unmarshal %s into taskfile", node.Line, node.ShortTag())
-}
-
-// ParsedVersion returns the version as a float64
-func (tf *Taskfile) ParsedVersion() (float64, error) {
-	v, err := strconv.ParseFloat(tf.Version, 64)
-	if err != nil {
-		return 0, fmt.Errorf(`task: Could not parse taskfile version "%s": %v`, tf.Version, err)
-	}
-	return v, nil
 }

--- a/variables.go
+++ b/variables.go
@@ -40,12 +40,7 @@ func (e *Executor) compiledTask(call taskfile.Call, evaluateShVars bool) (*taskf
 		return nil, err
 	}
 
-	v, err := e.Taskfile.ParsedVersion()
-	if err != nil {
-		return nil, err
-	}
-
-	r := templater.Templater{Vars: vars, RemoveNoValue: v >= 3.0}
+	r := templater.Templater{Vars: vars, RemoveNoValue: e.Taskfile.Version.Compare(taskfile.V3) >= 0}
 
 	new := taskfile.Task{
 		Task:                 origTask.Task,


### PR DESCRIPTION
Simple change to switch back to using the [Masterminds/semver](https://github.com/Masterminds/semver) package for storing/comparing the Taskfile schema version.

Also see [this related PR](https://github.com/Masterminds/semver/pull/196) which may make some of our comparisons a bit more readable.