### PR TITLE
Feature 664 group error only

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -94,6 +94,7 @@ func main() {
 	pflag.StringVarP(&output.Name, "output", "o", "", "sets output style: [interleaved|group|prefixed]")
 	pflag.StringVar(&output.Group.Begin, "output-group-begin", "", "message template to print before a task's grouped output")
 	pflag.StringVar(&output.Group.End, "output-group-end", "", "message template to print after a task's grouped output")
+	pflag.BoolVar(&output.Group.ErrorOnly, "output-group-error-only", false, "swallow output from successful tasks")
 	pflag.BoolVarP(&color, "color", "c", true, "colored output. Enabled by default. Set flag to false or use NO_COLOR=1 to disable")
 	pflag.IntVarP(&concurrency, "concurrency", "C", 0, "limit number tasks to run concurrently")
 	pflag.DurationVarP(&interval, "interval", "I", 0, "interval to watch for changes")
@@ -136,6 +137,10 @@ func main() {
 		}
 		if output.Group.End != "" {
 			log.Fatal("task: You can't set --output-group-end without --output=group")
+			return
+		}
+		if output.Group.ErrorOnly {
+			log.Fatal("task: You can't set --output-group-error-only without --output=group")
 			return
 		}
 	}

--- a/docs/docs/api_reference.md
+++ b/docs/docs/api_reference.md
@@ -36,6 +36,7 @@ variable
 | `-o` | `--output` | `string` | Default set in the Taskfile or `intervealed` | Sets output style: [`interleaved`/`group`/`prefixed`]. |
 |      | `--output-group-begin` | `string` | | Message template to print before a task's grouped output. |
 |      | `--output-group-end` | `string` | | Message template to print after a task's grouped output. |
+|      | `--output-group-error-only` | `bool` | `false` | Swallow command output on zero exit code. |
 | `-p` | `--parallel` | `bool` | `false` | Executes tasks provided on command line in parallel. |
 | `-s` | `--silent` | `bool` | `false` | Disables echoing. |
 |      | `--status` | `bool` | `false` | Exits with non-zero exit code if any of the given tasks is not up-to-date. |

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -1342,6 +1342,30 @@ Hello, World!
 ::endgroup::
 ```
 
+When using the `group` output, you may swallow the output of the executed command
+on standard output and standard error if it does not fail (zero exit code).
+
+```yaml
+version: '3'
+
+silent: true
+
+output:
+  group:
+    error_only: true
+
+tasks:
+  passes: echo 'output-of-passes'
+  errors: echo 'output-of-errors' && exit 1
+```
+
+```bash
+$ task passes
+$ task errors
+output-of-errors
+task: Failed to run task "errors": exit status 1
+```
+
 The `prefix` output will prefix every line printed by a command with
 `[task-name] ` as the prefix, but you can customize the prefix for a command
 with the `prefix:` attribute:

--- a/docs/static/schema.json
+++ b/docs/static/schema.json
@@ -331,6 +331,11 @@
               },
               "end": {
                 "type": "string"
+              },
+              "error_only": {
+                "description": "Swallows command output on zero exit code",
+                "type": "boolean",
+                "default": false
               }
             }
           }

--- a/internal/output/group.go
+++ b/internal/output/group.go
@@ -7,6 +7,7 @@ import (
 
 type Group struct {
 	Begin, End string
+	ErrorOnly  bool
 }
 
 func (g Group) WrapWriter(stdOut, _ io.Writer, _ string, tmpl Templater) (io.Writer, io.Writer, CloseFunc) {
@@ -17,7 +18,13 @@ func (g Group) WrapWriter(stdOut, _ io.Writer, _ string, tmpl Templater) (io.Wri
 	if g.End != "" {
 		gw.end = tmpl.Replace(g.End) + "\n"
 	}
-	return gw, gw, func() error { return gw.close() }
+	return gw, gw, func(err error) error {
+		if g.ErrorOnly && err == nil {
+			return nil
+		}
+
+		return gw.close()
+	}
 }
 
 type groupWriter struct {

--- a/internal/output/interleaved.go
+++ b/internal/output/interleaved.go
@@ -7,5 +7,5 @@ import (
 type Interleaved struct{}
 
 func (Interleaved) WrapWriter(stdOut, stdErr io.Writer, _ string, _ Templater) (io.Writer, io.Writer, CloseFunc) {
-	return stdOut, stdErr, func() error { return nil }
+	return stdOut, stdErr, func(error) error { return nil }
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -18,7 +18,7 @@ type Output interface {
 	WrapWriter(stdOut, stdErr io.Writer, prefix string, tmpl Templater) (io.Writer, io.Writer, CloseFunc)
 }
 
-type CloseFunc func() error
+type CloseFunc func(err error) error
 
 // Build the Output for the requested taskfile.Output.
 func BuildFor(o *taskfile.Output) (Output, error) {
@@ -30,8 +30,9 @@ func BuildFor(o *taskfile.Output) (Output, error) {
 		return Interleaved{}, nil
 	case "group":
 		return Group{
-			Begin: o.Group.Begin,
-			End:   o.Group.End,
+			Begin:     o.Group.Begin,
+			End:       o.Group.End,
+			ErrorOnly: o.Group.ErrorOnly,
 		}, nil
 	case "prefixed":
 		if err := checkOutputGroupUnset(o); err != nil {

--- a/internal/output/prefixed.go
+++ b/internal/output/prefixed.go
@@ -11,7 +11,7 @@ type Prefixed struct{}
 
 func (Prefixed) WrapWriter(stdOut, _ io.Writer, prefix string, _ Templater) (io.Writer, io.Writer, CloseFunc) {
 	pw := &prefixWriter{writer: stdOut, prefix: prefix}
-	return pw, pw, func() error { return pw.close() }
+	return pw, pw, func(error) error { return pw.close() }
 }
 
 type prefixWriter struct {

--- a/task_test.go
+++ b/task_test.go
@@ -1569,6 +1569,36 @@ Bye!
 	t.Log(buff.String())
 	assert.Equal(t, strings.TrimSpace(buff.String()), expectedOutputOrder)
 }
+func TestOutputGroupErrorOnlySwallowsOutputOnSuccess(t *testing.T) {
+	const dir = "testdata/output_group_error_only"
+	var buff bytes.Buffer
+	e := task.Executor{
+		Dir:    dir,
+		Stdout: &buff,
+		Stderr: &buff,
+	}
+	assert.NoError(t, e.Setup())
+
+	assert.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "passing"}))
+	t.Log(buff.String())
+	assert.Empty(t, buff.String())
+}
+
+func TestOutputGroupErrorOnlyShowsOutputOnFailure(t *testing.T) {
+	const dir = "testdata/output_group_error_only"
+	var buff bytes.Buffer
+	e := task.Executor{
+		Dir:    dir,
+		Stdout: &buff,
+		Stderr: &buff,
+	}
+	assert.NoError(t, e.Setup())
+
+	assert.Error(t, e.Run(context.Background(), taskfile.Call{Task: "failing"}))
+	t.Log(buff.String())
+	assert.Contains(t, "failing-output", strings.TrimSpace(buff.String()))
+	assert.NotContains(t, "passing", strings.TrimSpace(buff.String()))
+}
 
 func TestIncludedVars(t *testing.T) {
 	const dir = "testdata/include_with_vars"

--- a/taskfile/output.go
+++ b/taskfile/output.go
@@ -53,6 +53,7 @@ func (s *Output) UnmarshalYAML(node *yaml.Node) error {
 // OutputGroup is the style options specific to the Group style.
 type OutputGroup struct {
 	Begin, End string
+	ErrorOnly  bool `yaml:"error_only"`
 }
 
 // IsSet returns true if and only if a custom output style is set.

--- a/testdata/output_group_error_only/Taskfile.yml
+++ b/testdata/output_group_error_only/Taskfile.yml
@@ -1,0 +1,17 @@
+version: '3'
+
+silent: true
+
+output:
+  group:
+    error_only: true
+
+tasks:
+  passing: echo 'passing-output'
+
+  failing:
+    cmds:
+      - task: passing
+      - echo 'passing-output-2'
+      - echo 'passing-output-3'
+      - echo 'failing-output' && exit 1


### PR DESCRIPTION
Implementation idea for #664.

> Describe your changes 

## Usage

```yaml
version: '3'

silent: true

output:
  group:
    error_only: true

tasks:
  passing: echo 'passing-output'
  failing: echo 'failing-output' && exit 1
```

```sh
> task passing
(no output)
> task failing
failing-output
task: Failed to run task "failing": exit status 1
```

## Implementation
Enrich `Group` output by an `error_only` flag which should swallow the output (stdout + stderr) if any external command did not have a non zero exit code. By default this flag is disabled.

## backwards comapatibility

Changes should not interfere with task files created in previous versions as the default behavior is not changed.

## What's already done
- [x] high level tests (`task_test.go`)
- [x] tests for output writer
- [x] code style (fmt & lint)
- [x] documentation
- [x] schema definition

I would love to have some feedback if this goes into the right direction. If so, I would love to continue working on it.