### PR TITLE
Silenced Calls

### DIFF
--- a/docs/docs/api_reference.md
+++ b/docs/docs/api_reference.md
@@ -280,6 +280,7 @@ tasks:
 | --------- | ---------------------------------- | ------- | -------------------------------------------------------- |
 | `task`    | `string`                           |         | The task to be execute as a dependency.                  |
 | `vars`    | [`map[string]Variable`](#variable) |         | Optional additional variables to be passed to this task. |
+| `silent`  | `bool`                             | `false` | Hides task name and command from output. The command's output will still be redirected to `STDOUT` and `STDERR`. |
 
 :::tip
 

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -468,6 +468,7 @@ tasks:
         vars: { TEXT: 'before 1' }
       - task: echo_sth
         vars: { TEXT: 'before 2' }
+        silent: true
     cmds:
       - echo "after"
 
@@ -574,8 +575,8 @@ tasks:
       - echo "Another task"
 ```
 
-Overriding variables in the called task is as simple as informing `vars`
-attribute:
+Using the `vars` and `silent` attributes you can choose to pass variables and
+toggle [silent mode](#silent-mode) on a call-by-call basis:
 
 ```yaml
 version: '3'
@@ -591,6 +592,7 @@ tasks:
     cmds:
       - task: greet
         vars: { RECIPIENT: 'Cruel World' }
+        silent: true
 ```
 
 The above syntax is also supported in `deps`.

--- a/docs/static/schema.json
+++ b/docs/static/schema.json
@@ -241,6 +241,10 @@
           "vars": {
             "description": "Values passed to the task called",
             "$ref": "#/definitions/3/vars"
+          },
+          "silent": {
+            "description": "Hides task name and command from output. The command's output will still be redirected to `STDOUT` and `STDERR`.",
+            "type": "boolean"
           }
         }
       },

--- a/task.go
+++ b/task.go
@@ -177,7 +177,7 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 			}
 
 			if upToDate && preCondMet {
-				if e.Verbose || (!t.Silent && !e.Taskfile.Silent && !e.Silent) {
+				if e.Verbose || (!call.Silent && !t.Silent && !e.Taskfile.Silent && !e.Silent) {
 					e.Logger.Errf(logger.Magenta, "task: Task %q is up to date\n", t.Name())
 				}
 				return nil
@@ -237,9 +237,8 @@ func (e *Executor) runDeps(ctx context.Context, t *taskfile.Task) error {
 
 	for _, d := range t.Deps {
 		d := d
-
 		g.Go(func() error {
-			err := e.RunTask(ctx, taskfile.Call{Task: d.Task, Vars: d.Vars})
+			err := e.RunTask(ctx, taskfile.Call{Task: d.Task, Vars: d.Vars, Silent: d.Silent})
 			if err != nil {
 				return err
 			}
@@ -267,7 +266,7 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 		reacquire := e.releaseConcurrencyLimit()
 		defer reacquire()
 
-		err := e.RunTask(ctx, taskfile.Call{Task: cmd.Task, Vars: cmd.Vars})
+		err := e.RunTask(ctx, taskfile.Call{Task: cmd.Task, Vars: cmd.Vars, Silent: cmd.Silent})
 		if err != nil {
 			return err
 		}
@@ -278,7 +277,7 @@ func (e *Executor) runCommand(ctx context.Context, t *taskfile.Task, call taskfi
 			return nil
 		}
 
-		if e.Verbose || (!cmd.Silent && !t.Silent && !e.Taskfile.Silent && !e.Silent) {
+		if e.Verbose || (!call.Silent && !cmd.Silent && !t.Silent && !e.Taskfile.Silent && !e.Silent) {
 			e.Logger.Errf(logger.Green, "task: [%s] %s\n", t.Name(), cmd.Cmd)
 		}
 

--- a/task_test.go
+++ b/task_test.go
@@ -1965,4 +1965,26 @@ func TestSilence(t *testing.T) {
 	require.Empty(t, buff.String(), "While running task-test-chatty-calls-silenced-cmd: Expected not to see output. While the task itself is not silenced, its call to the chatty task is silent.")
 
 	buff.Reset()
+
+	// Then test calls via dependencies.
+	// A silent task that depends on a chatty task.
+	err = e.Run(context.Background(), taskfile.Call{Task: "task-test-is-silent-depends-on-chatty-non-silenced"})
+	require.NoError(t, err)
+	require.NotEmpty(t, buff.String(), "While running task-test-is-silent-depends-on-chatty-non-silenced: Expected to see output. The task is silent and depends on a chatty task. Dependencies does not inherit silence.")
+
+	buff.Reset()
+
+	// A silent task that depends on a silenced chatty task.
+	err = e.Run(context.Background(), taskfile.Call{Task: "task-test-is-silent-depends-on-chatty-silenced"})
+	require.NoError(t, err)
+	require.Empty(t, buff.String(), "While running task-test-is-silent-depends-on-chatty-silenced: Expected not to see output. The task is silent and has a silenced dependency on a chatty task.")
+
+	buff.Reset()
+
+	// A chatty task that, depends on a silenced chatty task.
+	err = e.Run(context.Background(), taskfile.Call{Task: "task-test-is-chatty-depends-on-chatty-silenced"})
+	require.NoError(t, err)
+	require.Empty(t, buff.String(), "While running task-test-is-chatty-depends-on-chatty-silenced: Expected not to see output. The task is chatty but does not have commands and has a silenced dependency on a chatty task.")
+
+	buff.Reset()
 }

--- a/taskfile/call.go
+++ b/taskfile/call.go
@@ -2,6 +2,7 @@ package taskfile
 
 // Call is the parameters to a task call
 type Call struct {
-	Task string
-	Vars *Vars
+	Task   string
+	Vars   *Vars
+	Silent bool
 }

--- a/taskfile/cmd.go
+++ b/taskfile/cmd.go
@@ -99,6 +99,7 @@ func (c *Cmd) UnmarshalYAML(node *yaml.Node) error {
 		if err := node.Decode(&taskCall); err == nil && taskCall.Task != "" {
 			c.Task = taskCall.Task
 			c.Vars = taskCall.Vars
+			c.Silent = cmdStruct.Silent
 			return nil
 		}
 

--- a/taskfile/dep.go
+++ b/taskfile/dep.go
@@ -8,8 +8,9 @@ import (
 
 // Dep is a task dependency
 type Dep struct {
-	Task string
-	Vars *Vars
+	Task   string
+	Vars   *Vars
+	Silent bool
 }
 
 func (d *Dep) DeepCopy() *Dep {
@@ -35,14 +36,16 @@ func (d *Dep) UnmarshalYAML(node *yaml.Node) error {
 
 	case yaml.MappingNode:
 		var taskCall struct {
-			Task string
-			Vars *Vars
+			Task   string
+			Vars   *Vars
+			Silent bool
 		}
 		if err := node.Decode(&taskCall); err != nil {
 			return err
 		}
 		d.Task = taskCall.Task
 		d.Vars = taskCall.Vars
+		d.Silent = taskCall.Silent
 		return nil
 	}
 

--- a/testdata/silent/Taskfile.yml
+++ b/testdata/silent/Taskfile.yml
@@ -48,3 +48,24 @@ tasks:
     cmds:
       - cmd: exit 0
         silent: true
+
+  # Now test with dependencies.
+  task-test-is-silent-depends-on-chatty-non-silenced:
+    silent: true
+    deps: [chatty, silent]
+
+  task-test-is-silent-depends-on-chatty-silenced:
+    silent: true
+    deps:
+      - task: chatty
+        silent: true
+      - task: silent
+        silent: false
+
+  task-test-is-chatty-depends-on-chatty-silenced:
+    silent: false
+    deps:
+      - task: chatty
+        silent: true
+      - task: silent
+        silent: false

--- a/testdata/silent/Taskfile.yml
+++ b/testdata/silent/Taskfile.yml
@@ -1,0 +1,50 @@
+version: '3'
+
+tasks:
+  silent:
+    desc: "silent"
+    silent: true
+    cmds:
+      - exit 0
+  chatty:
+    desc: "chatty"
+    silent: false
+    cmds:
+      - exit 0
+
+  # Test combinations of silent and chatty tasks
+  task-test-silent-calls-chatty-non-silenced:
+    silent: true
+    cmds:
+      - task: chatty
+
+  task-test-silent-calls-chatty-silenced:
+    silent: true
+    cmds:
+      - task: chatty
+        silent: true
+
+  task-test-no-cmds-calls-chatty-silenced:
+    silent: false
+    cmds:
+      - task: chatty
+        silent: true
+
+  task-test-chatty-calls-chatty-non-silenced:
+    silent: false
+    cmds:
+      - cmd: exit 0
+      - task: chatty
+
+  task-test-chatty-calls-chatty-silenced:
+    silent: false
+    cmds:
+      - cmd: exit 0
+      - task: chatty
+        silent: true
+
+  task-test-chatty-calls-silenced-cmd:
+    silent: false
+    cmds:
+      - cmd: exit 0
+        silent: true

--- a/variables.go
+++ b/variables.go
@@ -142,8 +142,9 @@ func (e *Executor) compiledTask(call taskfile.Call, evaluateShVars bool) (*taskf
 				continue
 			}
 			new.Deps = append(new.Deps, &taskfile.Dep{
-				Task: r.Replace(dep.Task),
-				Vars: r.ReplaceVars(dep.Vars),
+				Task:   r.Replace(dep.Task),
+				Vars:   r.ReplaceVars(dep.Vars),
+				Silent: dep.Silent,
 			})
 		}
 	}


### PR DESCRIPTION
This PR addresses #680 by fixing a behaviour and introducing a small new feature.

Task now support silencing calls to other calls. The `Cmd` struct already had a Silence field, but it did not actually silence the "task: " output that is produced whenever a task is invoked.

The fix has been implemented by expanding the [`Call`](https://github.com/danquah/task/blob/21a8bb025ba733616cb3abbf84b35a2a82522d74/taskfile/call.go) struct to now also pass a ´Silent` field.

Dependencies are also a type of `Call` and to stay consistent the `Dep` struct has also been expanded with a `Silent` field.