### PR TITLE
fix: exit codes for indirect tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fixed variable propagation in multi-level includes (#778, #996, #1256 by
   @hudclark).
+- Fixed a bug where the `--exit-code` code flag was not returning the correct
+  exit code when calling commands indirectly (#1266, #1270 by @pd93).
 
 ## v3.27.1 - 2023-06-30
 

--- a/task.go
+++ b/task.go
@@ -239,6 +239,10 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 					continue
 				}
 
+				if !call.Direct {
+					return err
+				}
+
 				return &errors.TaskRunError{TaskName: t.Task, Err: err}
 			}
 		}

--- a/testdata/error_code/Taskfile.yml
+++ b/testdata/error_code/Taskfile.yml
@@ -1,6 +1,10 @@
 version: '3'
 
 tasks:
-  test-exit-code:
+  direct:
     cmds:
       - exit 42
+
+  indirect:
+    cmds:
+      - task: direct


### PR DESCRIPTION
Fixes #1266

This bug is happening because when we run a command, we are always wrapping the `interp.exitStatus` error and returning a `TaskRunError`:

https://github.com/go-task/task/blob/7e7a016df393373ec9322b6fbadc1cbc3db61366/task.go#L232-L243

This works fine at the top-level (for direct calls) because we can simply unwrap the error in Task's main function: 

https://github.com/go-task/task/blob/7e7a016df393373ec9322b6fbadc1cbc3db61366/cmd/task/task.go#L84-L87

However, when we run a command _indirectly_ via another task, we are wrapping the `TaskRunError` in another `TaskRunError`. This problem is recursive and means that we can't effectively unwrap the error to get the exit code out.

The solution to this is simply to check if the command is being called directly and if not, we return the `interp.exitStatus` directly instead of wrapping it up. This means that we only wrap once on the top-level error and unwrapping in the main function just works.

I've also updated the tests to cover this case.