### PR TITLE
feat: unify prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Enabled the `--yes` flag for the
+  [Remote Taskfiles experiment](https://taskfile.dev/experiments/remote-taskfiles)
+  (#1344 by @pd93).
 - Add ability to set `watch: true` in a task to automatically run it in watch
   mode (#231, #1361 by @andreynering).
 - Fixed a bug on the watch mode where paths that contained `.git` (like

--- a/docs/docs/experiments/remote_taskfiles.md
+++ b/docs/docs/experiments/remote_taskfiles.md
@@ -54,6 +54,16 @@ Taskfiles:
    code `104` (not trusted) and nothing will run. If you accept the prompt, the
    checksum will be updated and the remote Taskfile will run.
 
+Sometimes you need to run Task in an environment that does not have an
+interactive terminal, so you are not able to accept a prompt. In these cases you
+are able to tell task to accept these prompts automatically by using the `--yes`
+flag. Before enabling this flag, you should:
+
+1. Be sure that you trust the source and contents of the remote Taskfile.
+2. Consider using a pinned version of the remote Taskfile (e.g. A link
+   containing a commit hash) to prevent Task from automatically accepting a
+   prompt that says a remote Taskfile has changed.
+
 Task currently supports both `http` and `https` URLs. However, the `http`
 requests will not execute by default unless you run the task with the
 `--insecure` flag. This is to protect you from accidentally running a remote

--- a/setup.go
+++ b/setup.go
@@ -157,10 +157,13 @@ func (e *Executor) setupStdFiles() {
 
 func (e *Executor) setupLogger() {
 	e.Logger = &logger.Logger{
-		Stdout:  e.Stdout,
-		Stderr:  e.Stderr,
-		Verbose: e.Verbose,
-		Color:   e.Color,
+		Stdin:      e.Stdin,
+		Stdout:     e.Stdout,
+		Stderr:     e.Stderr,
+		Verbose:    e.Verbose,
+		Color:      e.Color,
+		AssumeYes:  e.AssumeYes,
+		AssumeTerm: e.AssumeTerm,
 	}
 }
 

--- a/task_test.go
+++ b/task_test.go
@@ -681,11 +681,11 @@ func TestPromptInSummary(t *testing.T) {
 			inBuff.Write([]byte(test.input))
 
 			e := task.Executor{
-				Dir:         dir,
-				Stdin:       &inBuff,
-				Stdout:      &outBuff,
-				Stderr:      &errBuff,
-				AssumesTerm: true,
+				Dir:        dir,
+				Stdin:      &inBuff,
+				Stdout:     &outBuff,
+				Stderr:     &errBuff,
+				AssumeTerm: true,
 			}
 			require.NoError(t, e.Setup())
 
@@ -709,11 +709,11 @@ func TestPromptWithIndirectTask(t *testing.T) {
 	inBuff.Write([]byte("y\n"))
 
 	e := task.Executor{
-		Dir:         dir,
-		Stdin:       &inBuff,
-		Stdout:      &outBuff,
-		Stderr:      &errBuff,
-		AssumesTerm: true,
+		Dir:        dir,
+		Stdin:      &inBuff,
+		Stdout:     &outBuff,
+		Stderr:     &errBuff,
+		AssumeTerm: true,
 	}
 	require.NoError(t, e.Setup())
 


### PR DESCRIPTION
This allows the `--yes` flag to work for all prompts (including the ones in the remote Taskfiles experiment) and reduces some duplicated prompt code.
