### PR TITLE
fix: only rewrite checksum files if the checksum has changed

### DIFF
--- a/internal/fingerprint/sources_checksum.go
+++ b/internal/fingerprint/sources_checksum.go
@@ -42,7 +42,7 @@ func (checker *ChecksumChecker) IsUpToDate(t *taskfile.Task) (bool, error) {
 		return false, nil
 	}
 
-	if !checker.dry {
+	if !checker.dry && oldMd5 != newMd5 {
 		_ = os.MkdirAll(filepathext.SmartJoin(checker.tempDir, "checksum"), 0o755)
 		if err = os.WriteFile(checksumFile, []byte(newMd5+"\n"), 0o644); err != nil {
 			return false, err


### PR DESCRIPTION
Resolves https://github.com/go-task/task/issues/1185.

I verified that the test case fails on main as well.