### PR TITLE
Fix output "prefixed" option in schema.json

### DIFF
--- a/docs/static/schema.json
+++ b/docs/static/schema.json
@@ -317,7 +317,7 @@
       },
       "outputString": {
         "type": "string",
-        "enum": ["interleaved", "prefix", "group"],
+        "enum": ["interleaved", "prefixed", "group"],
         "default": "interleaved"
       },
       "outputObject": {


### PR DESCRIPTION
Fix the output option to match implementation and documentation.
