### PR TITLE
fix special variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fixed an issue where some special variables weren't being set correctly
+  (#1331, #1334 by @pd93)
+
 ## v3.30.0 - 2023-09-13
 
 - Prep work for Remote Taskfiles (#1316 by @pd93).

--- a/setup.go
+++ b/setup.go
@@ -55,6 +55,11 @@ func (e *Executor) Setup() error {
 }
 
 func (e *Executor) setCurrentDir() error {
+	// If the entrypoint is already set, we don't need to do anything
+	if e.Entrypoint != "" {
+		return nil
+	}
+
 	// Default the directory to the current working directory
 	if e.Dir == "" {
 		wd, err := os.Getwd()
@@ -64,22 +69,13 @@ func (e *Executor) setCurrentDir() error {
 		e.Dir = wd
 	}
 
-	// Ensure we have an absolute path
-	abs, err := filepath.Abs(e.Dir)
+	// Search for a taskfile
+	root, err := read.ExistsWalk(e.Dir)
 	if err != nil {
 		return err
 	}
-	e.Dir = abs
-
-	// If no entrypoint is specified, we need to search for a taskfile
-	if e.Entrypoint == "" {
-		root, err := read.ExistsWalk(e.Dir)
-		if err != nil {
-			return err
-		}
-		e.Dir = filepath.Dir(root)
-		e.Entrypoint = filepath.Base(root)
-	}
+	e.Dir = filepath.Dir(root)
+	e.Entrypoint = filepath.Base(root)
 
 	return nil
 }

--- a/setup.go
+++ b/setup.go
@@ -27,10 +27,10 @@ func (e *Executor) Setup() error {
 	if err := e.setCurrentDir(); err != nil {
 		return err
 	}
-	if err := e.setupTempDir(); err != nil {
+	if err := e.readTaskfile(); err != nil {
 		return err
 	}
-	if err := e.readTaskfile(); err != nil {
+	if err := e.setupTempDir(); err != nil {
 		return err
 	}
 	e.setupFuzzyModel()
@@ -88,6 +88,7 @@ func (e *Executor) readTaskfile() error {
 	if err != nil {
 		return err
 	}
+	e.Dir = filepath.Dir(e.Taskfile.Location)
 	return nil
 }
 

--- a/taskfile/read/node_file.go
+++ b/taskfile/read/node_file.go
@@ -25,7 +25,7 @@ func NewFileNode(uri string, opts ...NodeOption) (*FileNode, error) {
 		}
 		uri = d
 	}
-	path, err := existsWalk(uri)
+	path, err := Exists(uri)
 	if err != nil {
 		return nil, err
 	}

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -41,10 +41,14 @@ func readTaskfile(
 	l *logger.Logger,
 ) (*taskfile.Taskfile, error) {
 	var b []byte
+	var err error
 
-	cache, err := NewCache(tempDir)
-	if err != nil {
-		return nil, err
+	var cache *Cache
+	if node.Remote() {
+		cache, err = NewCache(tempDir)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// If the file is remote, check if we have a cached copy

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -42,8 +42,8 @@ func readTaskfile(
 ) (*taskfile.Taskfile, error) {
 	var b []byte
 	var err error
-
 	var cache *Cache
+
 	if node.Remote() {
 		cache, err = NewCache(tempDir)
 		if err != nil {
@@ -300,12 +300,12 @@ func Taskfile(
 	return _taskfile(node)
 }
 
-// exists will check if a file at the given path exists. If it does, it will
+// Exists will check if a file at the given path Exists. If it does, it will
 // return the path to it. If it does not, it will search the search for any
 // files at the given path with any of the default Taskfile files names. If any
 // of these match a file, the first matching path will be returned. If no files
 // are found, an error will be returned.
-func exists(path string) (string, error) {
+func Exists(path string) (string, error) {
 	fi, err := os.Stat(path)
 	if err != nil {
 		return "", err
@@ -324,19 +324,19 @@ func exists(path string) (string, error) {
 	return "", errors.TaskfileNotFoundError{URI: path, Walk: false}
 }
 
-// existsWalk will check if a file at the given path exists by calling the
+// ExistsWalk will check if a file at the given path exists by calling the
 // exists function. If a file is not found, it will walk up the directory tree
 // calling the exists function until it finds a file or reaches the root
 // directory. On supported operating systems, it will also check if the user ID
 // of the directory changes and abort if it does.
-func existsWalk(path string) (string, error) {
+func ExistsWalk(path string) (string, error) {
 	origPath := path
 	owner, err := sysinfo.Owner(path)
 	if err != nil {
 		return "", err
 	}
 	for {
-		fpath, err := exists(path)
+		fpath, err := Exists(path)
 		if err == nil {
 			return fpath, nil
 		}

--- a/taskfile/read/taskfile.go
+++ b/taskfile/read/taskfile.go
@@ -311,13 +311,13 @@ func Exists(path string) (string, error) {
 		return "", err
 	}
 	if fi.Mode().IsRegular() {
-		return path, nil
+		return filepath.Abs(path)
 	}
 
 	for _, n := range defaultTaskfiles {
 		fpath := filepathext.SmartJoin(path, n)
 		if _, err := os.Stat(fpath); err == nil {
-			return fpath, nil
+			return filepath.Abs(fpath)
 		}
 	}
 


### PR DESCRIPTION
Fixes #1331 

- fix: `e.Dir` not being set to the correct directory
- fix: only create a cache if the node is remote

The issue was that `e.Dir` wasn't being set to the root taskfile location after reading the taskfiles, so it was set to the working directory instead.

This fix causes some issues with the cache directory for the remote taskfiles experiment, but fixing the core functionality is the priority.