### PR TITLE
fix: propagate include vars in multi-level includes

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -1798,6 +1798,29 @@ VAR_2 is included-default-var2
 	assert.Equal(t, strings.TrimSpace(buff.String()), expectedOutputOrder)
 }
 
+func TestIncludedVarsMultiLevel(t *testing.T) {
+	const dir = "testdata/include_with_vars_multi_level"
+	var buff bytes.Buffer
+	e := task.Executor{
+		Dir:    dir,
+		Stdout: &buff,
+		Stderr: &buff,
+	}
+	require.NoError(t, e.Setup())
+
+	expectedOutputOrder := strings.TrimSpace(`
+task: [lib:greet] echo 'Hello world'
+Hello world
+task: [foo:lib:greet] echo 'Hello foo'
+Hello foo
+task: [bar:lib:greet] echo 'Hello bar'
+Hello bar
+`)
+	require.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "default"}))
+	t.Log(buff.String())
+	assert.Equal(t, strings.TrimSpace(buff.String()), expectedOutputOrder)
+}
+
 func TestErrorCode(t *testing.T) {
 	const dir = "testdata/error_code"
 

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -149,7 +149,10 @@ func Taskfile(readerNode *ReaderNode) (*taskfile.Taskfile, string, error) {
 
 			for _, task := range includedTaskfile.Tasks.Values() {
 				task.Dir = filepathext.SmartJoin(dir, task.Dir)
-				task.IncludeVars = includedTask.Vars
+				if task.IncludeVars == nil {
+					task.IncludeVars = &taskfile.Vars{}
+				}
+				task.IncludeVars.Merge(includedTask.Vars)
 				task.IncludedTaskfileVars = includedTaskfile.Vars
 				task.IncludedTaskfile = &includedTask
 			}

--- a/testdata/include_with_vars_multi_level/Taskfile.yml
+++ b/testdata/include_with_vars_multi_level/Taskfile.yml
@@ -1,0 +1,17 @@
+version: "3"
+
+includes:
+  lib:
+    taskfile: lib/Taskfile.yml
+    internal: true
+  foo:
+    taskfile: foo/Taskfile.yml
+  bar:
+    taskfile: bar/Taskfile.yml
+
+tasks:
+  default:
+    cmds:
+      - task: lib:greet
+      - task: foo:lib:greet
+      - task: bar:lib:greet

--- a/testdata/include_with_vars_multi_level/bar/Taskfile.yml
+++ b/testdata/include_with_vars_multi_level/bar/Taskfile.yml
@@ -1,0 +1,7 @@
+version: "3"
+
+includes:
+  lib:
+    taskfile: ../lib/Taskfile.yml
+    vars:
+      RECEIVER: "bar"

--- a/testdata/include_with_vars_multi_level/foo/Taskfile.yml
+++ b/testdata/include_with_vars_multi_level/foo/Taskfile.yml
@@ -1,0 +1,7 @@
+version: "3"
+
+includes:
+  lib:
+    taskfile: ../lib/Taskfile.yml
+    vars:
+      RECEIVER: "foo"

--- a/testdata/include_with_vars_multi_level/lib/Taskfile.yml
+++ b/testdata/include_with_vars_multi_level/lib/Taskfile.yml
@@ -1,0 +1,9 @@
+version: "3"
+
+vars:
+  RECEIVER: "world"
+
+tasks:
+  greet:
+    cmds:
+      - echo 'Hello {{.RECEIVER}}'


### PR DESCRIPTION
Previously, included vars would be set to nil upon being included by another taskfile. They are now propagated up during the include process.

This is especially problematic for users who want to use library-like taskfiles in a monorepo.
```
├── common
│   └── docker.yml
├── service-a
│   └── Taskfile.yml 
├── service-b
│   └── Taskfile.yml
└── Taskfile.yaml
```

You can imagine that the contents of `service-a/Taskfile.yml` resemble
```yaml
version: '3'
includes:
  docker:
    taskfile: ../common/docker.yml
    vars:
      DOCKER_IMAGE: service-a
```

Fixes: 
- https://github.com/go-task/task/issues/778
- https://github.com/go-task/task/issues/996

