### PR TITLE
chore: remove installation docs for Go 1.15

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -170,9 +170,10 @@ This installation method is community owned.
 
 ### Go Modules
 
-First, make sure you have [Go][go] properly installed and setup.
+Ensure that you have a supported version of [Go][go] properly installed and setup. You can find
+the minimum required version of Go in the [go.mod](https://github.com/go-task/task/blob/master/go.mod#L3) file.
 
-You can easily install the latest release globally by running:
+You can then install the latest release globally by running:
 
 ```bash
 go install github.com/go-task/task/v3/cmd/task@latest
@@ -182,12 +183,6 @@ Or you can install into another directory:
 
 ```bash
 env GOBIN=/bin go install github.com/go-task/task/v3/cmd/task@latest
-```
-
-If using Go 1.15 or earlier, instead use:
-
-```bash
-env GO111MODULE=on go get -u github.com/go-task/task/v3/cmd/task@latest
 ```
 
 :::tip

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/go-task/task/v3
 
+go 1.19
+
 require (
 	github.com/Masterminds/semver/v3 v3.2.0
 	github.com/fatih/color v1.14.1
@@ -26,5 +28,3 @@ require (
 	golang.org/x/term v0.3.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )
-
-go 1.19


### PR DESCRIPTION
Task has generic code in it now which requires 1.18 and so will not build on version 1.15 any more. Also, we only officially support the last 2 versions of Go and 1.15 is now 5 versions (2.5 years) old.

Therefore, I have removed the docs for installing on 1.15 or older and added some text about the minimum required version. Instead of statically typing this in the docs, I've linked to the `go.mod` so that we don't have to remember to update the docs and moved the `go` version to the top of the `go.mod` file so the line reference won't change.
