### PR TITLE
feat: release tool improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- More improvements to the release tool (#1096 by @pd93)
+
 ## v3.23.0 - 2023-03-26
 
 Task now has an [official extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=task.vscode-task) contributed by @pd93! :tada: The extension is maintained in a [new repository](https://github.com/go-task/vscode-task) under the `go-task` organization. We're looking to gather feedback from the community so please give it a go and let us know what you think via a [discussion](https://github.com/go-task/vscode-task/discussions), [issue](https://github.com/go-task/vscode-task/issues) or on our [Discord](https://discord.gg/6TY36E39UK)!

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -107,14 +107,6 @@ tasks:
     cmds:
       - go run ./cmd/release {{.CLI_ARGS}}
 
-  npm:bump:
-    desc: Bump version in package.json. Requires `jq`.
-    vars:
-      VERSION: '{{coalesce .CLI_ARGS .VERSION}}'
-    cmds:
-      - cat package.json | jq '.version = "{{.VERSION}}"' > temp.json; mv temp.json package.json
-      - cat package-lock.json | jq '.version = "{{.VERSION}}" | .packages."".version = "{{.VERSION}}"' > temp.json; mv temp.json package-lock.json
-
   npm:publish:
     desc: Publish release to npm
     cmds:


### PR DESCRIPTION
I noticed that the npm version bump was added to the Taskfile. I figured that we could just add this to the new release tool so now `task release -- major|minor|patch|x.x.x` will bump the changelog _and_ yarn files.