### PR TITLE
TASK_VERSION special var

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"runtime/debug"
 	"strings"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/go-task/task/v3"
 	"github.com/go-task/task/v3/args"
 	"github.com/go-task/task/v3/internal/logger"
+	ver "github.com/go-task/task/v3/internal/version"
 	"github.com/go-task/task/v3/taskfile"
 )
 
@@ -261,15 +261,7 @@ func getVersion() string {
 		return version
 	}
 
-	info, ok := debug.ReadBuildInfo()
-	if !ok || info.Main.Version == "" {
-		return "unknown"
-	}
-
-	version = info.Main.Version
-	if info.Main.Sum != "" {
-		version += fmt.Sprintf(" (%s)", info.Main.Sum)
-	}
+	version := ver.GetVersion()
 
 	return version
 }

--- a/docs/docs/api_reference.md
+++ b/docs/docs/api_reference.md
@@ -58,6 +58,7 @@ There are some special variables that is available on the templating system:
 | `USER_WORKING_DIR` | The absolute path of the directory `task` was called from. |
 | `CHECKSUM` | The checksum of the files listed in `sources`. Only available within the `status` prop and if method is set to `checksum`. |
 | `TIMESTAMP` | The date object of the greatest timestamp of the files listes in `sources`. Only available within the `status` prop and if method is set to `timestamp`. |
+| `TASK_VERSION` | The current version of task. |
 
 ## ENV
 

--- a/internal/compiler/v3/compiler_v3.go
+++ b/internal/compiler/v3/compiler_v3.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-task/task/v3/internal/filepathext"
 	"github.com/go-task/task/v3/internal/logger"
 	"github.com/go-task/task/v3/internal/templater"
+	"github.com/go-task/task/v3/internal/version"
 	"github.com/go-task/task/v3/taskfile"
 )
 
@@ -184,6 +185,7 @@ func (c *CompilerV3) getSpecialVars(t *taskfile.Task) (map[string]string, error)
 		"ROOT_DIR":         c.Dir,
 		"TASKFILE_DIR":     taskfileDir,
 		"USER_WORKING_DIR": c.UserWorkingDir,
+		"TASK_VERSION":     version.GetVersion(),
 	}, nil
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,20 @@
+package version
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+func GetVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok || info.Main.Version == "" {
+		return "unknown"
+	}
+
+	version := info.Main.Version
+	if info.Main.Sum != "" {
+		version += fmt.Sprintf(" (%s)", info.Main.Sum)
+	}
+
+	return version
+}

--- a/task_test.go
+++ b/task_test.go
@@ -190,11 +190,13 @@ func TestSpecialVars(t *testing.T) {
 	assert.Contains(t, output, "root/TASK=print")
 	assert.Contains(t, output, "root/ROOT_DIR="+toAbs("testdata/special_vars"))
 	assert.Contains(t, output, "root/TASKFILE_DIR="+toAbs("testdata/special_vars"))
+	assert.Contains(t, output, "root/TASK_VERSION=unknown")
 
 	// Included Taskfile
 	assert.Contains(t, output, "included/TASK=included:print")
 	assert.Contains(t, output, "included/ROOT_DIR="+toAbs("testdata/special_vars"))
 	assert.Contains(t, output, "included/TASKFILE_DIR="+toAbs("testdata/special_vars/included"))
+	assert.Contains(t, output, "included/TASK_VERSION=unknown")
 }
 
 func TestVarsInvalidTmpl(t *testing.T) {

--- a/testdata/special_vars/Taskfile.yml
+++ b/testdata/special_vars/Taskfile.yml
@@ -16,3 +16,4 @@ tasks:
       - echo root/TASK={{.TASK}}
       - echo root/ROOT_DIR={{.ROOT_DIR}}
       - echo root/TASKFILE_DIR={{.TASKFILE_DIR}}
+      - echo root/TASK_VERSION={{.TASK_VERSION}}

--- a/testdata/special_vars/included/Taskfile.yml
+++ b/testdata/special_vars/included/Taskfile.yml
@@ -6,3 +6,4 @@ tasks:
       - echo included/TASK={{.TASK}}
       - echo included/ROOT_DIR={{.ROOT_DIR}}
       - echo included/TASKFILE_DIR={{.TASKFILE_DIR}}
+      - echo included/TASK_VERSION={{.TASK_VERSION}}


### PR DESCRIPTION
As suggested [here](https://github.com/go-task/task/issues/990). This PR adds the `TASK_VERSION` special variable. It is retrieved from the value passed on the `version` build parameter.

It can be used as follows:
```yml
version: '3'

tasks:
  default:
    cmds:
      - echo "{{.TASK_VERSION}}"
```