### PR TITLE
Small prompt fixes

### DIFF
--- a/errors/errors_task.go
+++ b/errors/errors_task.go
@@ -105,10 +105,7 @@ type TaskCancelledByUserError struct {
 }
 
 func (err *TaskCancelledByUserError) Error() string {
-	return fmt.Sprintf(
-		`task: Task "%q" cancelled by user`,
-		err.TaskName,
-	)
+	return fmt.Sprintf(`task: Task %q cancelled by user`, err.TaskName)
 }
 
 func (err *TaskCancelledByUserError) Code() int {
@@ -122,7 +119,7 @@ type TaskCancelledNoTerminalError struct {
 
 func (err *TaskCancelledNoTerminalError) Error() string {
 	return fmt.Sprintf(
-		`task: Task "%q" cancelled because it has a prompt and the environment is not a terminal. Use --yes (-y) to run anyway.`,
+		`task: Task %q cancelled because it has a prompt and the environment is not a terminal. Use --yes (-y) to run anyway.`,
 		err.TaskName,
 	)
 }

--- a/task.go
+++ b/task.go
@@ -155,7 +155,7 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 			return &errors.TaskCancelledNoTerminalError{TaskName: call.Task}
 		}
 
-		e.Logger.Outf(logger.Yellow, "task: %q [y/N]\n", t.Prompt)
+		e.Logger.Outf(logger.Yellow, "task: %q [y/N]: ", t.Prompt)
 
 		reader := bufio.NewReader(e.Stdin)
 		userInput, err := reader.ReadString('\n')


### PR DESCRIPTION
This PR fixes a couple of minor output related "problems" with the new `prompt` feature:

- Removes duplicated double quotes. We don't need to add quotes when using `%q`:
- Removes the newline after the prompt is requested. This makes the output a bit tidier:

Before:
![image](https://github.com/go-task/task/assets/9294862/c67b2759-314f-4963-ad0f-50b8c933fd8e)
![image](https://github.com/go-task/task/assets/9294862/233770e4-2225-4af7-ac3f-3851614f1176)

After:
![image](https://github.com/go-task/task/assets/9294862/eebf0c83-bbb1-451f-bd14-043c07f6fa63)
![image](https://github.com/go-task/task/assets/9294862/1452372a-f07e-44a9-bff3-f598784d849f)
