### PR TITLE
Command pre/post/task_separator hooks

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -238,6 +238,7 @@ func (e *Executor) setupDefaults() {
 func (e *Executor) setupConcurrencyState() {
 	e.executionHashes = make(map[string]context.Context)
 
+	e.taskSeparated = new(int32)
 	e.taskCallCount = make(map[string]*int32, e.Taskfile.Tasks.Len())
 	e.mkdirMutexMap = make(map[string]*sync.Mutex, e.Taskfile.Tasks.Len())
 	for _, k := range e.Taskfile.Tasks.Keys() {

--- a/taskfile/cmds.go
+++ b/taskfile/cmds.go
@@ -1,0 +1,6 @@
+package taskfile
+
+type Cmds struct {
+	Pre  string
+	Post string
+}

--- a/taskfile/cmds.go
+++ b/taskfile/cmds.go
@@ -1,6 +1,7 @@
 package taskfile
 
 type Cmds struct {
-	Pre  string
-	Post string
+	Pre           string
+	Post          string
+	TaskSeparator string `yaml:"task_separator"`
 }

--- a/taskfile/taskfile.go
+++ b/taskfile/taskfile.go
@@ -27,6 +27,7 @@ type Taskfile struct {
 	Shopt      []string
 	Vars       *Vars
 	Env        *Vars
+	Cmds       Cmds
 	Tasks      Tasks
 	Silent     bool
 	Dotenv     []string
@@ -47,6 +48,7 @@ func (tf *Taskfile) UnmarshalYAML(node *yaml.Node) error {
 			Shopt      []string
 			Vars       *Vars
 			Env        *Vars
+			Cmds       Cmds
 			Tasks      Tasks
 			Silent     bool
 			Dotenv     []string
@@ -66,6 +68,7 @@ func (tf *Taskfile) UnmarshalYAML(node *yaml.Node) error {
 		tf.Vars = taskfile.Vars
 		tf.Env = taskfile.Env
 		tf.Tasks = taskfile.Tasks
+		tf.Cmds = taskfile.Cmds
 		tf.Silent = taskfile.Silent
 		tf.Dotenv = taskfile.Dotenv
 		tf.Run = taskfile.Run


### PR DESCRIPTION
fixes #1013 

before change:

<img width="1438" alt="image" src="https://github.com/go-task/task/assets/81212505/7766dae2-3387-40cd-bc09-10ffea308844">

adding such snippet:


```yml
cmds:
  pre: echo ""
```

will make it look like this: (output nicely grouped even when output style is interleaved)


<img width="1419" alt="image" src="https://github.com/go-task/task/assets/81212505/ea4df80b-f55e-4f37-9a49-7e7dcada0431">


using an output style 'group' with end "\n" does not make sense to me because then I need to wait for the long-running task (even 10 minutes) to see the grouped output. this solves my problem as I have still dynamically printed output  and it is grouped nicely by this pre cmd hook printing empty line exactly as I desired.



