### PR TITLE
fix: tabwriter in usage output

### DIFF
--- a/help.go
+++ b/help.go
@@ -99,13 +99,13 @@ func (e *Executor) ListTasks(o ListOptions) (bool, error) {
 	// Format in tab-separated columns with a tab stop of 8.
 	w := tabwriter.NewWriter(e.Stdout, 0, 8, 6, ' ', 0)
 	for _, task := range tasks {
-		e.Logger.Outf(logger.Yellow, "* ")
-		e.Logger.Outf(logger.Green, task.Task)
-		e.Logger.Outf(logger.Default, ": \t%s", task.Desc)
+		e.Logger.FOutf(w, logger.Yellow, "* ")
+		e.Logger.FOutf(w, logger.Green, task.Task)
+		e.Logger.FOutf(w, logger.Default, ": \t%s", task.Desc)
 		if len(task.Aliases) > 0 {
-			e.Logger.Outf(logger.Cyan, "\t(aliases: %s)", strings.Join(task.Aliases, ", "))
+			e.Logger.FOutf(w, logger.Cyan, "\t(aliases: %s)", strings.Join(task.Aliases, ", "))
 		}
-		e.Logger.Outf(logger.Default, "\n")
+		_, _ = fmt.Fprint(w, "\n")
 	}
 	if err := w.Flush(); err != nil {
 		return false, err


### PR DESCRIPTION
Small bug introduced in #1137 (not yet released) which stopped the usage/help text from using the tabwriter. This stopped it from printing in nice columns.

![image](https://user-images.githubusercontent.com/9294862/236479058-1bfe2b49-a963-460b-a43a-42842a4e4bf5.png)
![image](https://user-images.githubusercontent.com/9294862/236479114-92220a04-ee84-4f26-8da3-cec016a50fff.png)
