### PR TITLE
fix: templates on task descriptions

### DIFF
--- a/task.go
+++ b/task.go
@@ -458,13 +458,14 @@ func (e *Executor) GetTaskList(filters ...FilterFunc) ([]*taskfile.Task, error) 
 
 	// Compile the list of tasks
 	for i := range tasks {
-		task := tasks[i]
+		idx := i
+		task := tasks[idx]
 		g.Go(func() error {
 			compiledTask, err := e.FastCompiledTask(taskfile.Call{Task: task.Task})
 			if err == nil {
 				task = compiledTask
 			}
-			task = compiledTask
+			tasks[idx] = compiledTask
 			return nil
 		})
 	}

--- a/task_test.go
+++ b/task_test.go
@@ -828,6 +828,24 @@ func TestListCanListDescOnly(t *testing.T) {
 	}
 }
 
+func TestListDescInterpolation(t *testing.T) {
+	const dir = "testdata/list_desc_interpolation"
+
+	var buff bytes.Buffer
+	e := task.Executor{
+		Dir:    dir,
+		Stdout: &buff,
+		Stderr: &buff,
+	}
+
+	require.NoError(t, e.Setup())
+	if _, err := e.ListTasks(task.ListOptions{ListOnlyTasksWithDescriptions: true}); err != nil {
+		t.Error(err)
+	}
+
+	assert.Contains(t, buff.String(), "bar")
+}
+
 func TestStatusVariables(t *testing.T) {
 	const dir = "testdata/status_vars"
 

--- a/testdata/list_desc_interpolation/Taskfile.yml
+++ b/testdata/list_desc_interpolation/Taskfile.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+vars:
+  foo: bar
+
+tasks:
+  foo:
+    desc: "task has desc with {{ .foo }} var"


### PR DESCRIPTION
# Issue
When a task description has uses templates, they are not properly compiled when listing the tasks.

This was reported back in https://github.com/go-task/task/issues/276 and then fixed in https://github.com/go-task/task/pull/283

I think then there was a regression in f22389a8

I don't have much experience in go and in this project context, I've tried my best to find the real issue. 
