### PR TITLE
docs: add required version for supporting loops

### DIFF
--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -1001,9 +1001,9 @@ This works for all types of variables.
 
 ## Looping over values
 
-Task allows you to loop over certain values and execute a command for each.
-There are a number of ways to do this depending on the type of value you want to
-loop over.
+As of v3.28.0, Task allows you to loop over certain values and execute a
+command for each. There are a number of ways to do this depending on the type
+of value you want to loop over.
 
 ### Looping over a static list
 


### PR DESCRIPTION
I was banging my head on this for quite some time, reading the docs and trying to get loops working. Eventually I started looking through the issue queue to see if there were bugs reported on this functionality. After reading through the issue queue, I learned that this feature is new, and therefore not available on the version of task that is installed using homebrew. Since using this feature on older versions of Task reports no errors or warnings, I think this little documentation change would be helpful for others.