### PR TITLE
chore(website): update website colors

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -13,9 +13,49 @@
   --ifm-color-primary-lightest: #5D9993;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+
+  --ifm-navbar-link-color: #fffdf9;
+  --ifm-navbar-link-hover-color: #fffdf9;
+}
+.menu__link--sublist.menu__link--active,
+.menu__link--sublist.menu__link--active:hover {
+  background-color: #43aba2 !important;
 }
 
-[data-theme='dark'] {
+[data-theme='light'] {
+  --ifm-background-color: #fffdf9;
+  --ifm-background-surface-color: #2b2d31;
+  --ifm-color-primary: #43aba2;
+  --ifm-dropdown-link-color: #fffdf9;
+  --ifm-link-color: #43aba2;
+  --ifm-breadcrumb-color-active: #2b2d31;
+}
+
+.menu, .navbar, .navbar-sidebar {
+  --ifm-menu-color-background-active: #43aba2;
+  --ifm-menu-color-active: #fffdf9;
+}
+.navbar, .navbar-sidebar {
+  --ifm-menu-color: #fffdf9;
+}
+.navbar-sidebar__back {
+  color: #fffdf9;
+}
+
+[data-theme='light'] svg[class*="lightToggleIcon"],
+[data-theme='light'] .navbar__toggle {
+  color: #fffdf9 !important;
+}
+
+[data-theme='light'] div[class*="codeBlockTitle"],
+[data-theme='light'] code[class*="codeBlockLines"] {
+  background-color: #f7f5f1 !important;
+}
+
+[data-theme='dark'], .footer--dark {
+  --ifm-background-color: #242526 !important;
+  --ifm-background-surface-color: #2b2d31 !important;
+  --ifm-footer-background-color: #2b2d31 !important;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 


### PR DESCRIPTION
Make light theme less white and dark theme less black. I find the legibility better with a slightly reduced contrast. This in a work in progress ™️. Opening to PR to get a quick opinion, maybe additional suggestions.

We can keep improving with time. Our theme is very basic currently, mostly identical to Docusaurus' default one.

/cc @pd93 @misitebao 

## Light Theme

### Before

<img width="1148" alt="Screenshot 2023-06-03 at 15 52 35" src="https://github.com/go-task/task/assets/7011819/1048f31c-5904-463f-a420-1051b402ae27">

### After - Option A

<img width="1134" alt="Screenshot 2023-06-03 at 15 52 55" src="https://github.com/go-task/task/assets/7011819/66f0c811-c6b1-4210-9aaf-fd1b771722b5">

### After - Option B

<img width="1212" alt="Screenshot 2023-06-03 at 18 59 34" src="https://github.com/go-task/task/assets/7011819/18c7c557-2d0e-49b4-bef2-8fd897218692">

## Dark Theme

### Before

<img width="1137" alt="Screenshot 2023-06-03 at 15 53 11" src="https://github.com/go-task/task/assets/7011819/51d61451-370d-4665-b0c2-ec33e0e89048">

### After

<img width="1136" alt="Screenshot 2023-06-03 at 15 53 37" src="https://github.com/go-task/task/assets/7011819/2c9ad42b-b2a7-401c-ad6c-12c2e12855ad">
