### PR TITLE
powershell completion: disable file path autocomplete / add flags

### DIFF
--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -54,6 +54,6 @@ Register-ArgumentCompleter -CommandName task -ScriptBlock {
 		}
 
 
-		return $desc + "`n"
+		return $desc
 	}
 }

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -2,25 +2,43 @@ using namespace System.Management.Automation
 
 Register-ArgumentCompleter -CommandName task -ScriptBlock {
 	param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
-		if ($commandName.StartsWith('-')) {
-			$completions = @(
-				[CompletionResult]::new('--color ', '--color', [CompletionResultType]::ParameterName, 'Colored output.'),
-				[CompletionResult]::new('--concurrency=', '--concurrency=', [CompletionResultType]::ParameterName, 'concurrency'),
-				[CompletionResult]::new('--interval=', '--interval=', [CompletionResultType]::ParameterName, 'interval'),
-				[CompletionResult]::new('--output=interleaved ', '--output=interleaved', [CompletionResultType]::ParameterName, 'output style'),
-				[CompletionResult]::new('--output=group ', '--output=group', [CompletionResultType]::ParameterName, 'output style'),
-				[CompletionResult]::new('--output=prefixed ', '--output=prefixed', [CompletionResultType]::ParameterName, 'output style'),
-				[CompletionResult]::new('--dry ', '--dry', [CompletionResultType]::ParameterName, '--dry'),
-				[CompletionResult]::new('--force ', '--force', [CompletionResultType]::ParameterName, '--force'),
-				[CompletionResult]::new('--parallel ', '--parallel', [CompletionResultType]::ParameterName, '--parallel'),
-				[CompletionResult]::new('--silent ', '--silent', [CompletionResultType]::ParameterName, '--silent'),
-				[CompletionResult]::new('--status ', '--status', [CompletionResultType]::ParameterName, '--status'),
-				[CompletionResult]::new('--verbose ', '--verbose', [CompletionResultType]::ParameterName, '--verbose'),
-				[CompletionResult]::new('--watch ', '--watch', [CompletionResultType]::ParameterName,'--watch')
-			)
+	if ($commandName.StartsWith('-')) {
+		$completions = @(
+			[CompletionResult]::new('--color ', '--color', [CompletionResultType]::ParameterName, '--color'),
+			[CompletionResult]::new('--concurrency=', '--concurrency=', [CompletionResultType]::ParameterName, 'concurrency'),
+			[CompletionResult]::new('--interval=', '--interval=', [CompletionResultType]::ParameterName, 'interval'),
+			[CompletionResult]::new('--output=interleaved ', '--output=interleaved', [CompletionResultType]::ParameterName, 'output style'),
+			[CompletionResult]::new('--output=group ', '--output=group', [CompletionResultType]::ParameterName, 'output style'),
+			[CompletionResult]::new('--output=prefixed ', '--output=prefixed', [CompletionResultType]::ParameterName, 'output style'),
+			[CompletionResult]::new('--dry ', '--dry', [CompletionResultType]::ParameterName, '--dry'),
+			[CompletionResult]::new('--force ', '--force', [CompletionResultType]::ParameterName, '--force'),
+			[CompletionResult]::new('--parallel ', '--parallel', [CompletionResultType]::ParameterName, '--parallel'),
+			[CompletionResult]::new('--silent ', '--silent', [CompletionResultType]::ParameterName, '--silent'),
+			[CompletionResult]::new('--status ', '--status', [CompletionResultType]::ParameterName, '--status'),
+			[CompletionResult]::new('--verbose ', '--verbose', [CompletionResultType]::ParameterName, '--verbose'),
+			[CompletionResult]::new('--watch ', '--watch', [CompletionResultType]::ParameterName, '--watch')
+		)
 
-			return $completions.Where{ $_.CompletionText -like "$commandName*" }
+		return $completions.Where{ $_.Tooltip -like "$commandName*" }
+	}
+
+	$tasks = $(task --list-all --json) | ConvertFrom-Json
+
+	if ($commandName -ne '') {
+		# user already input something, complete current word
+		return $tasks.tasks | Where-Object { $_.name -like "$commandName*" } | ForEach-Object { $_.name }
+	}
+
+	# <tab> after <space>, show tasks with description
+	return $tasks.tasks | Where-Object { $_.name -like "$commandName*" } | ForEach-Object {
+		$desc = $_.name + "`n"
+		if ($_.summary -ne "") {
+			$desc = $_.name + "`t(" + $_.summary + ")`n"
+		}
+		elseif ($_.desc -ne "") {
+			$desc = $_.name + "`t(" + $_.desc + ")`n"
 		}
 
-		return $(task --list-all --silent) | Where-Object { $_ -like "$commandName*" }
+		return $desc
+	}
 }

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -1,7 +1,7 @@
 Register-ArgumentCompleter -CommandName task -ScriptBlock {
 	param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
 		if ($commandName -match '^-{1,2}[^-]*$') {
-			$listOutput = @(
+			return @(
 				'--concurrency=',
 				'--interval=',
 				'--output=interleaved',
@@ -15,10 +15,8 @@ Register-ArgumentCompleter -CommandName task -ScriptBlock {
 				'--status',
 				'--verbose',
 				'--watch'
-			)
-			$listOutput | Where-Object { $_ -like "$commandName*" } | ForEach-Object { $_ }
-		} else {
-			$listOutput = $(task --list-all --silent)
-			$listOutput | Where-Object { $_ -like "$commandName*" } | ForEach-Object { $_ }
-	}
+			) | Where-Object { $_ -like "$commandName*" } | ForEach-Object { $_ }
+		}
+
+		return $(task --list-all --silent) | Where-Object { $_ -like "$commandName*" } | ForEach-Object { $_ }
 }

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -19,7 +19,6 @@ Register-ArgumentCompleter -CommandName task -ScriptBlock {
 			$listOutput | Where-Object { $_ -like "$commandName*" } | ForEach-Object { $_ }
 		} else {
 			$listOutput = $(task --list-all --silent)
-			$reg = "^($commandName.*?)$"
 			$listOutput | Where-Object { $_ -like "$commandName*" } | ForEach-Object { $_ }
 	}
 }

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -1,59 +1,65 @@
 using namespace System.Management.Automation
 
 Register-ArgumentCompleter -CommandName task -ScriptBlock {
-	param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
-	if ($commandName.StartsWith('-')) {
-		$completions = @(
-			[CompletionResult]::new('--color ', '--color', [CompletionResultType]::ParameterName, '--color'),
-			[CompletionResult]::new('--concurrency=', '--concurrency=', [CompletionResultType]::ParameterName, 'concurrency'),
-			[CompletionResult]::new('--interval=', '--interval=', [CompletionResultType]::ParameterName, 'interval'),
-			[CompletionResult]::new('--output=interleaved ', '--output=interleaved', [CompletionResultType]::ParameterName, 'output style'),
-			[CompletionResult]::new('--output=group ', '--output=group', [CompletionResultType]::ParameterName, 'output style'),
-			[CompletionResult]::new('--output=prefixed ', '--output=prefixed', [CompletionResultType]::ParameterName, 'output style'),
-			[CompletionResult]::new('--dry ', '--dry', [CompletionResultType]::ParameterName, '--dry'),
-			[CompletionResult]::new('--force ', '--force', [CompletionResultType]::ParameterName, '--force'),
-			[CompletionResult]::new('--parallel ', '--parallel', [CompletionResultType]::ParameterName, '--parallel'),
-			[CompletionResult]::new('--silent ', '--silent', [CompletionResultType]::ParameterName, '--silent'),
-			[CompletionResult]::new('--status ', '--status', [CompletionResultType]::ParameterName, '--status'),
-			[CompletionResult]::new('--verbose ', '--verbose', [CompletionResultType]::ParameterName, '--verbose'),
-			[CompletionResult]::new('--watch ', '--watch', [CompletionResultType]::ParameterName, '--watch')
-		)
+  param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+  if ($commandName.StartsWith('-')) {
+    $completions = @(
+      [CompletionResult]::new('--color ', '--color', [CompletionResultType]::ParameterName, '--color'),
+      [CompletionResult]::new('--concurrency=', '--concurrency=', [CompletionResultType]::ParameterName, 'concurrency'),
+      [CompletionResult]::new('--interval=', '--interval=', [CompletionResultType]::ParameterName, 'interval'),
+      [CompletionResult]::new('--output=interleaved ', '--output=interleaved', [CompletionResultType]::ParameterName, 'output style'),
+      [CompletionResult]::new('--output=group ', '--output=group', [CompletionResultType]::ParameterName, 'output style'),
+      [CompletionResult]::new('--output=prefixed ', '--output=prefixed', [CompletionResultType]::ParameterName, 'output style'),
+      [CompletionResult]::new('--dry ', '--dry', [CompletionResultType]::ParameterName, '--dry'),
+      [CompletionResult]::new('--force ', '--force', [CompletionResultType]::ParameterName, '--force'),
+      [CompletionResult]::new('--parallel ', '--parallel', [CompletionResultType]::ParameterName, '--parallel'),
+      [CompletionResult]::new('--silent ', '--silent', [CompletionResultType]::ParameterName, '--silent'),
+      [CompletionResult]::new('--status ', '--status', [CompletionResultType]::ParameterName, '--status'),
+      [CompletionResult]::new('--verbose ', '--verbose', [CompletionResultType]::ParameterName, '--verbose'),
+      [CompletionResult]::new('--watch ', '--watch', [CompletionResultType]::ParameterName, '--watch')
+    )
 
-		return $completions.Where{ $_.Tooltip -like "$commandName*" }
-	}
+    return $completions.Where{ $_.Tooltip -like "$commandName*" }
+  }
 
-	$tasks = $(task --list-all --json) | ConvertFrom-Json
+  $tasks = $(task --list-all --json) | ConvertFrom-Json
 
-	$ava = $tasks.tasks | Where-Object { $_.name -like "$commandName*" }
-
-	if ($ava.Length -le 1) {
-		# user already input something, complete current word
-		return $ava | ForEach-Object { $_.name }
-	}
-
-	$Longest = 0
-	$ava | ForEach-Object {
-		# Look for the longest completion so that we can format things nicely
-		if ($Longest -lt $_.name.Length) {
-			$Longest = $_.name.Length
-		}
-	}
-
-	return $ava | ForEach-Object {
-		$desc = $_.name
-
-		while ($desc.Length -lt $Longest) {
-			$desc = $desc + " "
-		}
-
-		if ($_.summary -ne "") {
-			$desc = $desc + " (" + $_.summary + ")"
-		}
-		elseif ($_.desc -ne "") {
-			$desc = $desc + " (" + $_.desc + ")"
-		}
+  if ($commandName -eq "") {
+    $ava = $tasks.tasks
+  }
+  else {
+    $ava = $tasks.tasks | Where-Object { $_.name -like "$commandName*" }
+  }
 
 
-		return $desc
-	}
+  if ($ava.Length -le 1) {
+    # user already input something, complete current word
+    return $ava | ForEach-Object { $_.name + " " }
+  }
+
+  $Longest = 0
+  $ava | ForEach-Object {
+    # Look for the longest completion so that we can format things nicely
+    if ($Longest -lt $_.name.Length) {
+      $Longest = $_.name.Length
+    }
+  }
+
+  return $ava | ForEach-Object {
+    $desc = $_.name
+
+    while ($desc.Length -lt $Longest) {
+      $desc = $desc + " "
+    }
+
+    if ($_.summary -ne "") {
+      $desc = $desc + " (" + $_.summary + ")"
+    }
+    elseif ($_.desc -ne "") {
+      $desc = $desc + " (" + $_.desc + ")"
+    }
+
+
+    return $desc
+  }
 }

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -16,15 +16,10 @@ Register-ArgumentCompleter -CommandName task -ScriptBlock {
 				'--verbose',
 				'--watch'
 			)
-			$reg = "^($commandName.*?)$"
-			$listOutput | Select-String $reg -AllMatches | ForEach-Object {
-				$_.Matches.Groups[1].Value;
-			}
+			$listOutput | Where-Object { $_ -like "$commandName*" } | ForEach-Object { $_ }
 		} else {
 			$listOutput = $(task --list-all --silent)
 			$reg = "^($commandName.*?)$"
-			$listOutput | Select-String $reg -AllMatches | ForEach-Object {
-				$_.Matches.Groups[1].Value;
-			}
+			$listOutput | Where-Object { $_ -like "$commandName*" } | ForEach-Object { $_ }
 	}
 }

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -7,9 +7,9 @@ Register-ArgumentCompleter -CommandName task -ScriptBlock {
 			[CompletionResult]::new('--color ', '--color', [CompletionResultType]::ParameterName, '--color'),
 			[CompletionResult]::new('--concurrency=', '--concurrency=', [CompletionResultType]::ParameterName, 'concurrency'),
 			[CompletionResult]::new('--interval=', '--interval=', [CompletionResultType]::ParameterName, 'interval'),
-			[CompletionResult]::new('--output=interleaved ', '--output=interleaved', [CompletionResultType]::ParameterName, 'output style'),
-			[CompletionResult]::new('--output=group ', '--output=group', [CompletionResultType]::ParameterName, 'output style'),
-			[CompletionResult]::new('--output=prefixed ', '--output=prefixed', [CompletionResultType]::ParameterName, 'output style'),
+			[CompletionResult]::new('--output=interleaved ', '--output=interleaved', [CompletionResultType]::ParameterName, '--output='),
+			[CompletionResult]::new('--output=group ', '--output=group', [CompletionResultType]::ParameterName, '--output='),
+			[CompletionResult]::new('--output=prefixed ', '--output=prefixed', [CompletionResultType]::ParameterName, '--output='),
 			[CompletionResult]::new('--dry ', '--dry', [CompletionResultType]::ParameterName, '--dry'),
 			[CompletionResult]::new('--force ', '--force', [CompletionResultType]::ParameterName, '--force'),
 			[CompletionResult]::new('--parallel ', '--parallel', [CompletionResultType]::ParameterName, '--parallel'),
@@ -31,11 +31,29 @@ Register-ArgumentCompleter -CommandName task -ScriptBlock {
 		$ava = $tasks.tasks | Where-Object { $_.name -like "$commandName*" }
 	}
 
+	$Mode = (Get-PSReadLineKeyHandler | Where-Object { $_.Key -eq "Tab" }).Function
+
+	if ($Mode -eq "MenuComplete") {
+		# PS-Readline feature PSReadlineKeyHandler
+		return $ava | ForEach-Object {
+			$desc = $_.name
+
+			if ($_.summary -ne "") {
+				$desc = $_.summary
+			}
+			elseif ($_.desc -ne "") {
+				$desc = $_.desc
+			}
+
+			return	[CompletionResult]::new("$($_.name) ", "$($_.name) ", [CompletionResultType]::ParameterName, $desc)
+		}
+	}
 
 	if ($ava.Length -le 1) {
 		# user already input something, complete current word
 		return $ava | ForEach-Object { $_.name + " " }
 	}
+
 
 	$Longest = 0
 	$ava | ForEach-Object {

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -1,7 +1,10 @@
 $scriptBlock = {
-	param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters )
-	$listOutput = $(task --list-all --silent)
-	$listOutput | ForEach-Object { $_ }
+	param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+		$listOutput = $(task --list-all --silent)
+		$reg = "^($commandName.*?)$"
+		$listOutput | Select-String $reg -AllMatches | ForEach-Object {
+			 $_.Matches.Groups[1].Value;
+		}
 }
 
 Register-ArgumentCompleter -CommandName task -ScriptBlock $scriptBlock

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -2,6 +2,7 @@ using namespace System.Management.Automation
 
 Register-ArgumentCompleter -CommandName task -ScriptBlock {
 	param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+
 	if ($commandName.StartsWith('-')) {
 		$completions = @(
 			[CompletionResult]::new('--color ', '--color', [CompletionResultType]::ParameterName, '--color'),
@@ -22,62 +23,5 @@ Register-ArgumentCompleter -CommandName task -ScriptBlock {
 		return $completions.Where{ $_.CompletionText.StartsWith($commandName) }
 	}
 
-	$tasks = $(task --list-all --json) | ConvertFrom-Json
-
-	if ($commandName -eq "") {
-		$ava = $tasks.tasks
-	}
-	else {
-		$ava = $tasks.tasks | Where-Object { $_.name.StartsWith($commandName) }
-	}
-
-	$Mode = (Get-PSReadLineKeyHandler | Where-Object { $_.Key -eq "Tab" }).Function
-
-	if ($Mode -eq "MenuComplete") {
-		# PS-Readline feature PSReadlineKeyHandler
-		return $ava | ForEach-Object {
-			$desc = $_.name
-
-			if ($_.summary -ne "") {
-				$desc = $_.summary
-			}
-			elseif ($_.desc -ne "") {
-				$desc = $_.desc
-			}
-
-			return	[CompletionResult]::new("$($_.name) ", "$($_.name) ", [CompletionResultType]::ParameterName, $desc)
-		}
-	}
-
-	if ($ava.Length -le 1) {
-		# user already input something, complete current word
-		return $ava | ForEach-Object { $_.name + " " }
-	}
-
-
-	$Longest = 0
-	$ava | ForEach-Object {
-		# Look for the longest completion so that we can format things nicely
-		if ($Longest -lt $_.name.Length) {
-			$Longest = $_.name.Length
-		}
-	}
-
-	return $ava | ForEach-Object {
-		$desc = $_.name
-
-		while ($desc.Length -lt $Longest) {
-			$desc = $desc + " "
-		}
-
-		if ($_.summary -ne "") {
-			$desc = $desc + " (" + $_.summary + ")"
-		}
-		elseif ($_.desc -ne "") {
-			$desc = $desc + " (" + $_.desc + ")"
-		}
-
-
-		return $desc
-	}
+	return 	$(task --list-all --silent) | Where-Object { $_.StartsWith($commandName) }
 }

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -22,5 +22,5 @@ Register-ArgumentCompleter -CommandName task -ScriptBlock {
 			return $completions.Where{ $_.CompletionText -like "$commandName*" }
 		}
 
-		return $(task --list-all --silent) | Where-Object { $_ -like "$commandName*" } | ForEach-Object { $_ }
+		return $(task --list-all --silent) | Where-Object { $_ -like "$commandName*" }
 }

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -23,5 +23,5 @@ Register-ArgumentCompleter -CommandName task -ScriptBlock {
 		return $completions.Where{ $_.CompletionText.StartsWith($commandName) }
 	}
 
-	return 	$(task --list-all --silent) | Where-Object { $_.StartsWith($commandName) }
+	return 	$(task --list-all --silent) | Where-Object { $_.StartsWith($commandName) } | ForEach-Object { return $_ + " " }
 }

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -1,65 +1,65 @@
 using namespace System.Management.Automation
 
 Register-ArgumentCompleter -CommandName task -ScriptBlock {
-  param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
-  if ($commandName.StartsWith('-')) {
-    $completions = @(
-      [CompletionResult]::new('--color ', '--color', [CompletionResultType]::ParameterName, '--color'),
-      [CompletionResult]::new('--concurrency=', '--concurrency=', [CompletionResultType]::ParameterName, 'concurrency'),
-      [CompletionResult]::new('--interval=', '--interval=', [CompletionResultType]::ParameterName, 'interval'),
-      [CompletionResult]::new('--output=interleaved ', '--output=interleaved', [CompletionResultType]::ParameterName, 'output style'),
-      [CompletionResult]::new('--output=group ', '--output=group', [CompletionResultType]::ParameterName, 'output style'),
-      [CompletionResult]::new('--output=prefixed ', '--output=prefixed', [CompletionResultType]::ParameterName, 'output style'),
-      [CompletionResult]::new('--dry ', '--dry', [CompletionResultType]::ParameterName, '--dry'),
-      [CompletionResult]::new('--force ', '--force', [CompletionResultType]::ParameterName, '--force'),
-      [CompletionResult]::new('--parallel ', '--parallel', [CompletionResultType]::ParameterName, '--parallel'),
-      [CompletionResult]::new('--silent ', '--silent', [CompletionResultType]::ParameterName, '--silent'),
-      [CompletionResult]::new('--status ', '--status', [CompletionResultType]::ParameterName, '--status'),
-      [CompletionResult]::new('--verbose ', '--verbose', [CompletionResultType]::ParameterName, '--verbose'),
-      [CompletionResult]::new('--watch ', '--watch', [CompletionResultType]::ParameterName, '--watch')
-    )
+	param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+	if ($commandName.StartsWith('-')) {
+		$completions = @(
+			[CompletionResult]::new('--color ', '--color', [CompletionResultType]::ParameterName, '--color'),
+			[CompletionResult]::new('--concurrency=', '--concurrency=', [CompletionResultType]::ParameterName, 'concurrency'),
+			[CompletionResult]::new('--interval=', '--interval=', [CompletionResultType]::ParameterName, 'interval'),
+			[CompletionResult]::new('--output=interleaved ', '--output=interleaved', [CompletionResultType]::ParameterName, 'output style'),
+			[CompletionResult]::new('--output=group ', '--output=group', [CompletionResultType]::ParameterName, 'output style'),
+			[CompletionResult]::new('--output=prefixed ', '--output=prefixed', [CompletionResultType]::ParameterName, 'output style'),
+			[CompletionResult]::new('--dry ', '--dry', [CompletionResultType]::ParameterName, '--dry'),
+			[CompletionResult]::new('--force ', '--force', [CompletionResultType]::ParameterName, '--force'),
+			[CompletionResult]::new('--parallel ', '--parallel', [CompletionResultType]::ParameterName, '--parallel'),
+			[CompletionResult]::new('--silent ', '--silent', [CompletionResultType]::ParameterName, '--silent'),
+			[CompletionResult]::new('--status ', '--status', [CompletionResultType]::ParameterName, '--status'),
+			[CompletionResult]::new('--verbose ', '--verbose', [CompletionResultType]::ParameterName, '--verbose'),
+			[CompletionResult]::new('--watch ', '--watch', [CompletionResultType]::ParameterName, '--watch')
+		)
 
-    return $completions.Where{ $_.Tooltip -like "$commandName*" }
-  }
+		return $completions.Where{ $_.Tooltip -like "$commandName*" }
+	}
 
-  $tasks = $(task --list-all --json) | ConvertFrom-Json
+	$tasks = $(task --list-all --json) | ConvertFrom-Json
 
-  if ($commandName -eq "") {
-    $ava = $tasks.tasks
-  }
-  else {
-    $ava = $tasks.tasks | Where-Object { $_.name -like "$commandName*" }
-  }
-
-
-  if ($ava.Length -le 1) {
-    # user already input something, complete current word
-    return $ava | ForEach-Object { $_.name + " " }
-  }
-
-  $Longest = 0
-  $ava | ForEach-Object {
-    # Look for the longest completion so that we can format things nicely
-    if ($Longest -lt $_.name.Length) {
-      $Longest = $_.name.Length
-    }
-  }
-
-  return $ava | ForEach-Object {
-    $desc = $_.name
-
-    while ($desc.Length -lt $Longest) {
-      $desc = $desc + " "
-    }
-
-    if ($_.summary -ne "") {
-      $desc = $desc + " (" + $_.summary + ")"
-    }
-    elseif ($_.desc -ne "") {
-      $desc = $desc + " (" + $_.desc + ")"
-    }
+	if ($commandName -eq "") {
+		$ava = $tasks.tasks
+	}
+	else {
+		$ava = $tasks.tasks | Where-Object { $_.name -like "$commandName*" }
+	}
 
 
-    return $desc
-  }
+	if ($ava.Length -le 1) {
+		# user already input something, complete current word
+		return $ava | ForEach-Object { $_.name + " " }
+	}
+
+	$Longest = 0
+	$ava | ForEach-Object {
+		# Look for the longest completion so that we can format things nicely
+		if ($Longest -lt $_.name.Length) {
+			$Longest = $_.name.Length
+		}
+	}
+
+	return $ava | ForEach-Object {
+		$desc = $_.name
+
+		while ($desc.Length -lt $Longest) {
+			$desc = $desc + " "
+		}
+
+		if ($_.summary -ne "") {
+			$desc = $desc + " (" + $_.summary + ")"
+		}
+		elseif ($_.desc -ne "") {
+			$desc = $desc + " (" + $_.desc + ")"
+		}
+
+
+		return $desc
+	}
 }

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -1,10 +1,30 @@
-$scriptBlock = {
+Register-ArgumentCompleter -CommandName task -ScriptBlock {
 	param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
-		$listOutput = $(task --list-all --silent)
-		$reg = "^($commandName.*?)$"
-		$listOutput | Select-String $reg -AllMatches | ForEach-Object {
-			 $_.Matches.Groups[1].Value;
-		}
+		if ($commandName -match '^-{1,2}[^-]*$') {
+			$listOutput = @(
+				'--concurrency=',
+				'--interval=',
+				'--output=interleaved',
+				'--output=group',
+				'--output=prefixed',
+				'--color',
+				'--dry',
+				'--force',
+				'--parallel',
+				'--silent',
+				'--status',
+				'--verbose',
+				'--watch'
+			)
+			$reg = "^($commandName.*?)$"
+			$listOutput | Select-String $reg -AllMatches | ForEach-Object {
+				$_.Matches.Groups[1].Value;
+			}
+		} else {
+			$listOutput = $(task --list-all --silent)
+			$reg = "^($commandName.*?)$"
+			$listOutput | Select-String $reg -AllMatches | ForEach-Object {
+				$_.Matches.Groups[1].Value;
+			}
+	}
 }
-
-Register-ArgumentCompleter -CommandName task -ScriptBlock $scriptBlock

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -1,8 +1,7 @@
 $scriptBlock = {
 	param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters )
-	$reg = "\* ($commandName.+?):"
-	$listOutput = $(task --list-all)
-	$listOutput | Select-String $reg -AllMatches | ForEach-Object { $_.Matches.Groups[1].Value }
+	$listOutput = $(task --list-all --silent)
+	$listOutput | ForEach-Object { $_ }
 }
 
-Register-ArgumentCompleter -CommandName task -ScriptBlock $scriptBlock
+Register-ArgumentCompleter -Native -CommandName task -ScriptBlock $scriptBlock

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -1,21 +1,25 @@
+using namespace System.Management.Automation
+
 Register-ArgumentCompleter -CommandName task -ScriptBlock {
 	param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
-		if ($commandName -match '^-{1,2}[^-]*$') {
-			return @(
-				'--concurrency=',
-				'--interval=',
-				'--output=interleaved',
-				'--output=group',
-				'--output=prefixed',
-				'--color',
-				'--dry',
-				'--force',
-				'--parallel',
-				'--silent',
-				'--status',
-				'--verbose',
-				'--watch'
-			) | Where-Object { $_ -like "$commandName*" } | ForEach-Object { $_ }
+		if ($commandName.StartsWith('-')) {
+			$completions = @(
+				[CompletionResult]::new('--color ', '--color', [CompletionResultType]::ParameterName, 'Colored output.'),
+				[CompletionResult]::new('--concurrency=', '--concurrency=', [CompletionResultType]::ParameterName, 'concurrency'),
+				[CompletionResult]::new('--interval=', '--interval=', [CompletionResultType]::ParameterName, 'interval'),
+				[CompletionResult]::new('--output=interleaved ', '--output=interleaved', [CompletionResultType]::ParameterName, 'output style'),
+				[CompletionResult]::new('--output=group ', '--output=group', [CompletionResultType]::ParameterName, 'output style'),
+				[CompletionResult]::new('--output=prefixed ', '--output=prefixed', [CompletionResultType]::ParameterName, 'output style'),
+				[CompletionResult]::new('--dry ', '--dry', [CompletionResultType]::ParameterName, '--dry'),
+				[CompletionResult]::new('--force ', '--force', [CompletionResultType]::ParameterName, '--force'),
+				[CompletionResult]::new('--parallel ', '--parallel', [CompletionResultType]::ParameterName, '--parallel'),
+				[CompletionResult]::new('--silent ', '--silent', [CompletionResultType]::ParameterName, '--silent'),
+				[CompletionResult]::new('--status ', '--status', [CompletionResultType]::ParameterName, '--status'),
+				[CompletionResult]::new('--verbose ', '--verbose', [CompletionResultType]::ParameterName, '--verbose'),
+				[CompletionResult]::new('--watch ', '--watch', [CompletionResultType]::ParameterName,'--watch')
+			)
+
+			return $completions.Where{ $_.CompletionText -like "$commandName*" }
 		}
 
 		return $(task --list-all --silent) | Where-Object { $_ -like "$commandName*" } | ForEach-Object { $_ }

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -5,6 +5,7 @@ Register-ArgumentCompleter -CommandName task -ScriptBlock {
 
 	if ($commandName.StartsWith('-')) {
 		$completions = @(
+			[CompletionResult]::new('--list-all ', '--list-all ', [CompletionResultType]::ParameterName, 'list all tasks'),
 			[CompletionResult]::new('--color ', '--color', [CompletionResultType]::ParameterName, '--color'),
 			[CompletionResult]::new('--concurrency=', '--concurrency=', [CompletionResultType]::ParameterName, 'concurrency'),
 			[CompletionResult]::new('--interval=', '--interval=', [CompletionResultType]::ParameterName, 'interval'),

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -19,7 +19,7 @@ Register-ArgumentCompleter -CommandName task -ScriptBlock {
 			[CompletionResult]::new('--watch ', '--watch', [CompletionResultType]::ParameterName, '--watch')
 		)
 
-		return $completions.Where{ $_.Tooltip -like "$commandName*" }
+		return $completions.Where{ $_.CompletionText.StartsWith($commandName) }
 	}
 
 	$tasks = $(task --list-all --json) | ConvertFrom-Json
@@ -28,7 +28,7 @@ Register-ArgumentCompleter -CommandName task -ScriptBlock {
 		$ava = $tasks.tasks
 	}
 	else {
-		$ava = $tasks.tasks | Where-Object { $_.name -like "$commandName*" }
+		$ava = $tasks.tasks | Where-Object { $_.name.StartsWith($commandName) }
 	}
 
 	$Mode = (Get-PSReadLineKeyHandler | Where-Object { $_.Key -eq "Tab" }).Function

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -4,4 +4,4 @@ $scriptBlock = {
 	$listOutput | ForEach-Object { $_ }
 }
 
-Register-ArgumentCompleter -Native -CommandName task -ScriptBlock $scriptBlock
+Register-ArgumentCompleter -CommandName task -ScriptBlock $scriptBlock


### PR DESCRIPTION
> Thanks for your pull request, we really appreciate contributions!
>
> Please understand that it may take some time to be reviewed.
>
> Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).


Didn't know there is a command `task --list-all --json/--silent` for all available tasks when I submit last PR.

Previous, if your pwd have a dir or file named `gen` or `gen...`, and you have a task named `gen`,
when you type `task gen<tab>`, powershell will fallback to filepath complete, and your input will become `task .\gen`

after this pr, `task gen<tab>` are still `task gen`

File path auto completion still works with `.\<tab>` or `./<tab>`

