### PR TITLE
feat: add a deprecation warning when running Taskfiles with a v2 schema

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,13 +3,18 @@ name: Bug Report
 about: Use this to report bugs and issues
 ---
 
-> Thanks for your bug report!
->
-> Before submitting this issue, please make sure the same problem was
-> not already reported by someone else.
->
-> Please describe the bug you're facing. Consider pasting example
-> Taskfiles showing how to reproduce the problem.
+<!--
+
+Thanks for your bug report!
+
+Before submitting this issue, please make sure the same problem was not
+already reported by someone else.
+
+Please describe the bug you're facing. Consider pasting example Taskfiles
+showing how to reproduce the problem.
+
+-->
 
 - Task version:
-- Operating System:
+- Operating system:
+- Experiments enabled:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,9 +3,13 @@ name: Feature Request
 about: Use this to make feature requests
 ---
 
-> Describe in detail what feature do you want to see in Task.
-> Give examples if possible.
->
-> Please, search if this wasn't proposed before, and if this is more like an idea
-> than a strong feature request, consider opening a
-> [discussion](https://github.com/go-task/task/discussions) instead.
+<!--
+
+Describe in detail what feature do you want to see in Task.
+Give examples if possible.
+
+Please, search if this wasn't proposed before, and if this is more like an idea
+than a strong feature request, consider opening a
+[discussion](https://github.com/go-task/task/discussions) instead.
+
+-->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   #1194 by @deviantintegral).
 - Added [experiments documentation](https://taskfile.dev/experiments) to the
   website (#1198 by @pd93).
+- Deprecated `version: 2` schema. This will be removed in the next major release
+  (#1197, #1198, #1199 by @pd93).
 
 ## v3.25.0 - 2023-05-22
 

--- a/setup.go
+++ b/setup.go
@@ -250,7 +250,11 @@ func (e *Executor) doVersionChecks() error {
 	*v = *e.Taskfile.Version
 
 	if v.LessThan(taskfile.V2) {
-		return fmt.Errorf(`task: Taskfile versions prior to v2 are not supported anymore`)
+		return fmt.Errorf(`task: version 1 schemas are no longer supported`)
+	}
+
+	if v.LessThan(taskfile.V3) {
+		e.Logger.Errf(logger.Yellow, "task: version 2 schemas are deprecated and will be removed in a future release\nSee https://github.com/go-task/task/issues/1197 for more details\n")
 	}
 
 	// consider as equal to the greater version if round

--- a/task_test.go
+++ b/task_test.go
@@ -1371,7 +1371,7 @@ func TestDynamicVariablesShouldRunOnTheTaskDir(t *testing.T) {
 	tt.Run(t)
 }
 
-func TestDisplaysErrorOnUnsupportedVersion(t *testing.T) {
+func TestDisplaysErrorOnVersion1Schema(t *testing.T) {
 	e := task.Executor{
 		Dir:    "testdata/version/v1",
 		Stdout: io.Discard,
@@ -1379,7 +1379,19 @@ func TestDisplaysErrorOnUnsupportedVersion(t *testing.T) {
 	}
 	err := e.Setup()
 	require.Error(t, err)
-	assert.Equal(t, "task: Taskfile versions prior to v2 are not supported anymore", err.Error())
+	assert.Equal(t, "task: version 1 schemas are no longer supported", err.Error())
+}
+
+func TestDisplaysWarningOnVersion2Schema(t *testing.T) {
+	var buff bytes.Buffer
+	e := task.Executor{
+		Dir:    "testdata/version/v2",
+		Stdout: io.Discard,
+		Stderr: &buff,
+	}
+	err := e.Setup()
+	require.NoError(t, err)
+	assert.Equal(t, "task: version 2 schemas are deprecated and will be removed in a future release\nSee https://github.com/go-task/task/issues/1197 for more details\n", buff.String())
 }
 
 func TestShortTaskNotation(t *testing.T) {


### PR DESCRIPTION
Added a warning to the output when using a `version: 2` schema. (This functionality was split out of #1198).

![image](https://github.com/go-task/task/assets/9294862/17e9b6fb-b2fc-4a7f-abc1-fd2b9a5d57f3)

This might break things for people using v2 schemas in scripts if they update... we could stop output if the `--silent` flag is specified, but this might not stop it from breaking where some tasks have `silent: true`. Maybe we send the output to stderr instead? Thoughts welcome.