### PR TITLE
refactor: use require for testing errors

### DIFF
--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/go-task/task/v3/internal/output"
 	"github.com/go-task/task/v3/internal/templater"
@@ -39,7 +40,7 @@ func TestGroup(t *testing.T) {
 	fmt.Fprintln(stdErr, "err")
 	assert.Equal(t, "", b.String())
 
-	assert.NoError(t, cleanup(nil))
+	require.NoError(t, cleanup(nil))
 	assert.Equal(t, "out\nout\nerr\nerr\nout\nerr\n", b.String())
 }
 
@@ -65,13 +66,13 @@ func TestGroupWithBeginEnd(t *testing.T) {
 		assert.Equal(t, "", b.String())
 		fmt.Fprintln(w, "baz")
 		assert.Equal(t, "", b.String())
-		assert.NoError(t, cleanup(nil))
+		require.NoError(t, cleanup(nil))
 		assert.Equal(t, "::group::example-value\nfoo\nbar\nbaz\n::endgroup::\n", b.String())
 	})
 	t.Run("no output", func(t *testing.T) {
 		var b bytes.Buffer
 		_, _, cleanup := o.WrapWriter(&b, io.Discard, "", &tmpl)
-		assert.NoError(t, cleanup(nil))
+		require.NoError(t, cleanup(nil))
 		assert.Equal(t, "", b.String())
 	})
 }
@@ -86,7 +87,7 @@ func TestGroupErrorOnlySwallowsOutputOnNoError(t *testing.T) {
 	_, _ = fmt.Fprintln(stdOut, "std-out")
 	_, _ = fmt.Fprintln(stdErr, "std-err")
 
-	assert.NoError(t, cleanup(nil))
+	require.NoError(t, cleanup(nil))
 	assert.Empty(t, b.String())
 }
 
@@ -100,7 +101,7 @@ func TestGroupErrorOnlyShowsOutputOnError(t *testing.T) {
 	_, _ = fmt.Fprintln(stdOut, "std-out")
 	_, _ = fmt.Fprintln(stdErr, "std-err")
 
-	assert.NoError(t, cleanup(errors.New("any-error")))
+	require.NoError(t, cleanup(errors.New("any-error")))
 	assert.Equal(t, "std-out\nstd-err\n", b.String())
 }
 
@@ -116,7 +117,7 @@ func TestPrefixed(t *testing.T) {
 		assert.Equal(t, "[prefix] foo\n[prefix] bar\n", b.String())
 		fmt.Fprintln(w, "baz")
 		assert.Equal(t, "[prefix] foo\n[prefix] bar\n[prefix] baz\n", b.String())
-		assert.NoError(t, cleanup(nil))
+		require.NoError(t, cleanup(nil))
 	})
 
 	t.Run("multiple writes for a single line", func(t *testing.T) {
@@ -127,7 +128,7 @@ func TestPrefixed(t *testing.T) {
 			assert.Equal(t, "", b.String())
 		}
 
-		assert.NoError(t, cleanup(nil))
+		require.NoError(t, cleanup(nil))
 		assert.Equal(t, "[prefix] Test!\n", b.String())
 	})
 }

--- a/taskfile/platforms_test.go
+++ b/taskfile/platforms_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPlatformParsing(t *testing.T) {
@@ -37,10 +38,10 @@ func TestPlatformParsing(t *testing.T) {
 			err := p.parsePlatform(test.Input)
 
 			if test.Error != "" {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Equal(t, test.Error, err.Error())
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, test.ExpectedOS, p.OS)
 				assert.Equal(t, test.ExpectedArch, p.Arch)
 			}

--- a/taskfile/precondition_test.go
+++ b/taskfile/precondition_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
 	"github.com/go-task/task/v3/taskfile"
@@ -44,7 +45,7 @@ msg: "1 is not 2"
 	}
 	for _, test := range tests {
 		err := yaml.Unmarshal([]byte(test.content), test.v)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, test.expected, test.v)
 	}
 }

--- a/taskfile/taskfile_test.go
+++ b/taskfile/taskfile_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
 	"github.com/go-task/task/v3/taskfile"
@@ -77,7 +78,7 @@ vars:
 	}
 	for _, test := range tests {
 		err := yaml.Unmarshal([]byte(test.content), test.v)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, test.expected, test.v)
 	}
 }

--- a/watch_test.go
+++ b/watch_test.go
@@ -36,11 +36,11 @@ Hello, World!
 		Watch:  true,
 	}
 
-	assert.NoError(t, e.Setup())
+	require.NoError(t, e.Setup())
 	buff.Reset()
 
 	err := os.MkdirAll(filepathext.SmartJoin(dir, "src"), 0755)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = os.WriteFile(filepathext.SmartJoin(dir, "src/a"), []byte("test"), 0644)
 	if err != nil {
@@ -74,7 +74,7 @@ Hello, World!
 	assert.Equal(t, expectedOutput, strings.TrimSpace(buff.String()))
 	buff.Reset()
 	err = os.RemoveAll(filepathext.SmartJoin(dir, ".task"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = os.RemoveAll(filepathext.SmartJoin(dir, "src"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Uses [`github.com/stretchr/testify/require`](https://github.com/stretchr/testify/require) to test errors instead of [`github.com/stretchr/testify/assert`](https://github.com/stretchr/testify/assert). This applies to both `NoError` and `Error` functions.

This means that execution of the test will stop if we get an into an unexpected state and it will stop further cascading error assertions from obscuring the root cause.

The `assert` package is still used everywhere else as this means that we can see when multiple values are incorrect if the test is in a "good" state.