### PR TITLE
fix: status and sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fixed bug where `.task/checksum` file was sometimes not being created when
   task also declares a `status:`
-  ([#840](https://github.com/go-task/task/issues/840), [#1035](https://github.com/go-task/task/pull/1035) by @harelwa).
+  ([#840](https://github.com/go-task/task/issues/840), [#1035](https://github.com/go-task/task/pull/1035) by @harelwa, [#1037](https://github.com/go-task/task/pull/1037) by @pd93).
 - Fixed deadlock issue when using `run: once`
   ([#715](https://github.com/go-task/task/issues/715), [#1025](https://github.com/go-task/task/pull/1025) by @theunrepentantgeek).
 


### PR DESCRIPTION
Original [issue](https://github.com/go-task/task/issues/840) and [PR](https://github.com/go-task/task/pull/1035).

This PR fixes the `status` and `sources` implementation. Rather than optimising the boolean logic, I chose to make the code easier to read and understand. This should make it easier to maintain in the future.

Truth table for `status` and `sources`:

| Status up-to-date | Sources up-to-date | Task is up-to-date |
| ----------------- | ------------------ | ------------------ |
| not set           | not set            | ❌                 |
| not set           | ✔️               | ✔️               |
| not set           | ❌                 | ❌                 |
| ✔️              | not set            | ✔️               |
| ✔️              | ✔️               | ✔️               |
| ✔️              | ❌                 | ❌                 |
| ❌                | not set            | ❌                 |
| ❌                | ✔️               | ❌                 |
| ❌                | ❌                 | ❌                 |

If the task is up-to-date, it will not run.

The logic essentially goes like this:

- If both `status` and `sources` are set, the task is up-to-date if both `status` and `sources` are up-to-date
- If only `status` is set, the task is up-to-date if the `status` is up-to-date
- If only `sources` is set, the task is up-to-date if the `sources` are up-to-date
- If no `status` or `sources` are set, the task should always run  
  i.e. it is never considered "up-to-date"
