### PR TITLE
fix #1285: Add missing `\n` to watcher log

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -27,7 +27,7 @@ func (e *Executor) watchTasks(calls ...taskfile.Call) error {
 		tasks[i] = c.Task
 	}
 
-	e.Logger.Errf(logger.Green, "task: Started watching for tasks: %s", strings.Join(tasks, ", "))
+	e.Logger.Errf(logger.Green, "task: Started watching for tasks: %s\n", strings.Join(tasks, ", "))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	for _, c := range calls {

--- a/watch_test.go
+++ b/watch_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/go-task/task/v3"
 	"github.com/go-task/task/v3/internal/filepathext"


### PR DESCRIPTION
Also fix `TestFileWatcherInterval` where import was missing
