### PR TITLE
feat: support negative globs

### DIFF
--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -642,11 +642,27 @@ tasks:
       - public/bundle.css
 ```
 
-`sources` and `generates` can be files or file patterns. When given, Task will
+`sources` and `generates` can be files or glob patterns. When given, Task will
 compare the checksum of the source files to determine if it's necessary to run
 the task. If not, it will just print a message like `Task "js" is up to date`.
 
-If you prefer this check to be made by the modification timestamp of the files,
+Negative globs can also be used to exclude files from fingerprinting by
+prepending the source with a `!`. Sources are evaluated in order, so a negative
+globs must come after the positive glob it is negating.
+
+```yaml
+version: '3'
+
+tasks:
+  css:
+    sources:
+      - 'mysources/**/*.css'
+      - '!mysources/ignoreme.css'
+    generates:
+      - 'public/bundle.css'
+```
+
+If you prefer these check to be made by the modification timestamp of the files,
 instead of its checksum (content), just set the `method` property to
 `timestamp`.
 
@@ -1001,9 +1017,9 @@ This works for all types of variables.
 
 ## Looping over values
 
-As of v3.28.0, Task allows you to loop over certain values and execute a
-command for each. There are a number of ways to do this depending on the type
-of value you want to loop over.
+As of v3.28.0, Task allows you to loop over certain values and execute a command
+for each. There are a number of ways to do this depending on the type of value
+you want to loop over.
 
 ### Looping over a static list
 
@@ -1043,9 +1059,8 @@ match that glob.
 
 Source paths will always be returned as paths relative to the task directory. If
 you need to convert this to an absolute path, you can use the built-in
-`joinPath` function.
-There are some [special variables](/api/#special-variables) that you may find
-useful for this.
+`joinPath` function. There are some [special variables](/api/#special-variables)
+that you may find useful for this.
 
 ```yaml
 version: '3'

--- a/internal/fingerprint/glob.go
+++ b/internal/fingerprint/glob.go
@@ -3,6 +3,7 @@ package fingerprint
 import (
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/mattn/go-zglob"
 
@@ -11,13 +12,23 @@ import (
 )
 
 func Globs(dir string, globs []string) ([]string, error) {
-	files := make([]string, 0)
+	fileMap := make(map[string]bool)
 	for _, g := range globs {
-		f, err := Glob(dir, g)
+		var negate bool
+		g, negate = strings.CutPrefix(g, "!")
+		matches, err := Glob(dir, g)
 		if err != nil {
 			continue
 		}
-		files = append(files, f...)
+		for _, match := range matches {
+			fileMap[match] = !negate
+		}
+	}
+	files := make([]string, 0)
+	for file, includePath := range fileMap {
+		if includePath {
+			files = append(files, file)
+		}
 	}
 	sort.Strings(files)
 	return files, nil

--- a/task_test.go
+++ b/task_test.go
@@ -1867,27 +1867,47 @@ func TestEvaluateSymlinksInPaths(t *testing.T) {
 		Stderr: &buff,
 		Silent: false,
 	}
-	require.NoError(t, e.Setup())
-	err := e.Run(context.Background(), taskfile.Call{Task: "default"})
-	require.NoError(t, err)
-	assert.NotEqual(t, `task: Task "default" is up to date`, strings.TrimSpace(buff.String()))
-	buff.Reset()
-	err = e.Run(context.Background(), taskfile.Call{Task: "test-sym"})
-	require.NoError(t, err)
-	assert.NotEqual(t, `task: Task "test-sym" is up to date`, strings.TrimSpace(buff.String()))
-	buff.Reset()
-	err = e.Run(context.Background(), taskfile.Call{Task: "default"})
-	require.NoError(t, err)
-	assert.NotEqual(t, `task: Task "default" is up to date`, strings.TrimSpace(buff.String()))
-	buff.Reset()
-	err = e.Run(context.Background(), taskfile.Call{Task: "default"})
-	require.NoError(t, err)
-	assert.Equal(t, `task: Task "default" is up to date`, strings.TrimSpace(buff.String()))
-	buff.Reset()
-	err = e.Run(context.Background(), taskfile.Call{Task: "reset"})
-	require.NoError(t, err)
-	buff.Reset()
-	err = os.RemoveAll(dir + "/.task")
+	tests := []struct {
+		name     string
+		task     string
+		expected string
+	}{
+		{
+			name:     "default (1)",
+			task:     "default",
+			expected: "task: [default] echo \"some job\"\nsome job",
+		},
+		{
+			name:     "test-sym (1)",
+			task:     "test-sym",
+			expected: "task: [test-sym] echo \"shared file source changed\" > src/shared/b",
+		},
+		{
+			name:     "default (2)",
+			task:     "default",
+			expected: "task: [default] echo \"some job\"\nsome job",
+		},
+		{
+			name:     "default (3)",
+			task:     "default",
+			expected: `task: Task "default" is up to date`,
+		},
+		{
+			name:     "reset",
+			task:     "reset",
+			expected: "task: [reset] echo \"shared file source\" > src/shared/b\ntask: [reset] echo \"file source\" > src/a",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.NoError(t, e.Setup())
+			err := e.Run(context.Background(), taskfile.Call{Task: test.task})
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, strings.TrimSpace(buff.String()))
+			buff.Reset()
+		})
+	}
+	err := os.RemoveAll(dir + "/.task")
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
This PR adds native support for negating a glob pattern in Task. e.g.

```yaml
version: '3'

tasks:
  css:
    sources:
      - 'mysources/**/*.css'
      - '!mysources/ignoreme.css'
    generates:
      - 'public/bundle.css'
```

It works by looping over an array of patterns _in order_. If a pattern is normal, the files are added to a map with a value of `true` (i.e. the files should be included). if a pattern begins with a `!`, then all the files matched by that pattern are added to (or updated in) the map with a value of `false` (i.e. they should not be included). We then loop through the map and convert all keys with a value of `true` into a slice. This slice is then sorted and returned.
