### PR TITLE
feat: add French language in the navbar dropdown

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -27,7 +27,7 @@ const config = {
 
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'zh-Hans'],
+    locales: ['en', 'zh-Hans', 'fr-FR'],
     localeConfigs: {
       en: {
         label: 'English',
@@ -38,6 +38,11 @@ const config = {
         label: '简体中文',
         direction: 'ltr',
         htmlLang: 'zh-Hans'
+      },
+      'fr-FR': {
+        label: 'Français',
+        direction: 'ltr',
+        htmlLang: 'fr'
       }
     }
   },


### PR DESCRIPTION
Hello, 

According to the pull request https://github.com/go-task/task/pull/1156, French translations will be added. This PR adds the "Français" choice in the language dropdown list.

![image](https://github.com/go-task/task/assets/50453254/5a8dc07e-d572-429c-a2f9-d41acfc2a182)
