### PR TITLE
Support for experiment env vars

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-task/task/v3"
 	"github.com/go-task/task/v3/args"
 	"github.com/go-task/task/v3/errors"
+	"github.com/go-task/task/v3/internal/experiments"
 	"github.com/go-task/task/v3/internal/logger"
 	"github.com/go-task/task/v3/internal/sort"
 	ver "github.com/go-task/task/v3/internal/version"
@@ -96,6 +97,11 @@ func main() {
 func run() error {
 	log.SetFlags(0)
 	log.SetOutput(os.Stderr)
+
+	// Experiments must be parsed before pflag.Parse() is called
+	if err := experiments.Parse(); err != nil {
+		return err
+	}
 
 	pflag.Usage = func() {
 		log.Print(usage)

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -15,7 +15,6 @@ import (
 	"github.com/go-task/task/v3"
 	"github.com/go-task/task/v3/args"
 	"github.com/go-task/task/v3/errors"
-	"github.com/go-task/task/v3/internal/experiments"
 	"github.com/go-task/task/v3/internal/logger"
 	"github.com/go-task/task/v3/internal/sort"
 	ver "github.com/go-task/task/v3/internal/version"
@@ -97,11 +96,6 @@ func main() {
 func run() error {
 	log.SetFlags(0)
 	log.SetOutput(os.Stderr)
-
-	// Experiments must be parsed before pflag.Parse() is called
-	if err := experiments.Parse(); err != nil {
-		return err
-	}
 
 	pflag.Usage = func() {
 		log.Print(usage)

--- a/docs/docs/experiments/experiments.md
+++ b/docs/docs/experiments/experiments.md
@@ -21,13 +21,19 @@ are intended to replace.
 
 You can enable an experimental feature by:
 
-1. Using the `--x-{feature}` flag. This is intended for one-off invocations of
-   Task to test out experimental features. You can also disable a feature by
-   specifying a falsy value such as `--x-{feature}=false`.
-1. Using the `TASK_X_{FEATURE}=1` environment variable. This is intended for
-   permanently enabling experimental features in your environment.
+1. Using the relevant environment variable in front of a task command. For
+   example, `TASK_X_{FEATURE}=1 task {my-task}`. This is intended for one-off
+   invocations of Task to test out experimental features.
+1. Using the relevant environment variable in your "dotfiles" (e.g. `.bashrc`,
+   `.zshrc` etc.). This is intended for permanently enabling experimental
+   features in your environment.
+1. Creating a `.env` file in the same directory as your root Taskfile that
+   contains the relevant environment variables. e.g.
 
-Flags will always override environment variables.
+```shell
+# .env
+TASK_X_FEATURE=1
+```
 
 ## Current Experimental Features and Deprecations
 
@@ -38,11 +44,11 @@ existing Taskfiles to the new behavior.
 
 <!-- EXPERIMENT TEMPLATE - Include sections as necessary...
 
-### ![experiment] <Feature> ([#{issue}](https://github.com/go-task/task/issues/{issue})), ...)
+### ![experiment] {Feature} ([#{issue}](https://github.com/go-task/task/issues/{issue})), ...)
 
-- Flag to enable: `--x-{feature}`
-- Env to enable: `TASK_X_{feature}`
+- Environment variable: `TASK_X_{feature}`
 - Deprecates: {list any existing functionality that will be deprecated by this experiment}
+- Breaks: {list any existing functionality that will be broken by this experiment}
 
 {Short description of the feature}
 

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -1,0 +1,43 @@
+package experiments
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+)
+
+var Flags struct{}
+
+func Parse() error {
+	t := reflect.TypeOf(&Flags)
+	v := reflect.ValueOf(&Flags)
+	if t.Elem().Kind() != reflect.Struct {
+		return fmt.Errorf("expected struct, got %T", v.Kind())
+	}
+	for i := 0; i < t.Elem().NumField(); i++ {
+		fieldT := t.Elem().Field(i)
+		fieldV := v.Elem().Field(i)
+		if fieldT.Type.Kind() != reflect.Bool {
+			return fmt.Errorf("task: expected bool, got %T", fieldV.Kind())
+		}
+		if !fieldV.CanSet() {
+			return fmt.Errorf("task: cannot set experiment field: %q", fieldT.Name)
+		}
+		xName := fieldT.Tag.Get("x")
+		xEnabled := parseEnv(xName)
+		fieldV.SetBool(xEnabled)
+	}
+	return nil
+}
+
+func envName(xName string) string {
+	xName = strings.ToUpper(xName)
+	xName = strings.ReplaceAll(xName, " ", "_")
+	xName = fmt.Sprintf("TASK_X_%s", xName)
+	return xName
+}
+
+func parseEnv(xName string) bool {
+	return os.Getenv(envName(xName)) == "1"
+}

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"reflect"
 	"strings"
 
 	"github.com/joho/godotenv"
@@ -12,49 +11,26 @@ import (
 
 const envPrefix = "TASK_X_"
 
-var Flags struct{}
+var TestExperiment bool
 
-func Parse() error {
+func init() {
 	if err := readDotEnv(); err != nil {
-		return err
+		panic(err)
 	}
-	t := reflect.TypeOf(&Flags)
-	v := reflect.ValueOf(&Flags)
-	if t.Elem().Kind() != reflect.Struct {
-		return fmt.Errorf("expected struct, got %T", v.Kind())
-	}
-	for i := 0; i < t.Elem().NumField(); i++ {
-		fieldT := t.Elem().Field(i)
-		fieldV := v.Elem().Field(i)
-		if fieldT.Type.Kind() != reflect.Bool {
-			return fmt.Errorf("task: expected bool, got %T", fieldV.Kind())
-		}
-		if !fieldV.CanSet() {
-			return fmt.Errorf("task: cannot set experiment field: %q", fieldT.Name)
-		}
-		xName := fieldT.Tag.Get("x")
-		xEnabled := parseEnv(xName)
-		fieldV.SetBool(xEnabled)
-	}
-	return nil
-}
-
-func envName(xName string) string {
-	xName = strings.ToUpper(xName)
-	xName = strings.ReplaceAll(xName, " ", "_")
-	xName = fmt.Sprintf("%s%s", envPrefix, xName)
-	return xName
+	TestExperiment = parseEnv("TestExperiment")
 }
 
 func parseEnv(xName string) bool {
-	return os.Getenv(envName(xName)) == "1"
+	envName := fmt.Sprintf("%s%s", envPrefix, xName)
+	return os.Getenv(envName) == "1"
 }
 
 func readDotEnv() error {
 	env, err := godotenv.Read()
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
-	} else if err != nil {
+	}
+	if err != nil {
 		return err
 	}
 	// If the env var is an experiment, set it.


### PR DESCRIPTION
This PR adds support for experimental feature environment variables. This follows the design discussed in the [breaking changes proposal](https://github.com/go-task/task/issues/1191).

Environment variables can be specified in 3 ways:

1. Using the relevant environment variable in front of a task command. For
   example, `TASK_X_<FEATURE>=1 task <my-task>`. This is intended for one-off
   invocations of Task to test out experimental features.
1. Using the relevant environment variable in your "dotfiles" (e.g. `.bashrc`,
   `.zshrc` etc.). This is intended for permanently enabling experimental
   features in your environment.
1. Creating a `.env` file in the same directory as your root Taskfile that
   contains the relevant environment variables. e.g.

```shell
# .env
TASK_X_FEATURE=1
```

The dotenv reader will only read environment variables that start with `TASK_X_` to avoid polluting the environment with other variables.