### PR TITLE
fix: `--status` flag should not have side-effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Fix bug in usage of special variables like `{{.USER_WORKING_DIR}}` in
   combination with `includes` (#1046, #1205, #1250, #1293, #1312, #1274 by
   @andarto, #1309 by @andreynering).
+- Fix bug on `--status` flag. Running this flag should not have side-effects:
+  it should not update the checksum on `.task`, only report its status (#1305,
+  #1307 by @visciang, #1313 by @andreynering).
 
 ## v3.28.0 - 2023-07-24
 

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -221,7 +221,7 @@ func run() error {
 		Silent:      flags.silent,
 		AssumeYes:   flags.assumeYes,
 		Dir:         flags.dir,
-		Dry:         flags.dry,
+		Dry:         flags.dry || flags.status,
 		Entrypoint:  flags.entrypoint,
 		Summary:     flags.summary,
 		Parallel:    flags.parallel,


### PR DESCRIPTION
Closes https://github.com/go-task/task/issues/1305
Closes https://github.com/go-task/task/pull/1307