### PR TITLE
fix: exclude other "ignored" files.

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -176,6 +176,16 @@ func (e *Executor) registerWatchedFiles(w *watcher.Watcher, calls ...taskfile.Ca
 }
 
 func shouldIgnoreFile(path string) bool {
-	return strings.Contains(path, "/.git/") || strings.Contains(path, "/.hg/") ||
-		strings.Contains(path, "/.task/") || strings.Contains(path, "/node_modules/")
+	ignorePaths := []string{
+		"/.task",
+		"/.git",
+		"/.hg",
+		"/.node_modules",
+	}
+	for _, p := range ignorePaths {
+		if strings.Contains(path, fmt.Sprintf("%s/", p)) || strings.HasSuffix(path, p) {
+			return true
+		}
+	}
+	return false
 }

--- a/watch.go
+++ b/watch.go
@@ -176,6 +176,6 @@ func (e *Executor) registerWatchedFiles(w *watcher.Watcher, calls ...taskfile.Ca
 }
 
 func shouldIgnoreFile(path string) bool {
-	return strings.Contains(path, "/.git") || strings.Contains(path, "/.hg") ||
-		strings.Contains(path, "/.task") || strings.Contains(path, "/node_modules")
+	return strings.Contains(path, "/.git/") || strings.Contains(path, "/.hg/") ||
+		strings.Contains(path, "/.task/") || strings.Contains(path, "/node_modules/")
 }

--- a/watch_test.go
+++ b/watch_test.go
@@ -79,3 +79,18 @@ Hello, World!
 	err = os.RemoveAll(filepathext.SmartJoin(dir, "src"))
 	require.NoError(t, err)
 }
+
+
+func TestShouldIgnoreFile(t *testing.T) {
+	tt := []struct{path string, expect bool}{
+		{".git/hooks", true},
+		{".github/workflows/build.yaml", false},
+	}
+
+	for k, &ct := range tt {
+		t.Run(fmt.Sprintf("ignore - %d", k), func(*t testing.T){
+			t.Parallel()
+			require.Equal(t, shouldIgnoreFile(ct.path))
+		})
+	}
+}

--- a/watch_test.go
+++ b/watch_test.go
@@ -6,6 +6,7 @@ package task_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -80,17 +81,20 @@ Hello, World!
 	require.NoError(t, err)
 }
 
-
 func TestShouldIgnoreFile(t *testing.T) {
-	tt := []struct{path string, expect bool}{
-		{".git/hooks", true},
-		{".github/workflows/build.yaml", false},
+	tt := []struct {
+		path   string
+		expect bool
+	}{
+		{"/.git/hooks", true},
+		{"/.github/workflows/build.yaml", false},
 	}
 
-	for k, &ct := range tt {
-		t.Run(fmt.Sprintf("ignore - %d", k), func(*t testing.T){
+	for k, ct := range tt {
+		ct := ct
+		t.Run(fmt.Sprintf("ignore - %d", k), func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, shouldIgnoreFile(ct.path))
+			require.Equal(t, shouldIgnoreFile(ct.path), ct.expect)
 		})
 	}
 }


### PR DESCRIPTION
Limits ignore files to exact 4 directories used to be ignored before ".git/.hg/node_modules/.task"

Usecase: setting up monitoring for the files that matches ignored directory, but not location inside of it. So for example, we I want (actual case I run into) to monitor "yaml" templates and test them on change, I can't use `.github` directory as it ignored by default because it matches `.git`.