### PR TITLE
fix: defer keyword in json schema

### DIFF
--- a/docs/static/schema.json
+++ b/docs/static/schema.json
@@ -209,6 +209,9 @@
             "$ref": "#/definitions/3/task_call"
           },
           {
+            "$ref": "#/definitions/3/defer_call"
+          },
+          {
             "$ref": "#/definitions/3/for_call"
           }
         ]
@@ -308,10 +311,6 @@
             "description": "Prevent command from aborting the execution of task even after receiving a status code of 1",
             "type": "boolean"
           },
-          "defer": {
-            "description": "",
-            "type": "boolean"
-          },
           "platforms": {
             "description": "Specifies which platforms the command should be run on.",
             "type": "array",
@@ -322,6 +321,17 @@
         },
         "additionalProperties": false,
         "required": ["cmd"]
+      },
+      "defer_call": {
+        "type": "object",
+        "properties": {
+          "defer": {
+            "description": "Run a command when the task completes. This command will run even when the task fails",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["defer"]
       },
       "for_call": {
         "type": "object",


### PR DESCRIPTION
This fixes a few issues with JSON schema validation when using the `defer` keyword.
It adds a `defer_call` object that is used alongside `cmd_call` and `for_call`. Then, `defer` is removed from the `cmd_call`.

## Example Taskfile:
```yaml
version: "3"

tasks:
  integration-test:
    desc: Startup docker resources and run integration tests. Cleanup when done.
    dir: ./garden-app
    cmds:
      - docker compose -f ../deploy/docker-compose.yml --profile test up -d
      - defer: docker volume rm deploy_influxdb
      - defer: docker compose -f ../deploy/docker-compose.yml --profile test down
      - sleep 15
      - go test -race -covermode=atomic -coverprofile=integration_coverage.out -coverpkg=./... ./integration_tests
```

## Errors:
```
Incorrect type. Expected "boolean".
Missing property "cmd".
```
![Screenshot 2023-07-30 at 21 03 31](https://github.com/go-task/task/assets/19335917/6c79bed0-2ab0-4c89-a093-b2ca1849c920)
![Screenshot 2023-07-30 at 21 03 39](https://github.com/go-task/task/assets/19335917/c52a6163-c6da-4bfe-9376-e809d0abc8d3)

