### PR TITLE
fix: deep copying pointers inside slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   arguments not whitespaces
   ([#1040](https://github.com/go-task/task/issues/1040), [#1059](https://github.com/go-task/task/pull/1059) by @dhanusaputra).
 - Fix the value of `{{.CHECKSUM}}` variable in status ([#1076](https://github.com/go-task/task/issues/1076), [#1080](https://github.com/go-task/task/pull/1080) by @pd93).
+- Fixed deep copy implementation ([#1072](https://github.com/go-task/task/pull/1072) by @pd93)
 
 ## v3.22.0 - 2023-03-10
 

--- a/taskfile/copy.go
+++ b/taskfile/copy.go
@@ -1,23 +1,35 @@
 package taskfile
 
-import "golang.org/x/exp/constraints"
+type DeepCopier[T any] interface {
+	DeepCopy() T
+}
 
 func deepCopySlice[T any](orig []T) []T {
 	if orig == nil {
 		return nil
 	}
 	c := make([]T, len(orig))
-	copy(c, orig)
+	for i, v := range orig {
+		if copyable, ok := any(v).(DeepCopier[T]); ok {
+			c[i] = copyable.DeepCopy()
+		} else {
+			c[i] = v
+		}
+	}
 	return c
 }
 
-func deepCopyMap[K constraints.Ordered, V any](orig map[K]V) map[K]V {
+func deepCopyMap[K comparable, V any](orig map[K]V) map[K]V {
 	if orig == nil {
 		return nil
 	}
 	c := make(map[K]V, len(orig))
 	for k, v := range orig {
-		c[k] = v
+		if copyable, ok := any(v).(DeepCopier[V]); ok {
+			c[k] = copyable.DeepCopy()
+		} else {
+			c[k] = v
+		}
 	}
 	return c
 }

--- a/taskfile/dep.go
+++ b/taskfile/dep.go
@@ -1,0 +1,50 @@
+package taskfile
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Dep is a task dependency
+type Dep struct {
+	Task string
+	Vars *Vars
+}
+
+func (d *Dep) DeepCopy() *Dep {
+	if d == nil {
+		return nil
+	}
+	return &Dep{
+		Task: d.Task,
+		Vars: d.Vars.DeepCopy(),
+	}
+}
+
+func (d *Dep) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+
+	case yaml.ScalarNode:
+		var task string
+		if err := node.Decode(&task); err != nil {
+			return err
+		}
+		d.Task = task
+		return nil
+
+	case yaml.MappingNode:
+		var taskCall struct {
+			Task string
+			Vars *Vars
+		}
+		if err := node.Decode(&taskCall); err != nil {
+			return err
+		}
+		d.Task = taskCall.Task
+		d.Vars = taskCall.Vars
+		return nil
+	}
+
+	return fmt.Errorf("cannot unmarshal %s into dependency", node.ShortTag())
+}

--- a/taskfile/platforms.go
+++ b/taskfile/platforms.go
@@ -15,6 +15,16 @@ type Platform struct {
 	Arch string
 }
 
+func (p *Platform) DeepCopy() *Platform {
+	if p == nil {
+		return nil
+	}
+	return &Platform{
+		OS:   p.OS,
+		Arch: p.Arch,
+	}
+}
+
 type ErrInvalidPlatform struct {
 	Platform string
 }

--- a/taskfile/precondition.go
+++ b/taskfile/precondition.go
@@ -18,6 +18,16 @@ type Precondition struct {
 	Msg string
 }
 
+func (p *Precondition) DeepCopy() *Precondition {
+	if p == nil {
+		return nil
+	}
+	return &Precondition{
+		Sh:  p.Sh,
+		Msg: p.Msg,
+	}
+}
+
 // UnmarshalYAML implements yaml.Unmarshaler interface.
 func (p *Precondition) UnmarshalYAML(node *yaml.Node) error {
 	switch node.Kind {

--- a/taskfile/task.go
+++ b/taskfile/task.go
@@ -131,6 +131,9 @@ func (t *Task) UnmarshalYAML(node *yaml.Node) error {
 // DeepCopy creates a new instance of Task and copies
 // data by value from the source struct.
 func (t *Task) DeepCopy() *Task {
+	if t == nil {
+		return nil
+	}
 	c := &Task{
 		Task:                 t.Task,
 		Cmds:                 deepCopySlice(t.Cmds),


### PR DESCRIPTION
This is another piece of work that has fallen out of my changes in the `dag` branch. AFAIK This doesn't cause any issues currently. However, it is causing issues on my `dag` branch and I see no reason to delay merging the fix while I work on other things.

Deep copying currently isn't working as intended when a slice contains pointers. This PR fixes this by adding a `DeepCopier` interface which allows you to specify how a type should be deep copied. If a slice type implements this interface then the `DeepCopy()` function will now be called on each element. This gives us the ability to recurse into our structures and deep copy everything. Many of our types already satisfy this interface. However, I have added a method to the remaining ones that didn't.

I did consider using a 3rd party library to do all of this for us. However, they all use reflection to do it which is much slower. This custom implementation needs to be maintained, but by using an interface, this should be quite manageable.

Sidenote: I split up `Dep` and `Cmd` too as they have both grown and I think they deserve their own file now.