### PR TITLE
fix: wrong working directory with USER_WORKING_DIR in included Taskfi…

### DIFF
--- a/internal/compiler/v3/compiler_v3.go
+++ b/internal/compiler/v3/compiler_v3.go
@@ -84,6 +84,10 @@ func (c *CompilerV3) getVariables(t *taskfile.Task, call *taskfile.Call, evaluat
 
 	var taskRangeFunc func(k string, v taskfile.Var) error
 	if t != nil {
+		if strings.HasSuffix(t.Dir, "{{.USER_WORKING_DIR}}") {
+			t.Dir = "{{.USER_WORKING_DIR}}"
+		}
+
 		// NOTE(@andreynering): We're manually joining these paths here because
 		// this is the raw task, not the compiled one.
 		tr := templater.Templater{Vars: result, RemoveNoValue: true}

--- a/task_test.go
+++ b/task_test.go
@@ -1922,6 +1922,20 @@ func TestUserWorkingDirectory(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%s\n", wd), buff.String())
 }
 
+func TestUserWorkingDirectoryPwd(t *testing.T) {
+	var buff bytes.Buffer
+	e := task.Executor{
+		Dir:    "testdata/user_working_dir_pwd",
+		Stdout: &buff,
+		Stderr: &buff,
+	}
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, e.Setup())
+	require.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "included:default"}))
+	assert.Equal(t, fmt.Sprintf("%s\n", wd), buff.String())
+}
+
 func TestPlatforms(t *testing.T) {
 	var buff bytes.Buffer
 	e := task.Executor{

--- a/testdata/user_working_dir_pwd/Taskfile.yml
+++ b/testdata/user_working_dir_pwd/Taskfile.yml
@@ -1,0 +1,5 @@
+version: '3'
+
+includes:
+  included:
+    taskfile: ./included

--- a/testdata/user_working_dir_pwd/included/Taskfile.yml
+++ b/testdata/user_working_dir_pwd/included/Taskfile.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+tasks:
+  default:
+    dir: '{{.USER_WORKING_DIR}}'
+    cmds:
+      - pwd
+    silent: true


### PR DESCRIPTION
…les (#1250)

When using `dir: '{{.USER_WORKING_DIR}}'` in an included task, the working directory was set incorrectly by concatenating the base Taskfile directory and the USER_WORKING_DIR.

#1205 might be the same problem and is possibly fixed too, but I haven't tested the patch on Windows.

Also, while this patch fixes the symptom, there a better place to implement the fix would be where the USER_WORKING_DIR gets concatenated in the first place, but I wasn't able the find that in the time a had available. At least this patch and the included test case should point you in the right direction.
