### PR TITLE
chore: update workflows

### DIFF
--- a/.github/workflows/sync-translated-documents.yml
+++ b/.github/workflows/sync-translated-documents.yml
@@ -2,6 +2,8 @@ name: Sync Translations
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   sync-translated-documents:
@@ -32,3 +34,4 @@ jobs:
           author: task-bot <106601941+task-bot@users.noreply.github.com>
           labels: translation
           token: ${{ secrets.GH_PAT }}
+          draft: true

--- a/.github/workflows/upload-source-documents.yml
+++ b/.github/workflows/upload-source-documents.yml
@@ -1,0 +1,34 @@
+name: Upload Source Documents
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  push_files_to_crowdin:
+    name: Push files to Crowdin
+    if: github.repository == 'go-task/task'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Verify changed files
+        uses: tj-actions/verify-changed-files@v14
+        id: verify-changed-files
+        with:
+          files: |
+            docs/docs
+            docs/blog
+            docs/i18n/en
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          version: 3.x
+
+      - name: Upload source documents
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        run: task crowdin:push
+        env:
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+        working-directory: ./docs


### PR DESCRIPTION
- [x] Add auto upload source documents workflow. When the files in the document folder are updated, the source files will be automatically uploaded to Crowdin. This will always keep the source documentation on Crowdin up to date.
- [x] Add scheduled task for sync documents. The timed task will automatically translate the document and generate a draft PR. If the last generated PR has not been merged, it will be overwritten. When the maintainer thinks it can be merged, it will be merged. It will not generate redundant PR.

