### PR TITLE
feat: remote taskfiles (HTTP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-- Prep work for remote Taskfiles (#1316 by @pd93).
+- Prep work for Remote Taskfiles (#1316 by @pd93).
+- Added the
+  [Remote Taskfiles experiment](https://taskfile.dev/experiments/remote-taskfiles)
+  as a draft (#1152, #1317 by @pd93).
 
 ## v3.29.1 - 2023-08-26
 
@@ -42,7 +45,8 @@
 - Bug fixes were made to the
   [npm installation method](https://taskfile.dev/installation/#npm). (#1190, by
   @sounisi5011).
-- Added the [gentle force experiment](https://taskfile.dev/experiments) as a
+- Added the
+  [gentle force experiment](https://taskfile.dev/experiments/gentle-force) as a
   draft (#1200, #1216 by @pd93).
 - Added an `--experiments` flag to allow you to see which experiments are
   enabled (#1242 by @pd93).

--- a/args/args.go
+++ b/args/args.go
@@ -8,7 +8,7 @@ import (
 
 // ParseV3 parses command line argument: tasks and global variables
 func ParseV3(args ...string) ([]taskfile.Call, *taskfile.Vars) {
-	var calls []taskfile.Call
+	calls := []taskfile.Call{}
 	globals := &taskfile.Vars{}
 
 	for _, arg := range args {
@@ -21,16 +21,12 @@ func ParseV3(args ...string) ([]taskfile.Call, *taskfile.Vars) {
 		globals.Set(name, taskfile.Var{Static: value})
 	}
 
-	if len(calls) == 0 {
-		calls = append(calls, taskfile.Call{Task: "default", Direct: true})
-	}
-
 	return calls, globals
 }
 
 // ParseV2 parses command line argument: tasks and vars of each task
 func ParseV2(args ...string) ([]taskfile.Call, *taskfile.Vars) {
-	var calls []taskfile.Call
+	calls := []taskfile.Call{}
 	globals := &taskfile.Vars{}
 
 	for _, arg := range args {
@@ -49,10 +45,6 @@ func ParseV2(args ...string) ([]taskfile.Call, *taskfile.Vars) {
 			name, value := splitVar(arg)
 			calls[len(calls)-1].Vars.Set(name, taskfile.Var{Static: value})
 		}
-	}
-
-	if len(calls) == 0 {
-		calls = append(calls, taskfile.Call{Task: "default", Direct: true})
 	}
 
 	return calls, globals

--- a/args/args_test.go
+++ b/args/args_test.go
@@ -73,22 +73,16 @@ func TestArgsV3(t *testing.T) {
 			},
 		},
 		{
-			Args: nil,
-			ExpectedCalls: []taskfile.Call{
-				{Task: "default", Direct: true},
-			},
+			Args:          nil,
+			ExpectedCalls: []taskfile.Call{},
 		},
 		{
-			Args: []string{},
-			ExpectedCalls: []taskfile.Call{
-				{Task: "default", Direct: true},
-			},
+			Args:          []string{},
+			ExpectedCalls: []taskfile.Call{},
 		},
 		{
-			Args: []string{"FOO=bar", "BAR=baz"},
-			ExpectedCalls: []taskfile.Call{
-				{Task: "default", Direct: true},
-			},
+			Args:          []string{"FOO=bar", "BAR=baz"},
+			ExpectedCalls: []taskfile.Call{},
 			ExpectedGlobals: &taskfile.Vars{
 				OrderedMap: orderedmap.FromMapWithOrder(
 					map[string]taskfile.Var{
@@ -191,22 +185,16 @@ func TestArgsV2(t *testing.T) {
 			},
 		},
 		{
-			Args: nil,
-			ExpectedCalls: []taskfile.Call{
-				{Task: "default", Direct: true},
-			},
+			Args:          nil,
+			ExpectedCalls: []taskfile.Call{},
 		},
 		{
-			Args: []string{},
-			ExpectedCalls: []taskfile.Call{
-				{Task: "default", Direct: true},
-			},
+			Args:          []string{},
+			ExpectedCalls: []taskfile.Call{},
 		},
 		{
-			Args: []string{"FOO=bar", "BAR=baz"},
-			ExpectedCalls: []taskfile.Call{
-				{Task: "default", Direct: true},
-			},
+			Args:          []string{"FOO=bar", "BAR=baz"},
+			ExpectedCalls: []taskfile.Call{},
 			ExpectedGlobals: &taskfile.Vars{
 				OrderedMap: orderedmap.FromMapWithOrder(
 					map[string]taskfile.Var{

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -53,6 +53,7 @@ var flags struct {
 	listJson    bool
 	taskSort    string
 	status      bool
+	insecure    bool
 	force       bool
 	forceAll    bool
 	watch       bool
@@ -112,6 +113,7 @@ func run() error {
 	pflag.BoolVarP(&flags.listJson, "json", "j", false, "Formats task list as JSON.")
 	pflag.StringVar(&flags.taskSort, "sort", "", "Changes the order of the tasks when listed. [default|alphanumeric|none].")
 	pflag.BoolVar(&flags.status, "status", false, "Exits with non-zero exit code if any of the given tasks is not up-to-date.")
+	pflag.BoolVar(&flags.insecure, "insecure", false, "Forces Task to download Taskfiles over insecure connections.")
 	pflag.BoolVarP(&flags.watch, "watch", "w", false, "Enables watch of the given task.")
 	pflag.BoolVarP(&flags.verbose, "verbose", "v", false, "Enables verbose mode.")
 	pflag.BoolVarP(&flags.silent, "silent", "s", false, "Disables echoing.")
@@ -216,6 +218,7 @@ func run() error {
 	e := task.Executor{
 		Force:       flags.force,
 		ForceAll:    flags.forceAll,
+		Insecure:    flags.insecure,
 		Watch:       flags.watch,
 		Verbose:     flags.verbose,
 		Silent:      flags.silent,

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -72,6 +72,8 @@ var flags struct {
 	interval    time.Duration
 	global      bool
 	experiments bool
+	download    bool
+	offline     bool
 }
 
 func main() {
@@ -142,6 +144,12 @@ func run() error {
 		pflag.BoolVarP(&flags.forceAll, "force", "f", false, "Forces execution even when the task is up-to-date.")
 	}
 
+	// Remote Taskfiles experiment will adds the "download" and "offline" flags
+	if experiments.RemoteTaskfiles {
+		pflag.BoolVar(&flags.download, "download", false, "Downloads a cached version of a remote Taskfile.")
+		pflag.BoolVar(&flags.offline, "offline", false, "Forces Task to only use local or cached Taskfiles.")
+	}
+
 	pflag.Parse()
 
 	if flags.version {
@@ -173,6 +181,10 @@ func run() error {
 			log.Fatal(err)
 		}
 		return nil
+	}
+
+	if flags.download && flags.offline {
+		return errors.New("task: You can't set both --download and --offline flags")
 	}
 
 	if flags.global && flags.dir != "" {
@@ -219,6 +231,8 @@ func run() error {
 		Force:       flags.force,
 		ForceAll:    flags.forceAll,
 		Insecure:    flags.insecure,
+		Download:    flags.download,
+		Offline:     flags.offline,
 		Watch:       flags.watch,
 		Verbose:     flags.verbose,
 		Silent:      flags.silent,

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -295,6 +295,13 @@ func run() error {
 		calls, globals = args.ParseV2(tasksAndVars...)
 	}
 
+	// If there are no calls, run the default task instead
+	// Unless the download flag is specified, in which case we want to download
+	// the Taskfile and do nothing else
+	if len(calls) == 0 && !flags.download {
+		calls = append(calls, taskfile.Call{Task: "default", Direct: true})
+	}
+
 	globals.Set("CLI_ARGS", taskfile.Var{Static: cliArgs})
 	e.Taskfile.Vars.Merge(globals)
 

--- a/docs/docs/experiments/remote_taskfiles.md
+++ b/docs/docs/experiments/remote_taskfiles.md
@@ -1,0 +1,81 @@
+---
+slug: /experiments/remote-taskfiles/
+---
+
+# Remote Taskfiles
+
+- Issue: [#1317][remote-taskfiles-experiment]
+- Environment variable: `TASK_X_REMOTE_TASKFILES=1`
+
+This experiment allows you to specify a remote Taskfile URL when including a
+Taskfile. For example:
+
+```yaml
+version: '3'
+
+include:
+  my-remote-namespace: https://raw.githubusercontent.com/my-org/my-repo/main/Taskfile.yml
+```
+
+This works exactly the same way that including a local file does. Any tasks in
+the remote Taskfile will be available to run from your main Taskfile via the
+namespace `my-remote-namespace`. For example, if the remote file contains the
+following:
+
+```yaml
+version: '3'
+
+tasks:
+  hello:
+    silent: true
+    cmds:
+      - echo "Hello from the remote Taskfile!"
+```
+
+and you run `task my-remote-namespace:hello`, it will print the text: "Hello
+from the remote Taskfile!" to your console.
+
+## Security
+
+Running commands from sources that you do not control is always a potential
+security risk. For this reason, we have added some checks when using remote
+Taskfiles:
+
+1. When running a task from a remote Taskfile for the first time, Task will
+   print a warning to the console asking you to check that you are sure that you
+   trust the source of the Taskfile. If you do not accept the prompt, then Task
+   will exit with code `104` (not trusted) and nothing will run. If you accept
+   the prompt, the remote Taskfile will run and further calls to the remote
+   Taskfile will not prompt you again.
+2. Whenever you run a remote Taskfile, Task will create and store a checksum of
+   the file that you are running. If the checksum changes, then Task will print
+   another warning to the console to inform you that the contents of the remote
+   file has changed. If you do not accept the prompt, then Task will exit with
+   code `104` (not trusted) and nothing will run. If you accept the prompt, the
+   checksum will be updated and the remote Taskfile will run.
+
+Task currently supports both `http` and `https` URLs. However, the `http`
+requests will not execute by default unless you run the task with the
+`--insecure` flag. This is to protect you from accidentally running a remote
+Taskfile that is hosted on and unencrypted connection. Sources that are not
+protected by TLS are vulnerable to [man-in-the-middle
+attacks][man-in-the-middle-attacks] and should be avoided unless you know what
+you are doing.
+
+## Caching & Running Offline
+
+If for whatever reason, you don't have access to the internet, but you still
+need to be able to run your tasks, you are able to use the `--download` flag to
+store a cached copy of the remote Taskfile.
+
+<!-- TODO: The following behavior may change -->
+
+If Task detects that you have a local copy of the remote Taskfile, it will use
+your local copy instead of downloading the remote file. You can force Task to
+work offline by using the `--offline` flag. This will prevent Task from making
+any calls to remote sources.
+
+<!-- prettier-ignore-start -->
+[remote-taskfiles-experiment]: https://github.com/go-task/task/issues/1317
+[man-in-the-middle-attacks]: https://en.wikipedia.org/wiki/Man-in-the-middle_attack
+<!-- prettier-ignore-end -->

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -13,6 +13,7 @@ const (
 	CodeTaskfileNotFound int = iota + 100
 	CodeTaskfileAlreadyExists
 	CodeTaskfileInvalid
+	CodeTaskfileFetchFailed
 	CodeTaskfileNotTrusted
 	CodeTaskfileNotSecure
 )

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -14,6 +14,7 @@ const (
 	CodeTaskfileAlreadyExists
 	CodeTaskfileInvalid
 	CodeTaskfileNotTrusted
+	CodeTaskfileNotSecure
 )
 
 // Task related exit codes

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -45,10 +45,12 @@ func New(text string) error {
 	return errors.New(text)
 }
 
+// Is wraps the standard errors.Is function so that we don't need to alias that package.
 func Is(err, target error) bool {
 	return errors.Is(err, target)
 }
 
+// As wraps the standard errors.As function so that we don't need to alias that package.
 func As(err error, target any) bool {
 	return errors.As(err, target)
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -13,6 +13,7 @@ const (
 	CodeTaskfileNotFound int = iota + 100
 	CodeTaskfileAlreadyExists
 	CodeTaskfileInvalid
+	CodeTaskfileNotTrusted
 )
 
 // Task related exit codes
@@ -39,4 +40,12 @@ type TaskError interface {
 // errors.New function so that we don't need to alias that package.
 func New(text string) error {
 	return errors.New(text)
+}
+
+func Is(err, target error) bool {
+	return errors.Is(err, target)
+}
+
+func As(err error, target any) bool {
+	return errors.As(err, target)
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -16,6 +16,7 @@ const (
 	CodeTaskfileFetchFailed
 	CodeTaskfileNotTrusted
 	CodeTaskfileNotSecure
+	CodeTaskfileCacheNotFound
 )
 
 // Task related exit codes

--- a/errors/errors_taskfile.go
+++ b/errors/errors_taskfile.go
@@ -66,3 +66,20 @@ func (err *TaskfileNotTrustedError) Error() string {
 func (err *TaskfileNotTrustedError) Code() int {
 	return CodeTaskfileNotTrusted
 }
+
+// TaskfileNotSecureError is returned when the user attempts to download a
+// remote Taskfile over an insecure connection.
+type TaskfileNotSecureError struct {
+	URI string
+}
+
+func (err *TaskfileNotSecureError) Error() string {
+	return fmt.Sprintf(
+		`task: Taskfile %q cannot be downloaded over an insecure connection. You can override this by using the --insecure flag`,
+		err.URI,
+	)
+}
+
+func (err *TaskfileNotSecureError) Code() int {
+	return CodeTaskfileNotSecure
+}

--- a/errors/errors_taskfile.go
+++ b/errors/errors_taskfile.go
@@ -49,3 +49,20 @@ func (err TaskfileInvalidError) Error() string {
 func (err TaskfileInvalidError) Code() int {
 	return CodeTaskfileInvalid
 }
+
+// TaskfileNotTrustedError is returned when the user does not accept the trust
+// prompt when downloading a remote Taskfile.
+type TaskfileNotTrustedError struct {
+	URI string
+}
+
+func (err *TaskfileNotTrustedError) Error() string {
+	return fmt.Sprintf(
+		`task: Taskfile %q not trusted by user`,
+		err.URI,
+	)
+}
+
+func (err *TaskfileNotTrustedError) Code() int {
+	return CodeTaskfileNotTrusted
+}

--- a/errors/errors_taskfile.go
+++ b/errors/errors_taskfile.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // TaskfileNotFoundError is returned when no appropriate Taskfile is found when
@@ -16,7 +17,7 @@ func (err TaskfileNotFoundError) Error() string {
 	if err.Walk {
 		walkText = " (or any of the parent directories)"
 	}
-	return fmt.Sprintf(`task: No Taskfile found at "%s"%s`, err.URI, walkText)
+	return fmt.Sprintf(`task: No Taskfile found at %q%s`, err.URI, walkText)
 }
 
 func (err TaskfileNotFoundError) Code() int {
@@ -48,6 +49,25 @@ func (err TaskfileInvalidError) Error() string {
 
 func (err TaskfileInvalidError) Code() int {
 	return CodeTaskfileInvalid
+}
+
+// TaskfileFetchFailedError is returned when no appropriate Taskfile is found when
+// searching the filesystem.
+type TaskfileFetchFailedError struct {
+	URI            string
+	HTTPStatusCode int
+}
+
+func (err TaskfileFetchFailedError) Error() string {
+	var statusText string
+	if err.HTTPStatusCode != 0 {
+		statusText = fmt.Sprintf(" with status code %d (%s)", err.HTTPStatusCode, http.StatusText(err.HTTPStatusCode))
+	}
+	return fmt.Sprintf(`task: Download of %q failed%s`, err.URI, statusText)
+}
+
+func (err TaskfileFetchFailedError) Code() int {
+	return CodeTaskfileFetchFailed
 }
 
 // TaskfileNotTrustedError is returned when the user does not accept the trust

--- a/errors/errors_taskfile.go
+++ b/errors/errors_taskfile.go
@@ -103,3 +103,20 @@ func (err *TaskfileNotSecureError) Error() string {
 func (err *TaskfileNotSecureError) Code() int {
 	return CodeTaskfileNotSecure
 }
+
+// TaskfileCacheNotFound is returned when the user attempts to use an offline
+// (cached) Taskfile but the files does not exist in the cache.
+type TaskfileCacheNotFound struct {
+	URI string
+}
+
+func (err *TaskfileCacheNotFound) Error() string {
+	return fmt.Sprintf(
+		`task: Taskfile %q was not found in the cache. Remove the --offline flag to use a remote copy or download it using the --download flag`,
+		err.URI,
+	)
+}
+
+func (err *TaskfileCacheNotFound) Code() int {
+	return CodeTaskfileCacheNotFound
+}

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -2,6 +2,7 @@ package experiments
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -13,11 +14,16 @@ import (
 
 const envPrefix = "TASK_X_"
 
-var GentleForce bool
+// A list of experiments.
+var (
+	GentleForce     bool
+	RemoteTaskfiles bool
+)
 
 func init() {
 	readDotEnv()
 	GentleForce = parseEnv("GENTLE_FORCE")
+	RemoteTaskfiles = parseEnv("REMOTE_TASKFILES")
 }
 
 func parseEnv(xName string) bool {
@@ -35,10 +41,15 @@ func readDotEnv() {
 	}
 }
 
-func List(l *logger.Logger) error {
-	w := tabwriter.NewWriter(os.Stdout, 0, 8, 6, ' ', 0)
+func printExperiment(w io.Writer, l *logger.Logger, name string, value bool) {
 	l.FOutf(w, logger.Yellow, "* ")
-	l.FOutf(w, logger.Green, "GENTLE_FORCE")
-	l.FOutf(w, logger.Default, ": \t%t\n", GentleForce)
+	l.FOutf(w, logger.Green, name)
+	l.FOutf(w, logger.Default, ": \t%t\n", value)
+}
+
+func List(l *logger.Logger) error {
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 0, ' ', 0)
+	printExperiment(w, l, "GENTLE_FORCE", GentleForce)
+	printExperiment(w, l, "REMOTE_TASKFILES", RemoteTaskfiles)
 	return w.Flush()
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,11 +1,14 @@
 package logger
 
 import (
+	"bufio"
 	"io"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/fatih/color"
+	"golang.org/x/exp/slices"
 )
 
 type (
@@ -103,4 +106,18 @@ func (l *Logger) VerboseErrf(color Color, s string, args ...any) {
 	if l.Verbose {
 		l.Errf(color, s, args...)
 	}
+}
+
+func (l *Logger) Prompt(color Color, s string, defaultValue string, continueValues ...string) (bool, error) {
+	if len(continueValues) == 0 {
+		return false, nil
+	}
+	l.Outf(color, "%s [%s/%s]\n", s, strings.ToLower(continueValues[0]), strings.ToUpper(defaultValue))
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+	input = strings.TrimSpace(strings.ToLower(input))
+	return slices.Contains(continueValues, input), nil
 }

--- a/setup.go
+++ b/setup.go
@@ -76,7 +76,7 @@ func (e *Executor) readTaskfile() error {
 	e.Taskfile, err = read.Taskfile(&read.FileNode{
 		Dir:        e.Dir,
 		Entrypoint: e.Entrypoint,
-	}, e.TempDir, e.Logger)
+	}, e.Insecure, e.TempDir, e.Logger)
 	if err != nil {
 		return err
 	}

--- a/setup.go
+++ b/setup.go
@@ -26,16 +26,13 @@ func (e *Executor) Setup() error {
 	if err := e.setCurrentDir(); err != nil {
 		return err
 	}
-
-	if err := e.readTaskfile(); err != nil {
-		return err
-	}
-
-	e.setupFuzzyModel()
-
 	if err := e.setupTempDir(); err != nil {
 		return err
 	}
+	if err := e.readTaskfile(); err != nil {
+		return err
+	}
+	e.setupFuzzyModel()
 	e.setupStdFiles()
 	e.setupLogger()
 	if err := e.setupOutput(); err != nil {
@@ -79,7 +76,7 @@ func (e *Executor) readTaskfile() error {
 	e.Taskfile, err = read.Taskfile(&read.FileNode{
 		Dir:        e.Dir,
 		Entrypoint: e.Entrypoint,
-	})
+	}, e.TempDir, e.Logger)
 	if err != nil {
 		return err
 	}

--- a/setup.go
+++ b/setup.go
@@ -73,10 +73,17 @@ func (e *Executor) setCurrentDir() error {
 
 func (e *Executor) readTaskfile() error {
 	var err error
-	e.Taskfile, err = read.Taskfile(&read.FileNode{
-		Dir:        e.Dir,
-		Entrypoint: e.Entrypoint,
-	}, e.Insecure, e.TempDir, e.Logger)
+	e.Taskfile, err = read.Taskfile(
+		&read.FileNode{
+			Dir:        e.Dir,
+			Entrypoint: e.Entrypoint,
+		},
+		e.Insecure,
+		e.Download,
+		e.Offline,
+		e.TempDir,
+		e.Logger,
+	)
 	if err != nil {
 		return err
 	}

--- a/setup.go
+++ b/setup.go
@@ -72,12 +72,13 @@ func (e *Executor) setCurrentDir() error {
 }
 
 func (e *Executor) readTaskfile() error {
-	var err error
+	uri := filepath.Join(e.Dir, e.Entrypoint)
+	node, err := read.NewNode(uri, e.Insecure)
+	if err != nil {
+		return err
+	}
 	e.Taskfile, err = read.Taskfile(
-		&read.FileNode{
-			Dir:        e.Dir,
-			Entrypoint: e.Entrypoint,
-		},
+		node,
 		e.Insecure,
 		e.Download,
 		e.Offline,
@@ -87,7 +88,6 @@ func (e *Executor) readTaskfile() error {
 	if err != nil {
 		return err
 	}
-	e.Dir = filepath.Dir(e.Taskfile.Location)
 	return nil
 }
 

--- a/setup.go
+++ b/setup.go
@@ -23,6 +23,7 @@ import (
 )
 
 func (e *Executor) Setup() error {
+	e.setupLogger()
 	if err := e.setCurrentDir(); err != nil {
 		return err
 	}
@@ -34,7 +35,6 @@ func (e *Executor) Setup() error {
 	}
 	e.setupFuzzyModel()
 	e.setupStdFiles()
-	e.setupLogger()
 	if err := e.setupOutput(); err != nil {
 		return err
 	}

--- a/task.go
+++ b/task.go
@@ -51,6 +51,7 @@ type Executor struct {
 	Entrypoint  string
 	Force       bool
 	ForceAll    bool
+	Insecure    bool
 	Watch       bool
 	Verbose     bool
 	Silent      bool

--- a/task.go
+++ b/task.go
@@ -52,6 +52,8 @@ type Executor struct {
 	Force       bool
 	ForceAll    bool
 	Insecure    bool
+	Download    bool
+	Offline     bool
 	Watch       bool
 	Verbose     bool
 	Silent      bool

--- a/task_test.go
+++ b/task_test.go
@@ -704,6 +704,7 @@ func TestPromptWithIndirectTask(t *testing.T) {
 	const dir = "testdata/prompt"
 	var inBuff bytes.Buffer
 	var outBuff bytes.Buffer
+	var errBuff bytes.Buffer
 
 	inBuff.Write([]byte("y\n"))
 
@@ -711,6 +712,7 @@ func TestPromptWithIndirectTask(t *testing.T) {
 		Dir:         dir,
 		Stdin:       &inBuff,
 		Stdout:      &outBuff,
+		Stderr:      &errBuff,
 		AssumesTerm: true,
 	}
 	require.NoError(t, e.Setup())
@@ -734,6 +736,7 @@ func TestPromptAssumeYes(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var inBuff bytes.Buffer
 			var outBuff bytes.Buffer
+			var errBuff bytes.Buffer
 
 			// always cancel the prompt so we can require.Error
 			inBuff.Write([]byte("\n"))
@@ -742,6 +745,7 @@ func TestPromptAssumeYes(t *testing.T) {
 				Dir:       dir,
 				Stdin:     &inBuff,
 				Stdout:    &outBuff,
+				Stderr:    &errBuff,
 				AssumeYes: test.assumeYes,
 			}
 			require.NoError(t, e.Setup())

--- a/task_test.go
+++ b/task_test.go
@@ -676,6 +676,7 @@ func TestPromptInSummary(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var inBuff bytes.Buffer
 			var outBuff bytes.Buffer
+			var errBuff bytes.Buffer
 
 			inBuff.Write([]byte(test.input))
 
@@ -683,6 +684,7 @@ func TestPromptInSummary(t *testing.T) {
 				Dir:         dir,
 				Stdin:       &inBuff,
 				Stdout:      &outBuff,
+				Stderr:      &errBuff,
 				AssumesTerm: true,
 			}
 			require.NoError(t, e.Setup())

--- a/taskfile/included_taskfile.go
+++ b/taskfile/included_taskfile.go
@@ -3,6 +3,7 @@ package taskfile
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
@@ -148,6 +149,11 @@ func (it *IncludedTaskfile) FullDirPath() (string, error) {
 }
 
 func (it *IncludedTaskfile) resolvePath(path string) (string, error) {
+	// If the file is remote, we don't need to resolve the path
+	if strings.Contains(it.Taskfile, "://") {
+		return path, nil
+	}
+
 	path, err := execext.Expand(path)
 	if err != nil {
 		return "", err

--- a/taskfile/read/cache.go
+++ b/taskfile/read/cache.go
@@ -2,7 +2,6 @@ package read
 
 import (
 	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,7 +25,7 @@ func NewCache(dir string) (*Cache, error) {
 func checksum(b []byte) string {
 	h := sha256.New()
 	h.Write(b)
-	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
 func (c *Cache) write(node Node, b []byte) error {

--- a/taskfile/read/cache.go
+++ b/taskfile/read/cache.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type Cache struct {
@@ -22,7 +23,7 @@ func NewCache(dir string) (*Cache, error) {
 	}, nil
 }
 
-func (c *Cache) checksum(b []byte) string {
+func checksum(b []byte) string {
 	h := sha256.New()
 	h.Write(b)
 	return base64.StdEncoding.EncodeToString(h.Sum(nil))
@@ -46,7 +47,7 @@ func (c *Cache) readChecksum(node Node) string {
 }
 
 func (c *Cache) key(node Node) string {
-	return base64.StdEncoding.EncodeToString([]byte(node.Location()))
+	return strings.TrimRight(checksum([]byte(node.Location())), "=")
 }
 
 func (c *Cache) cacheFilePath(node Node) string {

--- a/taskfile/read/cache.go
+++ b/taskfile/read/cache.go
@@ -1,0 +1,58 @@
+package read
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type Cache struct {
+	dir string
+}
+
+func NewCache(dir string) (*Cache, error) {
+	dir = filepath.Join(dir, "remote")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	return &Cache{
+		dir: dir,
+	}, nil
+}
+
+func (c *Cache) checksum(b []byte) string {
+	h := sha256.New()
+	h.Write(b)
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+func (c *Cache) write(node Node, b []byte) error {
+	return os.WriteFile(c.cacheFilePath(node), b, 0o644)
+}
+
+func (c *Cache) read(node Node) ([]byte, error) {
+	return os.ReadFile(c.cacheFilePath(node))
+}
+
+func (c *Cache) writeChecksum(node Node, checksum string) error {
+	return os.WriteFile(c.checksumFilePath(node), []byte(checksum), 0o644)
+}
+
+func (c *Cache) readChecksum(node Node) string {
+	b, _ := os.ReadFile(c.checksumFilePath(node))
+	return string(b)
+}
+
+func (c *Cache) key(node Node) string {
+	return base64.StdEncoding.EncodeToString([]byte(node.Location()))
+}
+
+func (c *Cache) cacheFilePath(node Node) string {
+	return filepath.Join(c.dir, fmt.Sprintf("%s.yaml", c.key(node)))
+}
+
+func (c *Cache) checksumFilePath(node Node) string {
+	return filepath.Join(c.dir, fmt.Sprintf("%s.checksum", c.key(node)))
+}

--- a/taskfile/read/node.go
+++ b/taskfile/read/node.go
@@ -1,6 +1,7 @@
 package read
 
 import (
+	"context"
 	"strings"
 
 	"github.com/go-task/task/v3/errors"
@@ -10,7 +11,7 @@ import (
 )
 
 type Node interface {
-	Read() ([]byte, error)
+	Read(ctx context.Context) ([]byte, error)
 	Parent() Node
 	Optional() bool
 	Location() string

--- a/taskfile/read/node.go
+++ b/taskfile/read/node.go
@@ -3,6 +3,7 @@ package read
 import (
 	"strings"
 
+	"github.com/go-task/task/v3/internal/logger"
 	"github.com/go-task/task/v3/taskfile"
 )
 
@@ -13,9 +14,10 @@ type Node interface {
 	Location() string
 }
 
-func NewNodeFromIncludedTaskfile(parent Node, includedTaskfile taskfile.IncludedTaskfile) (Node, error) {
+func NewNodeFromIncludedTaskfile(parent Node, includedTaskfile taskfile.IncludedTaskfile, tempDir string, l *logger.Logger) (Node, error) {
 	switch getScheme(includedTaskfile.Taskfile) {
-	// TODO: Add support for other schemes.
+	case "https":
+		return NewHTTPNode(parent, includedTaskfile.Taskfile, includedTaskfile.Optional, tempDir, l)
 	// If no other scheme matches, we assume it's a file.
 	// This also allows users to explicitly set a file:// scheme.
 	default:

--- a/taskfile/read/node.go
+++ b/taskfile/read/node.go
@@ -12,24 +12,23 @@ type Node interface {
 	Read(ctx context.Context) ([]byte, error)
 	Parent() Node
 	Location() string
+	Optional() bool
 	Remote() bool
 }
 
 func NewNode(
-	parent Node,
 	uri string,
-	allowInsecure bool,
+	insecure bool,
+	opts ...NodeOption,
 ) (Node, error) {
 	var node Node
 	var err error
 	switch getScheme(uri) {
-	case "http":
-		node, err = NewHTTPNode(parent, uri, allowInsecure)
-	case "https":
-		node, err = NewHTTPNode(parent, uri, allowInsecure)
+	case "http", "https":
+		node, err = NewHTTPNode(uri, insecure, opts...)
 	default:
 		// If no other scheme matches, we assume it's a file
-		node, err = NewFileNode(parent, uri)
+		node, err = NewFileNode(uri, opts...)
 	}
 	if node.Remote() && !experiments.RemoteTaskfiles {
 		return nil, errors.New("task: Remote taskfiles are not enabled. You can read more about this experiment and how to enable it at https://taskfile.dev/experiments/remote-taskfiles")

--- a/taskfile/read/node.go
+++ b/taskfile/read/node.go
@@ -13,7 +13,6 @@ import (
 type Node interface {
 	Read(ctx context.Context) ([]byte, error)
 	Parent() Node
-	Optional() bool
 	Location() string
 	Remote() bool
 }
@@ -30,16 +29,16 @@ func NewNodeFromIncludedTaskfile(
 		if err != nil {
 			return nil, err
 		}
-		return NewFileNode(parent, path, includedTaskfile.Optional)
+		return NewFileNode(parent, path)
 	}
 	switch getScheme(includedTaskfile.Taskfile) {
 	case "http":
 		if !allowInsecure {
 			return nil, &errors.TaskfileNotSecureError{URI: includedTaskfile.Taskfile}
 		}
-		return NewHTTPNode(parent, includedTaskfile.Taskfile, includedTaskfile.Optional)
+		return NewHTTPNode(parent, includedTaskfile.Taskfile)
 	case "https":
-		return NewHTTPNode(parent, includedTaskfile.Taskfile, includedTaskfile.Optional)
+		return NewHTTPNode(parent, includedTaskfile.Taskfile)
 	// If no other scheme matches, we assume it's a file.
 	// This also allows users to explicitly set a file:// scheme.
 	default:
@@ -47,7 +46,7 @@ func NewNodeFromIncludedTaskfile(
 		if err != nil {
 			return nil, err
 		}
-		return NewFileNode(parent, path, includedTaskfile.Optional)
+		return NewFileNode(parent, path)
 	}
 }
 

--- a/taskfile/read/node.go
+++ b/taskfile/read/node.go
@@ -10,14 +10,20 @@ import (
 )
 
 type Node interface {
-	Read() (*taskfile.Taskfile, error)
+	Read() ([]byte, error)
 	Parent() Node
 	Optional() bool
 	Location() string
+	Remote() bool
 }
 
-func NewNodeFromIncludedTaskfile(parent Node, includedTaskfile taskfile.IncludedTaskfile, allowInsecure bool, tempDir string, l *logger.Logger) (Node, error) {
-	// TODO: Remove this condition when the remote taskfiles experiment is complete
+func NewNodeFromIncludedTaskfile(
+	parent Node,
+	includedTaskfile taskfile.IncludedTaskfile,
+	allowInsecure bool,
+	tempDir string,
+	l *logger.Logger,
+) (Node, error) {
 	if !experiments.RemoteTaskfiles {
 		path, err := includedTaskfile.FullTaskfilePath()
 		if err != nil {
@@ -30,9 +36,9 @@ func NewNodeFromIncludedTaskfile(parent Node, includedTaskfile taskfile.Included
 		if !allowInsecure {
 			return nil, &errors.TaskfileNotSecureError{URI: includedTaskfile.Taskfile}
 		}
-		return NewHTTPNode(parent, includedTaskfile.Taskfile, includedTaskfile.Optional, tempDir, l)
+		return NewHTTPNode(parent, includedTaskfile.Taskfile, includedTaskfile.Optional)
 	case "https":
-		return NewHTTPNode(parent, includedTaskfile.Taskfile, includedTaskfile.Optional, tempDir, l)
+		return NewHTTPNode(parent, includedTaskfile.Taskfile, includedTaskfile.Optional)
 	// If no other scheme matches, we assume it's a file.
 	// This also allows users to explicitly set a file:// scheme.
 	default:

--- a/taskfile/read/node.go
+++ b/taskfile/read/node.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/go-task/task/v3/errors"
+	"github.com/go-task/task/v3/internal/experiments"
 	"github.com/go-task/task/v3/internal/logger"
 	"github.com/go-task/task/v3/taskfile"
 )
@@ -16,6 +17,14 @@ type Node interface {
 }
 
 func NewNodeFromIncludedTaskfile(parent Node, includedTaskfile taskfile.IncludedTaskfile, allowInsecure bool, tempDir string, l *logger.Logger) (Node, error) {
+	// TODO: Remove this condition when the remote taskfiles experiment is complete
+	if !experiments.RemoteTaskfiles {
+		path, err := includedTaskfile.FullTaskfilePath()
+		if err != nil {
+			return nil, err
+		}
+		return NewFileNode(parent, path, includedTaskfile.Optional)
+	}
 	switch getScheme(includedTaskfile.Taskfile) {
 	case "http":
 		if !allowInsecure {

--- a/taskfile/read/node_base.go
+++ b/taskfile/read/node_base.go
@@ -1,13 +1,47 @@
 package read
 
-// BaseNode is a generic node that implements the Parent() and Optional()
-// methods of the NodeReader interface. It does not implement the Read() method
-// and it designed to be embedded in other node types so that this boilerplate
-// code does not need to be repeated.
-type BaseNode struct {
-	parent Node
+type (
+	NodeOption func(*BaseNode)
+	// BaseNode is a generic node that implements the Parent() and Optional()
+	// methods of the NodeReader interface. It does not implement the Read() method
+	// and it designed to be embedded in other node types so that this boilerplate
+	// code does not need to be repeated.
+	BaseNode struct {
+		parent   Node
+		optional bool
+	}
+)
+
+func NewBaseNode(opts ...NodeOption) *BaseNode {
+	node := &BaseNode{
+		parent:   nil,
+		optional: false,
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(node)
+	}
+
+	return node
+}
+
+func WithParent(parent Node) NodeOption {
+	return func(node *BaseNode) {
+		node.parent = parent
+	}
 }
 
 func (node *BaseNode) Parent() Node {
 	return node.parent
+}
+
+func WithOptional(optional bool) NodeOption {
+	return func(node *BaseNode) {
+		node.optional = optional
+	}
+}
+
+func (node *BaseNode) Optional() bool {
+	return node.optional
 }

--- a/taskfile/read/node_base.go
+++ b/taskfile/read/node_base.go
@@ -5,14 +5,9 @@ package read
 // and it designed to be embedded in other node types so that this boilerplate
 // code does not need to be repeated.
 type BaseNode struct {
-	parent   Node
-	optional bool
+	parent Node
 }
 
 func (node *BaseNode) Parent() Node {
 	return node.parent
-}
-
-func (node *BaseNode) Optional() bool {
-	return node.optional
 }

--- a/taskfile/read/node_file.go
+++ b/taskfile/read/node_file.go
@@ -1,14 +1,11 @@
 package read
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 
-	"gopkg.in/yaml.v3"
-
-	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/filepathext"
-	"github.com/go-task/task/v3/taskfile"
 )
 
 // A FileNode is a node that reads a taskfile from the local filesystem.
@@ -38,7 +35,11 @@ func (node *FileNode) Location() string {
 	return filepathext.SmartJoin(node.Dir, node.Entrypoint)
 }
 
-func (node *FileNode) Read() (*taskfile.Taskfile, error) {
+func (node *FileNode) Remote() bool {
+	return false
+}
+
+func (node *FileNode) Read() ([]byte, error) {
 	if node.Dir == "" {
 		d, err := os.Getwd()
 		if err != nil {
@@ -60,11 +61,5 @@ func (node *FileNode) Read() (*taskfile.Taskfile, error) {
 	}
 	defer f.Close()
 
-	var t taskfile.Taskfile
-	if err := yaml.NewDecoder(f).Decode(&t); err != nil {
-		return nil, &errors.TaskfileInvalidError{URI: filepathext.TryAbsToRel(path), Err: err}
-	}
-
-	t.Location = path
-	return &t, nil
+	return io.ReadAll(f)
 }

--- a/taskfile/read/node_file.go
+++ b/taskfile/read/node_file.go
@@ -16,12 +16,11 @@ type FileNode struct {
 	Entrypoint string
 }
 
-func NewFileNode(parent Node, path string) (*FileNode, error) {
-	path, err := exists(path)
+func NewFileNode(parent Node, uri string) (*FileNode, error) {
+	path, err := exists(uri)
 	if err != nil {
 		return nil, err
 	}
-
 	return &FileNode{
 		BaseNode: BaseNode{
 			parent: parent,

--- a/taskfile/read/node_file.go
+++ b/taskfile/read/node_file.go
@@ -1,6 +1,7 @@
 package read
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -39,7 +40,7 @@ func (node *FileNode) Remote() bool {
 	return false
 }
 
-func (node *FileNode) Read() ([]byte, error) {
+func (node *FileNode) Read(ctx context.Context) ([]byte, error) {
 	if node.Dir == "" {
 		d, err := os.Getwd()
 		if err != nil {

--- a/taskfile/read/node_file.go
+++ b/taskfile/read/node_file.go
@@ -16,7 +16,7 @@ type FileNode struct {
 	Entrypoint string
 }
 
-func NewFileNode(parent Node, path string, optional bool) (*FileNode, error) {
+func NewFileNode(parent Node, path string) (*FileNode, error) {
 	path, err := exists(path)
 	if err != nil {
 		return nil, err
@@ -24,8 +24,7 @@ func NewFileNode(parent Node, path string, optional bool) (*FileNode, error) {
 
 	return &FileNode{
 		BaseNode: BaseNode{
-			parent:   parent,
-			optional: optional,
+			parent: parent,
 		},
 		Dir:        filepath.Dir(path),
 		Entrypoint: filepath.Base(path),

--- a/taskfile/read/node_http.go
+++ b/taskfile/read/node_http.go
@@ -48,12 +48,15 @@ func (node *HTTPNode) Location() string {
 func (node *HTTPNode) Read() (*taskfile.Taskfile, error) {
 	resp, err := http.Get(node.URL.String())
 	if err != nil {
-		return nil, errors.TaskfileNotFoundError{URI: node.URL.String()}
+		return nil, errors.TaskfileFetchFailedError{URI: node.URL.String()}
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.TaskfileNotFoundError{URI: node.URL.String()}
+		return nil, errors.TaskfileFetchFailedError{
+			URI:            node.URL.String(),
+			HTTPStatusCode: resp.StatusCode,
+		}
 	}
 
 	// Read the entire response body

--- a/taskfile/read/node_http.go
+++ b/taskfile/read/node_http.go
@@ -1,0 +1,124 @@
+package read
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/go-task/task/v3/errors"
+	"github.com/go-task/task/v3/internal/logger"
+	"github.com/go-task/task/v3/taskfile"
+)
+
+// An HTTPNode is a node that reads a Taskfile from a remote location via HTTP.
+type HTTPNode struct {
+	BaseNode
+	Logger  *logger.Logger
+	URL     *url.URL
+	TempDir string
+}
+
+func NewHTTPNode(parent Node, urlString string, optional bool, tempDir string, l *logger.Logger) (*HTTPNode, error) {
+	url, err := url.Parse(urlString)
+	if err != nil {
+		return nil, err
+	}
+	return &HTTPNode{
+		BaseNode: BaseNode{
+			parent:   parent,
+			optional: optional,
+		},
+		URL:     url,
+		TempDir: tempDir,
+		Logger:  l,
+	}, nil
+}
+
+func (node *HTTPNode) Location() string {
+	return node.URL.String()
+}
+
+func (node *HTTPNode) Read() (*taskfile.Taskfile, error) {
+	resp, err := http.Get(node.URL.String())
+	if err != nil {
+		return nil, errors.TaskfileNotFoundError{URI: node.URL.String()}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.TaskfileNotFoundError{URI: node.URL.String()}
+	}
+
+	// Read the entire response body
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a hash of the response body
+	h := sha256.New()
+	h.Write(b)
+	hash := base64.URLEncoding.EncodeToString(h.Sum(nil))
+
+	// Get the cached hash
+	cachedHash, err := node.getHashFromCache()
+	if errors.Is(err, os.ErrNotExist) {
+		// If the hash doesn't exist in the cache, prompt the user to continue
+		if cont, err := node.Logger.Prompt(logger.Yellow, fmt.Sprintf("The task you are attempting to run depends on the remote Taskfile at %q.\n--- Make sure you trust the source of this Taskfile before continuing ---\nContinue?", node.URL.String()), "n", "y", "yes"); err != nil {
+			return nil, err
+		} else if !cont {
+			return nil, &errors.TaskfileNotTrustedError{URI: node.URL.String()}
+		}
+	} else if err != nil {
+		return nil, err
+	} else if hash != cachedHash {
+		// If there is a cached hash, but it doesn't match the expected hash, prompt the user to continue
+		if cont, err := node.Logger.Prompt(logger.Yellow, fmt.Sprintf("The Taskfile at %q has changed since you last used it!\n--- Make sure you trust the source of this Taskfile before continuing ---\nContinue?", node.URL.String()), "n", "y", "yes"); err != nil {
+			return nil, err
+		} else if !cont {
+			return nil, &errors.TaskfileNotTrustedError{URI: node.URL.String()}
+		}
+	}
+
+	// If the hash has changed (or is new), store it in the cache
+	if hash != cachedHash {
+		if err := node.toCache([]byte(hash)); err != nil {
+			return nil, err
+		}
+	}
+
+	// Unmarshal the taskfile
+	var t *taskfile.Taskfile
+	if err := yaml.Unmarshal(b, &t); err != nil {
+		return nil, &errors.TaskfileInvalidError{URI: node.URL.String(), Err: err}
+	}
+	t.Location = node.URL.String()
+	return t, nil
+}
+
+func (node *HTTPNode) getCachePath() string {
+	h := sha256.New()
+	h.Write([]byte(node.URL.String()))
+	return filepath.Join(node.TempDir, base64.URLEncoding.EncodeToString(h.Sum(nil)))
+}
+
+func (node *HTTPNode) getHashFromCache() (string, error) {
+	path := node.getCachePath()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func (node *HTTPNode) toCache(hash []byte) error {
+	path := node.getCachePath()
+	return os.WriteFile(path, hash, 0o644)
+}

--- a/taskfile/read/node_http.go
+++ b/taskfile/read/node_http.go
@@ -1,6 +1,7 @@
 package read
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -36,8 +37,13 @@ func (node *HTTPNode) Remote() bool {
 	return true
 }
 
-func (node *HTTPNode) Read() ([]byte, error) {
-	resp, err := http.Get(node.URL.String())
+func (node *HTTPNode) Read(ctx context.Context) ([]byte, error) {
+	req, err := http.NewRequest("GET", node.URL.String(), nil)
+	if err != nil {
+		return nil, errors.TaskfileFetchFailedError{URI: node.URL.String()}
+	}
+
+	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, errors.TaskfileFetchFailedError{URI: node.URL.String()}
 	}

--- a/taskfile/read/node_http.go
+++ b/taskfile/read/node_http.go
@@ -15,15 +15,14 @@ type HTTPNode struct {
 	URL *url.URL
 }
 
-func NewHTTPNode(parent Node, urlString string, optional bool) (*HTTPNode, error) {
+func NewHTTPNode(parent Node, urlString string) (*HTTPNode, error) {
 	url, err := url.Parse(urlString)
 	if err != nil {
 		return nil, err
 	}
 	return &HTTPNode{
 		BaseNode: BaseNode{
-			parent:   parent,
-			optional: optional,
+			parent: parent,
 		},
 		URL: url,
 	}, nil

--- a/taskfile/read/node_http.go
+++ b/taskfile/read/node_http.go
@@ -109,7 +109,7 @@ func (node *HTTPNode) Read() (*taskfile.Taskfile, error) {
 func (node *HTTPNode) getCachePath() string {
 	h := sha256.New()
 	h.Write([]byte(node.URL.String()))
-	return filepath.Join(node.TempDir, base64.URLEncoding.EncodeToString(h.Sum(nil)))
+	return filepath.Join(node.TempDir, "remote", base64.URLEncoding.EncodeToString(h.Sum(nil)))
 }
 
 func (node *HTTPNode) getHashFromCache() (string, error) {
@@ -123,5 +123,8 @@ func (node *HTTPNode) getHashFromCache() (string, error) {
 
 func (node *HTTPNode) toCache(hash []byte) error {
 	path := node.getCachePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
 	return os.WriteFile(path, hash, 0o644)
 }

--- a/taskfile/read/node_http.go
+++ b/taskfile/read/node_http.go
@@ -1,31 +1,20 @@
 package read
 
 import (
-	"crypto/sha256"
-	"encoding/base64"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"os"
-	"path/filepath"
-
-	"gopkg.in/yaml.v3"
 
 	"github.com/go-task/task/v3/errors"
-	"github.com/go-task/task/v3/internal/logger"
-	"github.com/go-task/task/v3/taskfile"
 )
 
 // An HTTPNode is a node that reads a Taskfile from a remote location via HTTP.
 type HTTPNode struct {
 	BaseNode
-	Logger  *logger.Logger
-	URL     *url.URL
-	TempDir string
+	URL *url.URL
 }
 
-func NewHTTPNode(parent Node, urlString string, optional bool, tempDir string, l *logger.Logger) (*HTTPNode, error) {
+func NewHTTPNode(parent Node, urlString string, optional bool) (*HTTPNode, error) {
 	url, err := url.Parse(urlString)
 	if err != nil {
 		return nil, err
@@ -35,9 +24,7 @@ func NewHTTPNode(parent Node, urlString string, optional bool, tempDir string, l
 			parent:   parent,
 			optional: optional,
 		},
-		URL:     url,
-		TempDir: tempDir,
-		Logger:  l,
+		URL: url,
 	}, nil
 }
 
@@ -45,7 +32,11 @@ func (node *HTTPNode) Location() string {
 	return node.URL.String()
 }
 
-func (node *HTTPNode) Read() (*taskfile.Taskfile, error) {
+func (node *HTTPNode) Remote() bool {
+	return true
+}
+
+func (node *HTTPNode) Read() ([]byte, error) {
 	resp, err := http.Get(node.URL.String())
 	if err != nil {
 		return nil, errors.TaskfileFetchFailedError{URI: node.URL.String()}
@@ -65,66 +56,5 @@ func (node *HTTPNode) Read() (*taskfile.Taskfile, error) {
 		return nil, err
 	}
 
-	// Create a hash of the response body
-	h := sha256.New()
-	h.Write(b)
-	hash := base64.URLEncoding.EncodeToString(h.Sum(nil))
-
-	// Get the cached hash
-	cachedHash, err := node.getHashFromCache()
-	if errors.Is(err, os.ErrNotExist) {
-		// If the hash doesn't exist in the cache, prompt the user to continue
-		if cont, err := node.Logger.Prompt(logger.Yellow, fmt.Sprintf("The task you are attempting to run depends on the remote Taskfile at %q.\n--- Make sure you trust the source of this Taskfile before continuing ---\nContinue?", node.URL.String()), "n", "y", "yes"); err != nil {
-			return nil, err
-		} else if !cont {
-			return nil, &errors.TaskfileNotTrustedError{URI: node.URL.String()}
-		}
-	} else if err != nil {
-		return nil, err
-	} else if hash != cachedHash {
-		// If there is a cached hash, but it doesn't match the expected hash, prompt the user to continue
-		if cont, err := node.Logger.Prompt(logger.Yellow, fmt.Sprintf("The Taskfile at %q has changed since you last used it!\n--- Make sure you trust the source of this Taskfile before continuing ---\nContinue?", node.URL.String()), "n", "y", "yes"); err != nil {
-			return nil, err
-		} else if !cont {
-			return nil, &errors.TaskfileNotTrustedError{URI: node.URL.String()}
-		}
-	}
-
-	// If the hash has changed (or is new), store it in the cache
-	if hash != cachedHash {
-		if err := node.toCache([]byte(hash)); err != nil {
-			return nil, err
-		}
-	}
-
-	// Unmarshal the taskfile
-	var t *taskfile.Taskfile
-	if err := yaml.Unmarshal(b, &t); err != nil {
-		return nil, &errors.TaskfileInvalidError{URI: node.URL.String(), Err: err}
-	}
-	t.Location = node.URL.String()
-	return t, nil
-}
-
-func (node *HTTPNode) getCachePath() string {
-	h := sha256.New()
-	h.Write([]byte(node.URL.String()))
-	return filepath.Join(node.TempDir, "remote", base64.URLEncoding.EncodeToString(h.Sum(nil)))
-}
-
-func (node *HTTPNode) getHashFromCache() (string, error) {
-	path := node.getCachePath()
-	b, err := os.ReadFile(path)
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
-}
-
-func (node *HTTPNode) toCache(hash []byte) error {
-	path := node.getCachePath()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	return os.WriteFile(path, hash, 0o644)
+	return b, nil
 }

--- a/taskfile/read/node_http.go
+++ b/taskfile/read/node_http.go
@@ -15,10 +15,13 @@ type HTTPNode struct {
 	URL *url.URL
 }
 
-func NewHTTPNode(parent Node, urlString string) (*HTTPNode, error) {
-	url, err := url.Parse(urlString)
+func NewHTTPNode(parent Node, uri string, allowInsecure bool) (*HTTPNode, error) {
+	url, err := url.Parse(uri)
 	if err != nil {
 		return nil, err
+	}
+	if url.Scheme == "http" && !allowInsecure {
+		return nil, &errors.TaskfileNotSecureError{URI: uri}
 	}
 	return &HTTPNode{
 		BaseNode: BaseNode{

--- a/taskfile/read/node_http.go
+++ b/taskfile/read/node_http.go
@@ -11,23 +11,22 @@ import (
 
 // An HTTPNode is a node that reads a Taskfile from a remote location via HTTP.
 type HTTPNode struct {
-	BaseNode
+	*BaseNode
 	URL *url.URL
 }
 
-func NewHTTPNode(parent Node, uri string, allowInsecure bool) (*HTTPNode, error) {
+func NewHTTPNode(uri string, insecure bool, opts ...NodeOption) (*HTTPNode, error) {
+	base := NewBaseNode(opts...)
 	url, err := url.Parse(uri)
 	if err != nil {
 		return nil, err
 	}
-	if url.Scheme == "http" && !allowInsecure {
+	if url.Scheme == "http" && !insecure {
 		return nil, &errors.TaskfileNotSecureError{URI: uri}
 	}
 	return &HTTPNode{
-		BaseNode: BaseNode{
-			parent: parent,
-		},
-		URL: url,
+		BaseNode: base,
+		URL:      url,
 	}, nil
 }
 

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -173,7 +173,12 @@ func Taskfile(
 				}
 			}
 
-			includeReaderNode, err := NewNodeFromIncludedTaskfile(node, includedTask, allowInsecure, tempDir, l)
+			uri, err := includedTask.FullTaskfilePath()
+			if err != nil {
+				return err
+			}
+
+			includeReaderNode, err := NewNode(node, uri, allowInsecure)
 			if err != nil {
 				if includedTask.Optional {
 					return nil

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -1,6 +1,7 @@
 package read
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -68,7 +69,7 @@ func readTaskfile(
 
 	// If we still don't have a copy, get the file in the usual way
 	if b == nil {
-		b, err = node.Read()
+		b, err = node.Read(context.Background())
 		if err != nil {
 			return nil, err
 		}
@@ -258,7 +259,7 @@ func Taskfile(
 						Entrypoint: path,
 						Dir:        node.Dir,
 					}
-					b, err := osNode.Read()
+					b, err := osNode.Read(context.Background())
 					if err != nil {
 						return nil, err
 					}

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -79,7 +79,7 @@ func readTaskfile(
 			l.VerboseOutf(logger.Magenta, "task: [%s] Fetched remote copy\n", node.Location())
 
 			// Get the checksums
-			checksum := cache.checksum(b)
+			checksum := checksum(b)
 			cachedChecksum := cache.readChecksum(node)
 
 			// If the checksum doesn't exist, prompt the user to continue

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -253,8 +253,7 @@ func Taskfile(
 				if _, err = os.Stat(path); err == nil {
 					osNode := &FileNode{
 						BaseNode: BaseNode{
-							parent:   node,
-							optional: false,
+							parent: node,
 						},
 						Entrypoint: path,
 						Dir:        node.Dir,

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/filepathext"
+	"github.com/go-task/task/v3/internal/logger"
 	"github.com/go-task/task/v3/internal/sysinfo"
 	"github.com/go-task/task/v3/internal/templater"
 	"github.com/go-task/task/v3/taskfile"
@@ -32,7 +33,7 @@ var (
 // Taskfile reads a Taskfile for a given directory
 // Uses current dir when dir is left empty. Uses Taskfile.yml
 // or Taskfile.yaml when entrypoint is left empty
-func Taskfile(node Node) (*taskfile.Taskfile, error) {
+func Taskfile(node Node, tempDir string, l *logger.Logger) (*taskfile.Taskfile, error) {
 	var _taskfile func(Node) (*taskfile.Taskfile, error)
 	_taskfile = func(node Node) (*taskfile.Taskfile, error) {
 		t, err := node.Read()
@@ -70,7 +71,7 @@ func Taskfile(node Node) (*taskfile.Taskfile, error) {
 				}
 			}
 
-			includeReaderNode, err := NewNodeFromIncludedTaskfile(node, includedTask)
+			includeReaderNode, err := NewNodeFromIncludedTaskfile(node, includedTask, tempDir, l)
 			if err != nil {
 				if includedTask.Optional {
 					return nil

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -33,7 +33,7 @@ var (
 // Taskfile reads a Taskfile for a given directory
 // Uses current dir when dir is left empty. Uses Taskfile.yml
 // or Taskfile.yaml when entrypoint is left empty
-func Taskfile(node Node, tempDir string, l *logger.Logger) (*taskfile.Taskfile, error) {
+func Taskfile(node Node, allowInsecure bool, tempDir string, l *logger.Logger) (*taskfile.Taskfile, error) {
 	var _taskfile func(Node) (*taskfile.Taskfile, error)
 	_taskfile = func(node Node) (*taskfile.Taskfile, error) {
 		t, err := node.Read()
@@ -71,7 +71,7 @@ func Taskfile(node Node, tempDir string, l *logger.Logger) (*taskfile.Taskfile, 
 				}
 			}
 
-			includeReaderNode, err := NewNodeFromIncludedTaskfile(node, includedTask, tempDir, l)
+			includeReaderNode, err := NewNodeFromIncludedTaskfile(node, includedTask, allowInsecure, tempDir, l)
 			if err != nil {
 				if includedTask.Optional {
 					return nil


### PR DESCRIPTION
#770 is now the most requested feature in Task by quite some margin and there have been frequent requests/questions around it in recent weeks. Previous requests have been rejected based on complexity, but I believe that the way this draft is implemented might actually reduce the Task reader complexity as it abstracts the logic for dealing with files away from the recursive reader. 

This PR is intended to open a dialogue about how this feature might look if it is added to Task. Please note that this is _first draft_ and is open to significant changes or rejection entirely.

## The PR

The first commit only contains changes to the underlying code to allow it to be more extensible via a new `Node` interface. This interface allows for multiple implementations of the Taskfile reader. This change also reimplements the existing filesystem based reader as a `FileNode`.

The second commit adds a very crude example of how a new `HTTPNode` might look. I've made a (temporary) change in this commit to the root Taskfile which changes the docs `include` to use `https://` (it just points to the same file on GitHub). You should be able to run `task --list` and see no difference as it will now download the remote file into memory and run exactly the same way as if the file was local!

## Discussion points

1. API design - Currently, the way this is implemented will allow you to specify any scheme by adding `myscheme://` to the start of the Taskfile URI when including a file. Is this flexible enough for everyone's needs? It should be easy enough to add `ssh://` or `git://` schemes etc. in the future.
1. CLI - It should be trivial to allow running a remote Taskfile from the CLI. i.e. where your root Taskfile is not on your filesystem. How should this look in terms of args/flags?