### PR TITLE
fix: tasks being incorrectly marked as internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed a bug where tasks were sometimes incorrectly marked as internal ([#1007](https://github.com/go-task/task/pull/1007) by @pd93).
+
 ## v3.20.0 - 2023-01-14
 
 - Improve behavior and performance of status checking when using the

--- a/taskfile/included_taskfile.go
+++ b/taskfile/included_taskfile.go
@@ -61,14 +61,6 @@ func (tfs *IncludedTaskfiles) Len() int {
 	return len(tfs.Keys)
 }
 
-// Merge merges the given IncludedTaskfiles into the caller one
-func (tfs *IncludedTaskfiles) Merge(other *IncludedTaskfiles) {
-	_ = other.Range(func(key string, value IncludedTaskfile) error {
-		tfs.Set(key, value)
-		return nil
-	})
-}
-
 // Set sets a value to a given key
 func (tfs *IncludedTaskfiles) Set(key string, includedTaskfile IncludedTaskfile) {
 	if tfs.Mapping == nil {

--- a/taskfile/merge.go
+++ b/taskfile/merge.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// NamespaceSeparator contains the character that separates namescapes
+// NamespaceSeparator contains the character that separates namespaces
 const NamespaceSeparator = ":"
 
 // Merge merges the second Taskfile into the first
@@ -20,11 +20,6 @@ func Merge(t1, t2 *Taskfile, includedTaskfile *IncludedTaskfile, namespaces ...s
 	if t2.Output.IsSet() {
 		t1.Output = t2.Output
 	}
-
-	if t1.Includes == nil {
-		t1.Includes = &IncludedTaskfiles{}
-	}
-	t1.Includes.Merge(t2.Includes)
 
 	if t1.Vars == nil {
 		t1.Vars = &Vars{}


### PR DESCRIPTION
## Repro

Given the following file structure:

```
├── tasks
│   ├── bar.yml
│   └── foo.yml
└── Taskfile.yml
```

and the contents:

```yaml
# Taskfile.yml
version: '3'

includes:
  included: ./tasks/included.yml
```

```yaml
# tasks/included.yml
version: '3'

includes:
  util:
    taskfile: ./util.yml
    internal: true

tasks:
  pwd:
    cmds:
      - pwd

  util-pwd:
    cmds:
      - task: util:pwd
```

```yaml
# tasks/util.yml
version: '3'

tasks:
  pwd:
    cmds:
      - pwd
```

The following output is expected:

```sh
> task --list-all
task: Available tasks for this project:
* bar:default:             (aliases: bar)
* foo:default:             (aliases: foo)
```

However, we get this instead:

```sh
> task --list-all              
task: Available tasks for this project:
* foo:default:             (aliases: foo)
```

## Cause

In `merge.go` we are merging the included taskfile struct into the parent's struct. This causes some strange behavior (such as the repro above) when including a file multiple times. In the case of the repro, the included file is being marked (overwritten) as internal if _any_ of the subsequent includes are internal.

Since we always iterate over Taskfiles using a depth-first search, when we merge a Taskfile into a parent, the child will always contain no further children (that aren't already merged). This means that the child's `IncludedTaskfile` struct is no longer required and does not need to be merged into the parent.

## Solution

Remove the code that merges the `IncludedTaskfile` struct into the parent's struct.
