### PR TITLE
fix: broken link to scoop bucket

### DIFF
--- a/docs/docs/community.md
+++ b/docs/docs/community.md
@@ -58,7 +58,7 @@ Some installation methods are maintained by third party:
   by [@arduino](https://github.com/arduino)
 - [AUR](https://aur.archlinux.org/packages/go-task-bin)
   by [@carlsmedstad](https://github.com/carlsmedstad)
-- [Scoop](https://github.com/lukesampson/scoop-extras/blob/master/bucket/task.json)
+- [Scoop](https://github.com/ScoopInstaller/Main/blob/master/bucket/task.json)
 - [Fedora](https://packages.fedoraproject.org/pkgs/golang-github-task/go-task/)
 - [NixOS](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/go-task/default.nix)
 


### PR DESCRIPTION
The Scoop project was moved from extras into the main bucket quite some time ago, so our link is broken. This PR fixes it.

Related:
- https://github.com/ScoopInstaller/Main/pull/1985
- https://github.com/ScoopInstaller/Extras/pull/8015