### PR TITLE
refactor: remove newlines from formatter print functions

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -255,7 +255,7 @@ func run() error {
 	}
 
 	if err := e.Run(ctx, calls...); err != nil {
-		e.Logger.Errf(logger.Red, "%v", err)
+		e.Logger.Errf(logger.Red, "%v\n", err)
 
 		if exitCode {
 			if err, ok := err.(*errors.TaskRunError); ok {

--- a/help.go
+++ b/help.go
@@ -88,24 +88,24 @@ func (e *Executor) ListTasks(o ListOptions) (bool, error) {
 	}
 	if len(tasks) == 0 {
 		if o.ListOnlyTasksWithDescriptions {
-			e.Logger.Outf(logger.Yellow, "task: No tasks with description available. Try --list-all to list all tasks")
+			e.Logger.Outf(logger.Yellow, "task: No tasks with description available. Try --list-all to list all tasks\n")
 		} else if o.ListAllTasks {
-			e.Logger.Outf(logger.Yellow, "task: No tasks available")
+			e.Logger.Outf(logger.Yellow, "task: No tasks available\n")
 		}
 		return false, nil
 	}
-	e.Logger.Outf(logger.Default, "task: Available tasks for this project:")
+	e.Logger.Outf(logger.Default, "task: Available tasks for this project:\n")
 
 	// Format in tab-separated columns with a tab stop of 8.
 	w := tabwriter.NewWriter(e.Stdout, 0, 8, 6, ' ', 0)
 	for _, task := range tasks {
-		e.Logger.FOutf(w, logger.Yellow, "* ")
-		e.Logger.FOutf(w, logger.Green, task.Task)
-		e.Logger.FOutf(w, logger.Default, ": \t%s", task.Desc)
+		e.Logger.Outf(logger.Yellow, "* ")
+		e.Logger.Outf(logger.Green, task.Task)
+		e.Logger.Outf(logger.Default, ": \t%s", task.Desc)
 		if len(task.Aliases) > 0 {
-			e.Logger.FOutf(w, logger.Cyan, "\t(aliases: %s)", strings.Join(task.Aliases, ", "))
+			e.Logger.Outf(logger.Cyan, "\t(aliases: %s)", strings.Join(task.Aliases, ", "))
 		}
-		_, _ = fmt.Fprint(w, "\n")
+		e.Logger.Outf(logger.Default, "\n")
 	}
 	if err := w.Flush(); err != nil {
 		return false, err

--- a/internal/compiler/v2/compiler_v2.go
+++ b/internal/compiler/v2/compiler_v2.go
@@ -117,7 +117,7 @@ func (c *CompilerV2) HandleDynamicVar(v taskfile.Var, _ string) (string, error) 
 	result := strings.TrimSuffix(stdout.String(), "\n")
 
 	c.dynamicCache[v.Sh] = result
-	c.Logger.VerboseErrf(logger.Magenta, `task: dynamic variable: '%s' result: '%s'`, v.Sh, result)
+	c.Logger.VerboseErrf(logger.Magenta, "task: dynamic variable: %q result: %q\n", v.Sh, result)
 
 	return result, nil
 }

--- a/internal/compiler/v3/compiler_v3.go
+++ b/internal/compiler/v3/compiler_v3.go
@@ -161,7 +161,7 @@ func (c *CompilerV3) HandleDynamicVar(v taskfile.Var, dir string) (string, error
 	result = strings.TrimSuffix(result, "\n")
 
 	c.dynamicCache[v.Sh] = result
-	c.Logger.VerboseErrf(logger.Magenta, `task: dynamic variable: '%s' result: '%s'`, v.Sh, result)
+	c.Logger.VerboseErrf(logger.Magenta, "task: dynamic variable: %q result: %q\n", v.Sh, result)
 
 	return result, nil
 }

--- a/internal/fingerprint/status.go
+++ b/internal/fingerprint/status.go
@@ -27,10 +27,10 @@ func (checker *StatusChecker) IsUpToDate(ctx context.Context, t *taskfile.Task) 
 			Env:     env.Get(t),
 		})
 		if err != nil {
-			checker.logger.VerboseOutf(logger.Yellow, "task: status command %s exited non-zero: %s", s, err)
+			checker.logger.VerboseOutf(logger.Yellow, "task: status command %s exited non-zero: %s\n", s, err)
 			return false, nil
 		}
-		checker.logger.VerboseOutf(logger.Yellow, "task: status command %s exited zero", s)
+		checker.logger.VerboseOutf(logger.Yellow, "task: status command %s exited zero\n", s)
 	}
 	return true, nil
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -64,7 +64,7 @@ type Logger struct {
 
 // Outf prints stuff to STDOUT.
 func (l *Logger) Outf(color Color, s string, args ...any) {
-	l.FOutf(l.Stdout, color, s+"\n", args...)
+	l.FOutf(l.Stdout, color, s, args...)
 }
 
 // FOutf prints stuff to the given writer.
@@ -95,7 +95,7 @@ func (l *Logger) Errf(color Color, s string, args ...any) {
 		color = Default
 	}
 	print := color()
-	print(l.Stderr, s+"\n", args...)
+	print(l.Stderr, s, args...)
 }
 
 // VerboseErrf prints stuff to STDERR if verbose mode is enabled.

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -20,8 +20,8 @@ func PrintSpaceBetweenSummaries(l *logger.Logger, i int) {
 		return
 	}
 
-	l.Outf(logger.Default, "")
-	l.Outf(logger.Default, "")
+	l.Outf(logger.Default, "\n")
+	l.Outf(logger.Default, "\n")
 }
 
 func PrintTask(l *logger.Logger, t *taskfile.Task) {
@@ -51,26 +51,26 @@ func printTaskSummary(l *logger.Logger, t *taskfile.Task) {
 	for i, line := range lines {
 		notLastLine := i+1 < len(lines)
 		if notLastLine || line != "" {
-			l.Outf(logger.Default, line)
+			l.Outf(logger.Default, "%s\n", line)
 		}
 	}
 }
 
 func printTaskName(l *logger.Logger, t *taskfile.Task) {
-	l.FOutf(l.Stdout, logger.Default, "task: ")
-	l.FOutf(l.Stdout, logger.Green, "%s\n", t.Name())
-	l.Outf(logger.Default, "")
+	l.Outf(logger.Default, "task: ")
+	l.Outf(logger.Green, "%s\n", t.Name())
+	l.Outf(logger.Default, "\n")
 }
 
 func printTaskAliases(l *logger.Logger, t *taskfile.Task) {
 	if len(t.Aliases) == 0 {
 		return
 	}
-	l.Outf(logger.Default, "")
-	l.Outf(logger.Default, "aliases:")
+	l.Outf(logger.Default, "\n")
+	l.Outf(logger.Default, "aliases:\n")
 	for _, alias := range t.Aliases {
-		l.FOutf(l.Stdout, logger.Default, " - ")
-		l.Outf(logger.Cyan, alias)
+		l.Outf(logger.Default, " - ")
+		l.Outf(logger.Cyan, "%s\n", alias)
 	}
 }
 
@@ -79,11 +79,11 @@ func hasDescription(t *taskfile.Task) bool {
 }
 
 func printTaskDescription(l *logger.Logger, t *taskfile.Task) {
-	l.Outf(logger.Default, t.Desc)
+	l.Outf(logger.Default, "%s\n", t.Desc)
 }
 
 func printNoDescriptionOrSummary(l *logger.Logger) {
-	l.Outf(logger.Default, "(task does not have description or summary)")
+	l.Outf(logger.Default, "(task does not have description or summary)\n")
 }
 
 func printTaskDependencies(l *logger.Logger, t *taskfile.Task) {
@@ -91,11 +91,11 @@ func printTaskDependencies(l *logger.Logger, t *taskfile.Task) {
 		return
 	}
 
-	l.Outf(logger.Default, "")
-	l.Outf(logger.Default, "dependencies:")
+	l.Outf(logger.Default, "\n")
+	l.Outf(logger.Default, "dependencies:\n")
 
 	for _, d := range t.Deps {
-		l.Outf(logger.Default, " - %s", d.Task)
+		l.Outf(logger.Default, " - %s\n", d.Task)
 	}
 }
 
@@ -104,15 +104,15 @@ func printTaskCommands(l *logger.Logger, t *taskfile.Task) {
 		return
 	}
 
-	l.Outf(logger.Default, "")
-	l.Outf(logger.Default, "commands:")
+	l.Outf(logger.Default, "\n")
+	l.Outf(logger.Default, "commands:\n")
 	for _, c := range t.Cmds {
 		isCommand := c.Cmd != ""
-		l.FOutf(l.Stdout, logger.Default, " - ")
+		l.Outf(logger.Default, " - ")
 		if isCommand {
-			l.FOutf(l.Stdout, logger.Yellow, "%s\n", c.Cmd)
+			l.Outf(logger.Yellow, "%s\n", c.Cmd)
 		} else {
-			l.FOutf(l.Stdout, logger.Green, "Task: %s\n", c.Task)
+			l.Outf(logger.Green, "Task: %s\n", c.Task)
 		}
 	}
 }

--- a/precondition.go
+++ b/precondition.go
@@ -21,7 +21,7 @@ func (e *Executor) areTaskPreconditionsMet(ctx context.Context, t *taskfile.Task
 			Env:     env.Get(t),
 		})
 		if err != nil {
-			e.Logger.Errf(logger.Magenta, "task: %s", p.Msg)
+			e.Logger.Errf(logger.Magenta, "task: %s\n", p.Msg)
 			return false, ErrPreconditionFailed
 		}
 	}

--- a/signals.go
+++ b/signals.go
@@ -20,11 +20,11 @@ func (e *Executor) InterceptInterruptSignals() {
 			sig := <-ch
 
 			if i < 3 {
-				e.Logger.Outf(logger.Yellow, `task: Signal received: "%s"`, sig)
+				e.Logger.Outf(logger.Yellow, "task: Signal received: %q\n", sig)
 				continue
 			}
 
-			e.Logger.Errf(logger.Red, `task: Signal received for the third time: "%s". Forcing shutdown`, sig)
+			e.Logger.Errf(logger.Red, "task: Signal received for the third time: %q. Forcing shutdown\n", sig)
 			os.Exit(1)
 		}
 	}()

--- a/task.go
+++ b/task.go
@@ -141,11 +141,11 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 
 	return e.startExecution(ctx, t, func(ctx context.Context) error {
 		if !shouldRunOnCurrentPlatform(t.Platforms) {
-			e.Logger.VerboseOutf(logger.Yellow, `task: "%s" not for current platform - ignored`, call.Task)
+			e.Logger.VerboseOutf(logger.Yellow, `task: %q not for current platform - ignored\n`, call.Task)
 			return nil
 		}
 
-		e.Logger.VerboseErrf(logger.Magenta, `task: "%s" started`, call.Task)
+		e.Logger.VerboseErrf(logger.Magenta, "task: %q started\n", call.Task)
 		if err := e.runDeps(ctx, t); err != nil {
 			return err
 		}
@@ -178,14 +178,14 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 
 			if upToDate && preCondMet {
 				if e.Verbose || (!t.Silent && !e.Taskfile.Silent && !e.Silent) {
-					e.Logger.Errf(logger.Magenta, `task: Task "%s" is up to date`, t.Name())
+					e.Logger.Errf(logger.Magenta, "task: Task %q is up to date\n", t.Name())
 				}
 				return nil
 			}
 		}
 
 		if err := e.mkdir(t); err != nil {
-			e.Logger.Errf(logger.Red, "task: cannot make directory %q: %v", t.Dir, err)
+			e.Logger.Errf(logger.Red, "task: cannot make directory %q: %v\n", t.Dir, err)
 		}
 
 		for i := range t.Cmds {
@@ -196,18 +196,18 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 
 			if err := e.runCommand(ctx, t, call, i); err != nil {
 				if err2 := e.statusOnError(t); err2 != nil {
-					e.Logger.VerboseErrf(logger.Yellow, "task: error cleaning status on error: %v", err2)
+					e.Logger.VerboseErrf(logger.Yellow, "task: error cleaning status on error: %v\n", err2)
 				}
 
 				if execext.IsExitError(err) && t.IgnoreError {
-					e.Logger.VerboseErrf(logger.Yellow, "task: task error ignored: %v", err)
+					e.Logger.VerboseErrf(logger.Yellow, "task: task error ignored: %v\n", err)
 					continue
 				}
 
 				return &errors.TaskRunError{TaskName: t.Task, Err: err}
 			}
 		}
-		e.Logger.VerboseErrf(logger.Magenta, `task: "%s" finished`, call.Task)
+		e.Logger.VerboseErrf(logger.Magenta, "task: %q finished\n", call.Task)
 		return nil
 	})
 }
@@ -255,7 +255,7 @@ func (e *Executor) runDeferred(t *taskfile.Task, call taskfile.Call, i int) {
 	defer cancel()
 
 	if err := e.runCommand(ctx, t, call, i); err != nil {
-		e.Logger.VerboseErrf(logger.Yellow, `task: ignored error in deferred cmd: %s`, err.Error())
+		e.Logger.VerboseErrf(logger.Yellow, "task: ignored error in deferred cmd: %s\n", err.Error())
 	}
 }
 
@@ -274,12 +274,12 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 		return nil
 	case cmd.Cmd != "":
 		if !shouldRunOnCurrentPlatform(cmd.Platforms) {
-			e.Logger.VerboseOutf(logger.Yellow, `task: [%s] %s not for current platform - ignored`, t.Name(), cmd.Cmd)
+			e.Logger.VerboseOutf(logger.Yellow, "task: [%s] %s not for current platform - ignored\n", t.Name(), cmd.Cmd)
 			return nil
 		}
 
 		if e.Verbose || (!cmd.Silent && !t.Silent && !e.Taskfile.Silent && !e.Silent) {
-			e.Logger.Errf(logger.Green, "task: [%s] %s", t.Name(), cmd.Cmd)
+			e.Logger.Errf(logger.Green, "task: [%s] %s\n", t.Name(), cmd.Cmd)
 		}
 
 		if e.Dry {
@@ -308,10 +308,10 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 			Stderr:    stdErr,
 		})
 		if closeErr := close(err); closeErr != nil {
-			e.Logger.Errf(logger.Red, "task: unable to close writer: %v", closeErr)
+			e.Logger.Errf(logger.Red, "task: unable to close writer: %v\n", closeErr)
 		}
 		if execext.IsExitError(err) && cmd.IgnoreError {
-			e.Logger.VerboseErrf(logger.Yellow, "task: [%s] command error ignored: %v", t.Name(), err)
+			e.Logger.VerboseErrf(logger.Yellow, "task: [%s] command error ignored: %v\n", t.Name(), err)
 			return nil
 		}
 		return err
@@ -334,7 +334,7 @@ func (e *Executor) startExecution(ctx context.Context, t *taskfile.Task, execute
 
 	if otherExecutionCtx, ok := e.executionHashes[h]; ok {
 		e.executionHashesMutex.Unlock()
-		e.Logger.VerboseErrf(logger.Magenta, "task: skipping execution of task: %s", h)
+		e.Logger.VerboseErrf(logger.Magenta, "task: skipping execution of task: %s\n", h)
 
 		// Release our execution slot to avoid blocking other tasks while we wait
 		reacquire := e.releaseConcurrencyLimit()

--- a/watch.go
+++ b/watch.go
@@ -34,7 +34,7 @@ func (e *Executor) watchTasks(calls ...taskfile.Call) error {
 		c := c
 		go func() {
 			if err := e.RunTask(ctx, c); err != nil && !isContextError(err) {
-				e.Logger.Errf(logger.Red, "%v", err)
+				e.Logger.Errf(logger.Red, "%v\n", err)
 			}
 		}()
 	}
@@ -49,7 +49,7 @@ func (e *Executor) watchTasks(calls ...taskfile.Call) error {
 		watchInterval = defaultWatchInterval
 	}
 
-	e.Logger.VerboseOutf(logger.Green, "task: Watching for changes every %v", watchInterval)
+	e.Logger.VerboseOutf(logger.Green, "task: Watching for changes every %v\n", watchInterval)
 
 	w := watcher.New()
 	defer w.Close()
@@ -61,7 +61,7 @@ func (e *Executor) watchTasks(calls ...taskfile.Call) error {
 		for {
 			select {
 			case event := <-w.Event:
-				e.Logger.VerboseErrf(logger.Magenta, "task: received watch event: %v", event)
+				e.Logger.VerboseErrf(logger.Magenta, "task: received watch event: %v\n", event)
 
 				cancel()
 				ctx, cancel = context.WithCancel(context.Background())
@@ -72,7 +72,7 @@ func (e *Executor) watchTasks(calls ...taskfile.Call) error {
 					c := c
 					go func() {
 						if err := e.RunTask(ctx, c); err != nil && !isContextError(err) {
-							e.Logger.Errf(logger.Red, "%v", err)
+							e.Logger.Errf(logger.Red, "%v\n", err)
 						}
 					}()
 				}
@@ -80,7 +80,7 @@ func (e *Executor) watchTasks(calls ...taskfile.Call) error {
 				switch err {
 				case watcher.ErrWatchedFileDeleted:
 				default:
-					e.Logger.Errf(logger.Red, "%v", err)
+					e.Logger.Errf(logger.Red, "%v\n", err)
 				}
 			case <-w.Closed:
 				cancel()
@@ -93,7 +93,7 @@ func (e *Executor) watchTasks(calls ...taskfile.Call) error {
 		// re-register every 5 seconds because we can have new files, but this process is expensive to run
 		for {
 			if err := e.registerWatchedFiles(w, calls...); err != nil {
-				e.Logger.Errf(logger.Red, "%v", err)
+				e.Logger.Errf(logger.Red, "%v\n", err)
 			}
 			time.Sleep(watchInterval)
 		}
@@ -161,7 +161,7 @@ func (e *Executor) registerWatchedFiles(w *watcher.Watcher, calls ...taskfile.Ca
 				if err := w.Add(absFile); err != nil {
 					return err
 				}
-				e.Logger.VerboseOutf(logger.Green, "task: watching new file: %v", absFile)
+				e.Logger.VerboseOutf(logger.Green, "task: watching new file: %v\n", absFile)
 			}
 		}
 		return nil


### PR DESCRIPTION
As discussed in #1110.

Simply makes line endings consistent in our format printers which gives a bit more control to the caller of the function.