### PR TITLE
fix: checksum variable in status is incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   (`{{splitArgs "foo bar 'foo bar baz'"}}`) to ensure string is splitted as
   arguments not whitespaces
   ([#1040](https://github.com/go-task/task/issues/1040), [#1059](https://github.com/go-task/task/pull/1059) by @dhanusaputra).
+- Fix the value of `{{.CHECKSUM}}` variable in status ([#1076](https://github.com/go-task/task/issues/1076), [#1080](https://github.com/go-task/task/pull/1080) by @pd93).
 
 ## v3.22.0 - 2023-03-10
 

--- a/task_test.go
+++ b/task_test.go
@@ -691,7 +691,7 @@ func TestStatusVariables(t *testing.T) {
 	assert.NoError(t, e.Setup())
 	assert.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "build"}))
 
-	assert.Contains(t, buff.String(), "d41d8cd98f00b204e9800998ecf8427e")
+	assert.Contains(t, buff.String(), "a41e7948dcd321db412ce61d3d5c9864")
 
 	inf, err := os.Stat(filepathext.SmartJoin(dir, "source.txt"))
 	assert.NoError(t, err)


### PR DESCRIPTION
Fixes #1076. FWIW, I don't think this ever worked as the test was checking for the value that is always returned.

Original feature PR: https://github.com/go-task/task/pull/216