### PR TITLE
fix --status side effect, it should not write the computed checksum file

### DIFF
--- a/internal/fingerprint/task.go
+++ b/internal/fingerprint/task.go
@@ -68,7 +68,7 @@ func IsTaskUpToDate(
 	config := &CheckerConfig{
 		method:         "none",
 		tempDir:        "",
-		dry:            false,
+		dry:            true,
 		logger:         nil,
 		statusChecker:  nil,
 		sourcesChecker: nil,

--- a/status.go
+++ b/status.go
@@ -28,7 +28,6 @@ func (e *Executor) Status(ctx context.Context, calls ...taskfile.Call) error {
 		isUpToDate, err := fingerprint.IsTaskUpToDate(ctx, t,
 			fingerprint.WithMethod(method),
 			fingerprint.WithTempDir(e.TempDir),
-			fingerprint.WithDry(e.Dry),
 			fingerprint.WithLogger(e.Logger),
 		)
 		if err != nil {


### PR DESCRIPTION
This address #1305.

`task --status` writes the computed checksum on file.
The operation should be side effect free and just report if the task is up-to-date or not.

I'm opening the PR in draft to validate if my guess is correct.

I miss a test on this change, currently I don't think I can write an idiomatic test, maybe @pd93 could jump in for a bit of support / review.
 
Thank you