### PR TITLE
fix: add nil guards in dependency merge

### DIFF
--- a/taskfile/merge.go
+++ b/taskfile/merge.go
@@ -41,7 +41,9 @@ func Merge(t1, t2 *Taskfile, includedTaskfile *IncludedTaskfile, namespaces ...s
 
 		// Add namespaces to dependencies, commands and aliases
 		for _, dep := range task.Deps {
-			dep.Task = taskNameWithNamespace(dep.Task, namespaces...)
+			if dep != nil && dep.Task != "" {
+				dep.Task = taskNameWithNamespace(dep.Task, namespaces...)
+			}
 		}
 		for _, cmd := range task.Cmds {
 			if cmd != nil && cmd.Task != "" {


### PR DESCRIPTION
I accidentally had an empty `deps` row in a nested config, like so:

```
tasks:
  task-name:
    deps:
      - dep-task-name 
      - # commented-out-task-name  , but at wrong place!
```

This caused a panic like this:
```
> task --version
Task version: 3.27.1

> task
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1028c0fb0]

goroutine 1 [running]:
github.com/go-task/task/v3/taskfile.Merge.func1({0x140001dc350, 0xe}, 0x140001fb0e0)
        github.com/go-task/task/v3/taskfile/merge.go:44 +0xd0
github.com/go-task/task/v3/internal/orderedmap.(*OrderedMap[...]).Range(0x102a1c5e0, 0x140001337a8)
        github.com/go-task/task/v3/internal/orderedmap/orderedmap.go:114 +0xa4
github.com/go-task/task/v3/taskfile.Merge(0x140001347e0, 0x14000200fc0, 0x14000064fc0, {0x14000133900, 0x1, 0x1})
        github.com/go-task/task/v3/taskfile/merge.go:33 +0x23c
github.com/go-task/task/v3/taskfile/read.Taskfile.func2({0x14000015410, 0x8}, {{0x140000163f0, 0x17}, {0x14000015440, 0xa}, 0x0, 0x0, {0x0, 0x0, ...}, ...})
        github.com/go-task/task/v3/taskfile/read/taskfile.go:158 +0x6c4
github.com/go-task/task/v3/taskfile.(*IncludedTaskfiles).Range(0x14000062800, 0x14000133ba8)
        github.com/go-task/task/v3/taskfile/included_taskfile.go:80 +0x134
github.com/go-task/task/v3/taskfile/read.Taskfile(0x14000079440)
        github.com/go-task/task/v3/taskfile/read/taskfile.go:75 +0x160
github.com/go-task/task/v3.(*Executor).readTaskfile(0x14000001180)
        github.com/go-task/task/v3/setup.go:79 +0x94
github.com/go-task/task/v3.(*Executor).Setup(0x14000001180)
        github.com/go-task/task/v3/setup.go:30 +0x2c
main.run()
        github.com/go-task/task/v3/cmd/task/task.go:250 +0xdb4
main.main()
        github.com/go-task/task/v3/cmd/task/task.go:77 +0x20
```

There was an unguarded `nil` pointer dereference in [`github.com/go-task/task/v3/taskfile/merge.go:44`](https://github.com/go-task/task/blob/v3.27.1/taskfile/merge.go#L44).