### PR TITLE
feat: enable root remote taskfiles

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -92,11 +91,6 @@ func run() error {
 			return fmt.Errorf("task: Failed to get user home directory: %w", err)
 		}
 		dir = home
-	}
-
-	if entrypoint != "" {
-		dir = filepath.Dir(entrypoint)
-		entrypoint = filepath.Base(entrypoint)
 	}
 
 	var taskSorter sort.TaskSorter

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -131,10 +131,6 @@ func Validate() error {
 		return nil
 	}
 
-	if Dir != "" && Entrypoint != "" {
-		return errors.New("task: You can't set both --dir and --taskfile")
-	}
-
 	if Output.Name != "group" {
 		if Output.Group.Begin != "" {
 			return errors.New("task: You can't set --output-group-begin without --output=group")

--- a/setup.go
+++ b/setup.go
@@ -54,11 +54,11 @@ func (e *Executor) Setup() error {
 }
 
 func (e *Executor) getRootNode() (taskfile.Node, error) {
-	node, err := taskfile.NewRootNode(e.Dir, e.Entrypoint, e.Insecure)
+	node, err := taskfile.NewRootNode(e.Logger, e.Entrypoint, e.Dir, e.Insecure)
 	if err != nil {
 		return nil, err
 	}
-	e.Dir = node.BaseDir()
+	e.Dir = node.Dir()
 	return node, err
 }
 

--- a/setup.go
+++ b/setup.go
@@ -54,7 +54,7 @@ func (e *Executor) Setup() error {
 }
 
 func (e *Executor) getRootNode() (taskfile.Node, error) {
-	node, err := taskfile.NewRootNode(e.Logger, e.Entrypoint, e.Dir, e.Insecure)
+	node, err := taskfile.NewRootNode(e.Logger, e.Entrypoint, e.Dir, e.Insecure, e.Timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/task_test.go
+++ b/task_test.go
@@ -73,7 +73,7 @@ func (fct fileContentTest) Run(t *testing.T) {
 
 	for name, expectContent := range fct.Files {
 		t.Run(fct.name(name), func(t *testing.T) {
-			path := filepathext.SmartJoin(fct.Dir, name)
+			path := filepathext.SmartJoin(e.Dir, name)
 			b, err := os.ReadFile(path)
 			require.NoError(t, err, "Error reading file")
 			s := string(b)
@@ -1123,8 +1123,8 @@ func TestIncludesOptionalExplicitFalse(t *testing.T) {
 
 func TestIncludesFromCustomTaskfile(t *testing.T) {
 	tt := fileContentTest{
+		Entrypoint: "testdata/includes_yaml/Custom.ext",
 		Dir:        "testdata/includes_yaml",
-		Entrypoint: "Custom.ext",
 		Target:     "default",
 		TrimSpace:  true,
 		Files: map[string]string{
@@ -1486,16 +1486,12 @@ func TestDotenvShouldIncludeAllEnvFiles(t *testing.T) {
 }
 
 func TestDotenvShouldErrorWhenIncludingDependantDotenvs(t *testing.T) {
-	const dir = "testdata/dotenv/error_included_envs"
-	const entry = "Taskfile.yml"
-
 	var buff bytes.Buffer
 	e := task.Executor{
-		Dir:        dir,
-		Entrypoint: entry,
-		Summary:    true,
-		Stdout:     &buff,
-		Stderr:     &buff,
+		Dir:     "testdata/dotenv/error_included_envs",
+		Summary: true,
+		Stdout:  &buff,
+		Stderr:  &buff,
 	}
 
 	err := e.Setup()

--- a/taskfile/node.go
+++ b/taskfile/node.go
@@ -18,8 +18,8 @@ type Node interface {
 	Dir() string
 	Optional() bool
 	Remote() bool
-	ResolveIncludeEntrypoint(entrypoint string) (string, error)
-	ResolveIncludeDir(dir string) (string, error)
+	ResolveEntrypoint(entrypoint string) (string, error)
+	ResolveDir(dir string) (string, error)
 }
 
 func NewRootNode(

--- a/taskfile/node.go
+++ b/taskfile/node.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/experiments"
@@ -27,6 +28,7 @@ func NewRootNode(
 	entrypoint string,
 	dir string,
 	insecure bool,
+	timeout time.Duration,
 ) (Node, error) {
 	dir = getDefaultDir(entrypoint, dir)
 	// Check if there is something to read on STDIN
@@ -34,7 +36,7 @@ func NewRootNode(
 	if (stat.Mode()&os.ModeCharDevice) == 0 && stat.Size() > 0 {
 		return NewStdinNode(dir)
 	}
-	return NewNode(l, entrypoint, dir, insecure)
+	return NewNode(l, entrypoint, dir, insecure, timeout)
 }
 
 func NewNode(
@@ -42,13 +44,14 @@ func NewNode(
 	entrypoint string,
 	dir string,
 	insecure bool,
+	timeout time.Duration,
 	opts ...NodeOption,
 ) (Node, error) {
 	var node Node
 	var err error
 	switch getScheme(entrypoint) {
 	case "http", "https":
-		node, err = NewHTTPNode(l, entrypoint, dir, insecure, opts...)
+		node, err = NewHTTPNode(l, entrypoint, dir, insecure, timeout, opts...)
 	default:
 		// If no other scheme matches, we assume it's a file
 		node, err = NewFileNode(l, entrypoint, dir, opts...)

--- a/taskfile/node.go
+++ b/taskfile/node.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/experiments"
 	"github.com/go-task/task/v3/internal/logger"
-	"github.com/go-task/task/v3/taskfile/ast"
 )
 
 type Node interface {
@@ -19,8 +18,8 @@ type Node interface {
 	Dir() string
 	Optional() bool
 	Remote() bool
-	ResolveIncludeEntrypoint(include ast.Include) (string, error)
-	ResolveIncludeDir(include ast.Include) (string, error)
+	ResolveIncludeEntrypoint(entrypoint string) (string, error)
+	ResolveIncludeDir(dir string) (string, error)
 }
 
 func NewRootNode(

--- a/taskfile/node_base.go
+++ b/taskfile/node_base.go
@@ -9,6 +9,7 @@ type (
 	BaseNode struct {
 		parent   Node
 		optional bool
+		dir      string
 	}
 )
 
@@ -16,6 +17,7 @@ func NewBaseNode(opts ...NodeOption) *BaseNode {
 	node := &BaseNode{
 		parent:   nil,
 		optional: false,
+		dir:      "",
 	}
 
 	// Apply options
@@ -44,4 +46,8 @@ func WithOptional(optional bool) NodeOption {
 
 func (node *BaseNode) Optional() bool {
 	return node.optional
+}
+
+func (node *BaseNode) Dir() string {
+	return node.dir
 }

--- a/taskfile/node_base.go
+++ b/taskfile/node_base.go
@@ -13,11 +13,11 @@ type (
 	}
 )
 
-func NewBaseNode(opts ...NodeOption) *BaseNode {
+func NewBaseNode(dir string, opts ...NodeOption) *BaseNode {
 	node := &BaseNode{
 		parent:   nil,
 		optional: false,
-		dir:      "",
+		dir:      dir,
 	}
 
 	// Apply options

--- a/taskfile/node_file.go
+++ b/taskfile/node_file.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
 	"github.com/go-task/task/v3/internal/logger"
-	"github.com/go-task/task/v3/taskfile/ast"
 )
 
 // A FileNode is a node that reads a taskfile from the local filesystem.
@@ -78,13 +77,13 @@ func resolveFileNodeEntrypointAndDir(l *logger.Logger, entrypoint, dir string) (
 	return entrypoint, dir, nil
 }
 
-func (node *FileNode) ResolveIncludeEntrypoint(include ast.Include) (string, error) {
+func (node *FileNode) ResolveIncludeEntrypoint(entrypoint string) (string, error) {
 	// If the file is remote, we don't need to resolve the path
-	if strings.Contains(include.Taskfile, "://") {
-		return include.Taskfile, nil
+	if strings.Contains(entrypoint, "://") {
+		return entrypoint, nil
 	}
 
-	path, err := execext.Expand(include.Taskfile)
+	path, err := execext.Expand(entrypoint)
 	if err != nil {
 		return "", err
 	}
@@ -99,8 +98,8 @@ func (node *FileNode) ResolveIncludeEntrypoint(include ast.Include) (string, err
 	return filepathext.SmartJoin(entrypointDir, path), nil
 }
 
-func (node *FileNode) ResolveIncludeDir(include ast.Include) (string, error) {
-	path, err := execext.Expand(include.Dir)
+func (node *FileNode) ResolveIncludeDir(dir string) (string, error) {
+	path, err := execext.Expand(dir)
 	if err != nil {
 		return "", err
 	}

--- a/taskfile/node_file.go
+++ b/taskfile/node_file.go
@@ -5,39 +5,36 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
+	"github.com/go-task/task/v3/internal/logger"
+	"github.com/go-task/task/v3/taskfile/ast"
 )
 
 // A FileNode is a node that reads a taskfile from the local filesystem.
 type FileNode struct {
 	*BaseNode
-	Dir        string
 	Entrypoint string
 }
 
-func NewFileNode(uri string, opts ...NodeOption) (*FileNode, error) {
+func NewFileNode(l *logger.Logger, entrypoint, dir string, opts ...NodeOption) (*FileNode, error) {
+	var err error
 	base := NewBaseNode(opts...)
-	if uri == "" {
-		d, err := os.Getwd()
-		if err != nil {
-			return nil, err
-		}
-		uri = d
-	}
-	path, err := Exists(uri)
+	entrypoint, dir, err = resolveFileNodeEntrypointAndDir(l, entrypoint, dir)
 	if err != nil {
 		return nil, err
 	}
+	base.dir = dir
 	return &FileNode{
 		BaseNode:   base,
-		Dir:        filepath.Dir(path),
-		Entrypoint: filepath.Base(path),
+		Entrypoint: entrypoint,
 	}, nil
 }
 
 func (node *FileNode) Location() string {
-	return filepathext.SmartJoin(node.Dir, node.Entrypoint)
+	return node.Entrypoint
 }
 
 func (node *FileNode) Remote() bool {
@@ -53,6 +50,67 @@ func (node *FileNode) Read(ctx context.Context) ([]byte, error) {
 	return io.ReadAll(f)
 }
 
-func (node *FileNode) BaseDir() string {
-	return node.Dir
+// resolveFileNodeEntrypointAndDir resolves checks the values of entrypoint and dir and
+// populates them with default values if necessary.
+func resolveFileNodeEntrypointAndDir(l *logger.Logger, entrypoint, dir string) (string, string, error) {
+	var err error
+	if entrypoint != "" {
+		entrypoint, err = Exists(l, entrypoint)
+		if err != nil {
+			return "", "", err
+		}
+		if dir == "" {
+			dir = filepath.Dir(entrypoint)
+		}
+		return entrypoint, dir, nil
+	}
+	if dir == "" {
+		dir, err = os.Getwd()
+		if err != nil {
+			return "", "", err
+		}
+	}
+	entrypoint, err = ExistsWalk(l, dir)
+	if err != nil {
+		return "", "", err
+	}
+	dir = filepath.Dir(entrypoint)
+	return entrypoint, dir, nil
+}
+
+func (node *FileNode) ResolveIncludeEntrypoint(include ast.Include) (string, error) {
+	// If the file is remote, we don't need to resolve the path
+	if strings.Contains(include.Taskfile, "://") {
+		return include.Taskfile, nil
+	}
+
+	path, err := execext.Expand(include.Taskfile)
+	if err != nil {
+		return "", err
+	}
+
+	if filepathext.IsAbs(path) {
+		return path, nil
+	}
+
+	// NOTE: Uses the directory of the entrypoint (Taskfile), not the current working directory
+	// This means that files are included relative to one another
+	entrypointDir := filepath.Dir(node.Entrypoint)
+	return filepathext.SmartJoin(entrypointDir, path), nil
+}
+
+func (node *FileNode) ResolveIncludeDir(include ast.Include) (string, error) {
+	path, err := execext.Expand(include.Dir)
+	if err != nil {
+		return "", err
+	}
+
+	if filepathext.IsAbs(path) {
+		return path, nil
+	}
+
+	// NOTE: Uses the directory of the entrypoint (Taskfile), not the current working directory
+	// This means that files are included relative to one another
+	entrypointDir := filepath.Dir(node.Entrypoint)
+	return filepathext.SmartJoin(entrypointDir, path), nil
 }

--- a/taskfile/node_file.go
+++ b/taskfile/node_file.go
@@ -77,7 +77,7 @@ func resolveFileNodeEntrypointAndDir(l *logger.Logger, entrypoint, dir string) (
 	return entrypoint, dir, nil
 }
 
-func (node *FileNode) ResolveIncludeEntrypoint(entrypoint string) (string, error) {
+func (node *FileNode) ResolveEntrypoint(entrypoint string) (string, error) {
 	// If the file is remote, we don't need to resolve the path
 	if strings.Contains(entrypoint, "://") {
 		return entrypoint, nil
@@ -98,7 +98,7 @@ func (node *FileNode) ResolveIncludeEntrypoint(entrypoint string) (string, error
 	return filepathext.SmartJoin(entrypointDir, path), nil
 }
 
-func (node *FileNode) ResolveIncludeDir(dir string) (string, error) {
+func (node *FileNode) ResolveDir(dir string) (string, error) {
 	path, err := execext.Expand(dir)
 	if err != nil {
 		return "", err

--- a/taskfile/node_file.go
+++ b/taskfile/node_file.go
@@ -20,12 +20,11 @@ type FileNode struct {
 
 func NewFileNode(l *logger.Logger, entrypoint, dir string, opts ...NodeOption) (*FileNode, error) {
 	var err error
-	base := NewBaseNode(opts...)
-	entrypoint, dir, err = resolveFileNodeEntrypointAndDir(l, entrypoint, dir)
+	base := NewBaseNode(dir, opts...)
+	entrypoint, base.dir, err = resolveFileNodeEntrypointAndDir(l, entrypoint, base.dir)
 	if err != nil {
 		return nil, err
 	}
-	base.dir = dir
 	return &FileNode{
 		BaseNode:   base,
 		Entrypoint: entrypoint,

--- a/taskfile/node_http.go
+++ b/taskfile/node_http.go
@@ -5,8 +5,13 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path/filepath"
 
 	"github.com/go-task/task/v3/errors"
+	"github.com/go-task/task/v3/internal/execext"
+	"github.com/go-task/task/v3/internal/filepathext"
+	"github.com/go-task/task/v3/internal/logger"
+	"github.com/go-task/task/v3/taskfile/ast"
 )
 
 // An HTTPNode is a node that reads a Taskfile from a remote location via HTTP.
@@ -15,14 +20,19 @@ type HTTPNode struct {
 	URL *url.URL
 }
 
-func NewHTTPNode(uri string, insecure bool, opts ...NodeOption) (*HTTPNode, error) {
+func NewHTTPNode(l *logger.Logger, entrypoint, dir string, insecure bool, opts ...NodeOption) (*HTTPNode, error) {
 	base := NewBaseNode(opts...)
-	url, err := url.Parse(uri)
+	base.dir = dir
+	url, err := url.Parse(entrypoint)
 	if err != nil {
 		return nil, err
 	}
 	if url.Scheme == "http" && !insecure {
-		return nil, &errors.TaskfileNotSecureError{URI: uri}
+		return nil, &errors.TaskfileNotSecureError{URI: entrypoint}
+	}
+	url, err = RemoteExists(l, url)
+	if err != nil {
+		return nil, err
 	}
 	return &HTTPNode{
 		BaseNode: base,
@@ -66,6 +76,26 @@ func (node *HTTPNode) Read(ctx context.Context) ([]byte, error) {
 	return b, nil
 }
 
-func (node *HTTPNode) BaseDir() string {
-	return ""
+func (node *HTTPNode) ResolveIncludeEntrypoint(include ast.Include) (string, error) {
+	ref, err := url.Parse(include.Taskfile)
+	if err != nil {
+		return "", err
+	}
+	return node.URL.ResolveReference(ref).String(), nil
+}
+
+func (node *HTTPNode) ResolveIncludeDir(include ast.Include) (string, error) {
+	path, err := execext.Expand(include.Dir)
+	if err != nil {
+		return "", err
+	}
+
+	if filepathext.IsAbs(path) {
+		return path, nil
+	}
+
+	// NOTE: Uses the directory of the entrypoint (Taskfile), not the current working directory
+	// This means that files are included relative to one another
+	entrypointDir := filepath.Dir(node.Dir())
+	return filepathext.SmartJoin(entrypointDir, path), nil
 }

--- a/taskfile/node_http.go
+++ b/taskfile/node_http.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
 	"github.com/go-task/task/v3/internal/logger"
-	"github.com/go-task/task/v3/taskfile/ast"
 )
 
 // An HTTPNode is a node that reads a Taskfile from a remote location via HTTP.
@@ -76,16 +75,16 @@ func (node *HTTPNode) Read(ctx context.Context) ([]byte, error) {
 	return b, nil
 }
 
-func (node *HTTPNode) ResolveIncludeEntrypoint(include ast.Include) (string, error) {
-	ref, err := url.Parse(include.Taskfile)
+func (node *HTTPNode) ResolveIncludeEntrypoint(entrypoint string) (string, error) {
+	ref, err := url.Parse(entrypoint)
 	if err != nil {
 		return "", err
 	}
 	return node.URL.ResolveReference(ref).String(), nil
 }
 
-func (node *HTTPNode) ResolveIncludeDir(include ast.Include) (string, error) {
-	path, err := execext.Expand(include.Dir)
+func (node *HTTPNode) ResolveIncludeDir(dir string) (string, error) {
+	path, err := execext.Expand(dir)
 	if err != nil {
 		return "", err
 	}

--- a/taskfile/node_http.go
+++ b/taskfile/node_http.go
@@ -75,7 +75,7 @@ func (node *HTTPNode) Read(ctx context.Context) ([]byte, error) {
 	return b, nil
 }
 
-func (node *HTTPNode) ResolveIncludeEntrypoint(entrypoint string) (string, error) {
+func (node *HTTPNode) ResolveEntrypoint(entrypoint string) (string, error) {
 	ref, err := url.Parse(entrypoint)
 	if err != nil {
 		return "", err
@@ -83,7 +83,7 @@ func (node *HTTPNode) ResolveIncludeEntrypoint(entrypoint string) (string, error
 	return node.URL.ResolveReference(ref).String(), nil
 }
 
-func (node *HTTPNode) ResolveIncludeDir(dir string) (string, error) {
+func (node *HTTPNode) ResolveDir(dir string) (string, error) {
 	path, err := execext.Expand(dir)
 	if err != nil {
 		return "", err

--- a/taskfile/node_http.go
+++ b/taskfile/node_http.go
@@ -20,8 +20,7 @@ type HTTPNode struct {
 }
 
 func NewHTTPNode(l *logger.Logger, entrypoint, dir string, insecure bool, opts ...NodeOption) (*HTTPNode, error) {
-	base := NewBaseNode(opts...)
-	base.dir = dir
+	base := NewBaseNode(dir, opts...)
 	url, err := url.Parse(entrypoint)
 	if err != nil {
 		return nil, err

--- a/taskfile/node_stdin.go
+++ b/taskfile/node_stdin.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
-	"github.com/go-task/task/v3/taskfile/ast"
 )
 
 // A StdinNode is a node that reads a taskfile from the standard input stream.
@@ -45,13 +44,13 @@ func (node *StdinNode) Read(ctx context.Context) ([]byte, error) {
 	return stdin, nil
 }
 
-func (node *StdinNode) ResolveIncludeEntrypoint(include ast.Include) (string, error) {
+func (node *StdinNode) ResolveIncludeEntrypoint(entrypoint string) (string, error) {
 	// If the file is remote, we don't need to resolve the path
-	if strings.Contains(include.Taskfile, "://") {
-		return include.Taskfile, nil
+	if strings.Contains(entrypoint, "://") {
+		return entrypoint, nil
 	}
 
-	path, err := execext.Expand(include.Taskfile)
+	path, err := execext.Expand(entrypoint)
 	if err != nil {
 		return "", err
 	}
@@ -63,8 +62,8 @@ func (node *StdinNode) ResolveIncludeEntrypoint(include ast.Include) (string, er
 	return filepathext.SmartJoin(node.Dir(), path), nil
 }
 
-func (node *StdinNode) ResolveIncludeDir(include ast.Include) (string, error) {
-	path, err := execext.Expand(include.Dir)
+func (node *StdinNode) ResolveIncludeDir(dir string) (string, error) {
+	path, err := execext.Expand(dir)
 	if err != nil {
 		return "", err
 	}

--- a/taskfile/node_stdin.go
+++ b/taskfile/node_stdin.go
@@ -44,7 +44,7 @@ func (node *StdinNode) Read(ctx context.Context) ([]byte, error) {
 	return stdin, nil
 }
 
-func (node *StdinNode) ResolveIncludeEntrypoint(entrypoint string) (string, error) {
+func (node *StdinNode) ResolveEntrypoint(entrypoint string) (string, error) {
 	// If the file is remote, we don't need to resolve the path
 	if strings.Contains(entrypoint, "://") {
 		return entrypoint, nil
@@ -62,7 +62,7 @@ func (node *StdinNode) ResolveIncludeEntrypoint(entrypoint string) (string, erro
 	return filepathext.SmartJoin(node.Dir(), path), nil
 }
 
-func (node *StdinNode) ResolveIncludeDir(dir string) (string, error) {
+func (node *StdinNode) ResolveDir(dir string) (string, error) {
 	path, err := execext.Expand(dir)
 	if err != nil {
 		return "", err

--- a/taskfile/node_stdin.go
+++ b/taskfile/node_stdin.go
@@ -17,10 +17,8 @@ type StdinNode struct {
 }
 
 func NewStdinNode(dir string) (*StdinNode, error) {
-	base := NewBaseNode()
-	base.dir = dir
 	return &StdinNode{
-		BaseNode: base,
+		BaseNode: NewBaseNode(dir),
 	}, nil
 }
 

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -64,12 +64,12 @@ func Read(
 				return err
 			}
 
-			entrypoint, err := node.ResolveIncludeEntrypoint(include)
+			entrypoint, err := node.ResolveIncludeEntrypoint(include.Taskfile)
 			if err != nil {
 				return err
 			}
 
-			dir, err := node.ResolveIncludeDir(include)
+			dir, err := node.ResolveIncludeDir(include.Dir)
 			if err != nil {
 				return err
 			}

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -64,12 +64,12 @@ func Read(
 				return err
 			}
 
-			entrypoint, err := node.ResolveIncludeEntrypoint(include.Taskfile)
+			entrypoint, err := node.ResolveEntrypoint(include.Taskfile)
 			if err != nil {
 				return err
 			}
 
-			dir, err := node.ResolveIncludeDir(include.Dir)
+			dir, err := node.ResolveDir(include.Dir)
 			if err != nil {
 				return err
 			}

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -74,7 +74,7 @@ func Read(
 				return err
 			}
 
-			includeReaderNode, err := NewNode(l, entrypoint, dir, insecure,
+			includeReaderNode, err := NewNode(l, entrypoint, dir, insecure, timeout,
 				WithParent(node),
 				WithOptional(include.Optional),
 			)

--- a/taskfile/taskfile.go
+++ b/taskfile/taskfile.go
@@ -1,11 +1,16 @@
 package taskfile
 
 import (
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/filepathext"
+	"github.com/go-task/task/v3/internal/logger"
 	"github.com/go-task/task/v3/internal/sysinfo"
 )
 
@@ -23,14 +28,80 @@ var (
 		"Taskfile.dist.yaml",
 		"taskfile.dist.yaml",
 	}
+
+	allowedContentTypes = []string{
+		"text/plain",
+		"text/yaml",
+		"text/x-yaml",
+		"application/yaml",
+		"application/x-yaml",
+	}
 )
 
+// RemoteExists will check if a file at the given URL Exists. If it does, it
+// will return its URL. If it does not, it will search the search for any files
+// at the given URL with any of the default Taskfile files names. If any of
+// these match a file, the first matching path will be returned. If no files are
+// found, an error will be returned.
+func RemoteExists(l *logger.Logger, u *url.URL) (*url.URL, error) {
+	// Create a new HEAD request for the given URL to check if the resource exists
+	req, err := http.NewRequest("HEAD", u.String(), nil)
+	if err != nil {
+		return nil, errors.TaskfileFetchFailedError{URI: u.String()}
+	}
+
+	// Request the given URL
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, errors.TaskfileFetchFailedError{URI: u.String()}
+	}
+	defer resp.Body.Close()
+
+	// If the request was successful and the content type is allowed, return the
+	// URL The content type check is to avoid downloading files that are not
+	// Taskfiles It means we can try other files instead of downloading
+	// something that is definitely not a Taskfile
+	contentType := resp.Header.Get("Content-Type")
+	if resp.StatusCode == http.StatusOK && slices.ContainsFunc(allowedContentTypes, func(s string) bool {
+		return strings.Contains(contentType, s)
+	}) {
+		return u, nil
+	}
+
+	// If the request was not successful, append the default Taskfile names to
+	// the URL and return the URL of the first successful request
+	for _, taskfile := range defaultTaskfiles {
+		// Fixes a bug with JoinPath where a leading slash is not added to the
+		// path if it is empty
+		if u.Path == "" {
+			u.Path = "/"
+		}
+		alt := u.JoinPath(taskfile)
+		req.URL = alt
+
+		// Try the alternative URL
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, errors.TaskfileFetchFailedError{URI: u.String()}
+		}
+		defer resp.Body.Close()
+
+		// If the request was successful, return the URL
+		if resp.StatusCode == http.StatusOK {
+			l.VerboseOutf(logger.Magenta, "task: [%s] Not found - Using alternative (%s)\n", alt.String(), taskfile)
+			return alt, nil
+		}
+	}
+
+	return nil, errors.TaskfileNotFoundError{URI: u.String(), Walk: false}
+}
+
 // Exists will check if a file at the given path Exists. If it does, it will
-// return the path to it. If it does not, it will search the search for any
-// files at the given path with any of the default Taskfile files names. If any
-// of these match a file, the first matching path will be returned. If no files
-// are found, an error will be returned.
-func Exists(path string) (string, error) {
+// return the path to it. If it does not, it will search for any files at the
+// given path with any of the default Taskfile files names. If any of these
+// match a file, the first matching path will be returned. If no files are
+// found, an error will be returned.
+func Exists(l *logger.Logger, path string) (string, error) {
 	fi, err := os.Stat(path)
 	if err != nil {
 		return "", err
@@ -42,10 +113,11 @@ func Exists(path string) (string, error) {
 		return filepath.Abs(path)
 	}
 
-	for _, n := range defaultTaskfiles {
-		fpath := filepathext.SmartJoin(path, n)
-		if _, err := os.Stat(fpath); err == nil {
-			return filepath.Abs(fpath)
+	for _, taskfile := range defaultTaskfiles {
+		alt := filepathext.SmartJoin(path, taskfile)
+		if _, err := os.Stat(alt); err == nil {
+			l.VerboseOutf(logger.Magenta, "task: [%s] Not found - Using alternative (%s)\n", path, taskfile)
+			return filepath.Abs(alt)
 		}
 	}
 
@@ -57,14 +129,14 @@ func Exists(path string) (string, error) {
 // calling the exists function until it finds a file or reaches the root
 // directory. On supported operating systems, it will also check if the user ID
 // of the directory changes and abort if it does.
-func ExistsWalk(path string) (string, error) {
+func ExistsWalk(l *logger.Logger, path string) (string, error) {
 	origPath := path
 	owner, err := sysinfo.Owner(path)
 	if err != nil {
 		return "", err
 	}
 	for {
-		fpath, err := Exists(path)
+		fpath, err := Exists(l, path)
 		if err == nil {
 			return fpath, nil
 		}

--- a/taskfile/taskfile.go
+++ b/taskfile/taskfile.go
@@ -1,6 +1,7 @@
 package taskfile
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"os"
@@ -43,7 +44,7 @@ var (
 // at the given URL with any of the default Taskfile files names. If any of
 // these match a file, the first matching path will be returned. If no files are
 // found, an error will be returned.
-func RemoteExists(l *logger.Logger, u *url.URL) (*url.URL, error) {
+func RemoteExists(ctx context.Context, l *logger.Logger, u *url.URL) (*url.URL, error) {
 	// Create a new HEAD request for the given URL to check if the resource exists
 	req, err := http.NewRequest("HEAD", u.String(), nil)
 	if err != nil {
@@ -51,7 +52,7 @@ func RemoteExists(l *logger.Logger, u *url.URL) (*url.URL, error) {
 	}
 
 	// Request the given URL
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, errors.TaskfileFetchFailedError{URI: u.String()}
 	}

--- a/website/static/Taskfile.yml
+++ b/website/static/Taskfile.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+tasks:
+  default:
+    cmds:
+      - task: hello
+
+  hello:
+    cmds:
+      - echo "Hello Task!"

--- a/website/versioned_docs/version-latest/experiments/remote_taskfiles.md
+++ b/website/versioned_docs/version-latest/experiments/remote_taskfiles.md
@@ -48,6 +48,16 @@ tasks:
 and you run `task my-remote-namespace:hello`, it will print the text: "Hello
 from the remote Taskfile!" to your console.
 
+## Root remote Taskfiles
+
+You can also specify a remote Taskfile as the entrypoint for Task by using the
+`--taskfile` flag. This means you don't need to have any Taskfile defined
+locally at all. For example:
+
+```shell
+task --taskfile https://taskfile.dev hello
+```
+
 ## Security
 
 Running commands from sources that you do not control is always a potential


### PR DESCRIPTION
Fixes #1531

This PR enables the ability to pass a remote Taskfile URI to the `--taskfile` flag. This means that your root Taskfile no longer needs to exist locally.

When specifying the `--taskfile` flag, Task usually assumes that the execution directory is the directory that the root Taskfile resides in. Since this isn't possible with a remote Taskfile, the execution directory will default to the current working directory instead when the Task command is executed.

However, I have also added the ability to change this default directory using the existing `--dir` flag. This now means that you are able to specify BOTH `--taskfile` and `--dir` flags simultaneously - Something that was not previously allowed. The following semantics are now applied:

- If `--taskfile` is specified without `--dir`, the specified Taskfile is used and the directory will default to the directory containing the specified Taskfile (no change).
- If `--dir` is specified without `--taskfile`, Task will search the specified directory for a Taskfile and use that as the entrypoint. The directory will be the one specified (no change).
- If BOTH `--dir` and `--taskfile` are specified, the entrypoint will be the specified taskfile and the directory will be the specified directory.
- If NEITHER are specified, Task will recursively search up the filesystem for a Taskfile starting in the current working directory. If one is found, the directory is set to the directory containing the found Taskfile.

Finally, this PR also fixes issues related to resolving the location of included Taskfiles inside remote Taskfiles. For example, if you are using a remote Taskfile that includes a "local" file. The included file will now be resolved as a remote file too and the include will work as expected.