### PR TITLE
Fix fish completions for tasks with aliases

### DIFF
--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -10,7 +10,7 @@ function __task_get_tasks --description "Prints all available tasks with their d
   end
 
   # Grab names and descriptions (if any) of the tasks
-  set -l output (echo $rawOutput | sed '1d; s/\* \(.*\):\s*\(.*\)/\1\t\2/' | string split0)
+  set -l output (echo $rawOutput | sed -e '1d; s/\* \(.*\):\s*\(.*\)\s*(aliases.*/\1\t\2/' -e 's/\* \(.*\):\s*\(.*\)/\1\t\2/'| string split0)
   if test $output
     echo $output
   end


### PR DESCRIPTION
The existing fish completions script is broken when tasks include aliases. This change adds an additional sed replacement to match against commands with aliases.

Here's an example recording with the existing completions, then sourcing and using this fixed version: https://asciinema.org/a/jVlyeadd643J6FC3o5V6927hM

