### PR TITLE
docs: Add tea installation

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -29,6 +29,23 @@ so you also have that option if you prefer:
 brew install go-task
 ```
 
+### Tea
+
+If you're on macOS or Linux and have [tea][tea] installed, getting
+Task is as simple as running:
+
+```bash
+tea task
+```
+
+or, if you have tea’s magic enabled:
+
+```bash
+task
+```
+This installation method is community owned. After a new release of Task, they
+are automatically released by tea in a minimum of time.
+
 ### Snap
 
 Task is available in [Snapcraft][snapcraft], but keep in mind that your Linux
@@ -281,4 +298,5 @@ Invoke-Expression -Command path/to/task.ps1
 [godownloader]: https://github.com/goreleaser/godownloader
 [choco]: https://chocolatey.org/
 [scoop]: https://scoop.sh/
+[tea]: https://tea.xyz/
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
I just added `task` to the `tea` package manager, see https://tea.xyz/+taskfile.dev/ and https://github.com/teaxyz/pantry/pull/2323

This MR adds the related installation documentation.

According to the update statement, `tea` is automated at this: https://github.com/teaxyz/pantry#after-your-contribution

Greetings