### PR TITLE
feat: bump minimum go version to 1.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.20.x, 1.21.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.platform}}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update to Go 1.21 (bump minimum version to 1.20) (#1302 by @pd93)
 - Fix a missing a line break on log when using `--watch` mode (#1285, #1297 by
   @FilipSolich).
 - Fix `defer` on JSON Schema (#1288 by @calvinmclean and @andreynering).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-task/task/v3
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
[Go 1.21 was recently released](https://golang.org/blog/go1.21). This PR bumps the minimum required version to 1.20 inline with our promise of compatibility with the latest 2 versions of Go.