### PR TITLE
Add splitArgs template function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added new `splitArgs` to the template system
+  (`{{splitArgs "foo bar 'foo bar baz'"}}`) to ensure string is splitted as arguments not whitespaces
+
 ## v3.22.0 - 2023-03-10
 
 - Add a brand new `--global` (`-g`) flag that will run a Taskfile from your

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -5,6 +5,11 @@ sidebar_position: 7
 
 # Changelog
 
+## Unreleased
+
+- Added new `splitArgs` to the template system
+  (`{{splitArgs "foo bar 'foo bar baz'"}}`) to ensure string is splitted as sh arguments not whitespaces
+
 ## v3.22.0 - 2023-03-10
 
 - Add a brand new `--global` (`-g`) flag that will run a Taskfile from your

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -5,11 +5,6 @@ sidebar_position: 7
 
 # Changelog
 
-## Unreleased
-
-- Added new `splitArgs` to the template system
-  (`{{splitArgs "foo bar 'foo bar baz'"}}`) to ensure string is splitted as sh arguments not whitespaces
-
 ## v3.22.0 - 2023-03-10
 
 - Add a brand new `--global` (`-g`) flag that will run a Taskfile from your

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -1046,6 +1046,8 @@ Task also adds the following functions:
 - `shellQuote`: Quotes a string to make it safe for use in shell scripts.
   Task uses [this Go function](https://pkg.go.dev/mvdan.cc/sh/v3@v3.4.0/syntax#Quote)
   for this. The Bash dialect is assumed.
+- `splitArgs`: Splits a string as if it were a command's arguments.
+  Task uses [this Go function](https://pkg.go.dev/mvdan.cc/sh/v3@v3.4.0/shell#Fields)
 
 Example:
 

--- a/internal/templater/funcs.go
+++ b/internal/templater/funcs.go
@@ -7,6 +7,7 @@ import (
 	"text/template"
 
 	sprig "github.com/go-task/slim-sprig"
+	"mvdan.cc/sh/v3/shell"
 	"mvdan.cc/sh/v3/syntax"
 )
 
@@ -40,6 +41,9 @@ func init() {
 		},
 		"shellQuote": func(str string) (string, error) {
 			return syntax.Quote(str, syntax.LangBash)
+		},
+		"splitArgs": func(s string) ([]string, error) {
+			return shell.Fields(s, nil)
 		},
 		// IsSH is deprecated.
 		"IsSH": func() bool { return true },

--- a/task_test.go
+++ b/task_test.go
@@ -1832,3 +1832,18 @@ func TestBashShellOptsCommandLevel(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "globstar\ton\n", buff.String())
 }
+
+func TestSplitArgs(t *testing.T) {
+	var buff bytes.Buffer
+	e := task.Executor{
+		Dir:    "testdata/split_args",
+		Stdout: &buff,
+		Stderr: &buff,
+		Silent: true,
+	}
+	assert.NoError(t, e.Setup())
+
+	err := e.Run(context.Background(), taskfile.Call{Task: "default"})
+	assert.NoError(t, err)
+	assert.Equal(t, "3\n", buff.String())
+}

--- a/task_test.go
+++ b/task_test.go
@@ -1843,7 +1843,10 @@ func TestSplitArgs(t *testing.T) {
 	}
 	assert.NoError(t, e.Setup())
 
-	err := e.Run(context.Background(), taskfile.Call{Task: "default"})
+	vars := &taskfile.Vars{}
+	vars.Set("CLI_ARGS", taskfile.Var{Static: "foo bar 'foo bar baz'"})
+
+	err := e.Run(context.Background(), taskfile.Call{Task: "default", Vars: vars})
 	assert.NoError(t, err)
 	assert.Equal(t, "3\n", buff.String())
 }

--- a/testdata/split_args/Taskfile.yml
+++ b/testdata/split_args/Taskfile.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+tasks:
+  default:
+    cmds:
+      - cmd: echo '{{splitArgs "foo bar 'foo bar baz'" | len}}'

--- a/testdata/split_args/Taskfile.yml
+++ b/testdata/split_args/Taskfile.yml
@@ -3,4 +3,4 @@ version: '3'
 tasks:
   default:
     cmds:
-      - cmd: echo '{{splitArgs "foo bar 'foo bar baz'" | len}}'
+      - cmd: echo '{{splitArgs .CLI_ARGS | len}}'


### PR DESCRIPTION
close #1040 

This PR adds a new splitArgs template function

example:
```yaml
version: '3'

tasks:
  default:
    cmds:
      - cmd: echo '{{splitArgs "foo bar 'foo bar baz'"}}'
```