### PR TITLE
Initial requires_strict setup

### DIFF
--- a/docs/static/schema.json
+++ b/docs/static/schema.json
@@ -189,6 +189,10 @@
             "description": "A list of variables which should be set if this task is to run, if any of these variables are unset the task will error and not run",
             "$ref": "#/definitions/3/requires_obj"
           },
+          "requires_strict": {
+            "description": "A list of variables which should be set if this task is to run, if any of these variables are unset or have a length of zero the task will error and not run",
+            "$ref": "#/definitions/3/requires_strict_obj"
+          },
           "watch": {
             "description": "Configures a task to run in watch mode automatically.",
             "type": "boolean",
@@ -478,6 +482,25 @@
           "vars": {
             "description": "List of variables that must be defined for the task to run",
             "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "requires_strict_obj": {
+        "type": "object",
+        "properties": {
+          "vars": {
+            "description": "List of variables that must be defined and not empty for the task to run",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "limit_values": {
+            "description": "A dictionary of list that allow matching vars against allowed values",
+            "type": "object",
             "items": {
               "type": "string"
             }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -29,6 +29,8 @@ const (
 	CodeTaskCalledTooManyTimes
 	CodeTaskCancelled
 	CodeTaskMissingRequiredVars
+	CodeTaskRequiredStrictVarsEmpty
+	CodeTaskRequiredStrictVarsLimitFail
 )
 
 // TaskError extends the standard error interface with a Code method. This code will

--- a/errors/errors_task.go
+++ b/errors/errors_task.go
@@ -145,3 +145,39 @@ func (err *TaskMissingRequiredVars) Error() string {
 func (err *TaskMissingRequiredVars) Code() int {
 	return CodeTaskMissingRequiredVars
 }
+
+// TaskRequiredStrictVarsEmpty is returned when a task required vars are empty.
+type TaskRequiredStrictVarsEmpty struct {
+	TaskName    string
+	InvalidVars []string
+}
+
+func (err *TaskRequiredStrictVarsEmpty) Error() string {
+	return fmt.Sprintf(
+		`task: Task %q cancelled because the required vars are empty string: %s`,
+		err.TaskName,
+		strings.Join(err.InvalidVars, ", "),
+	)
+}
+
+func (err *TaskRequiredStrictVarsEmpty) Code() int {
+	return CodeTaskRequiredStrictVarsEmpty
+}
+
+// TaskRequiredStrictVarsLimitFail is returned when a task required vars don't match the limit_values.
+type TaskRequiredStrictVarsLimitFail struct {
+	TaskName    string
+	InvalidVars []string
+}
+
+func (err *TaskRequiredStrictVarsLimitFail) Error() string {
+	return fmt.Sprintf(
+		`task: Task %q cancelled because the required vars don't match the limits provided': %s`,
+		err.TaskName,
+		strings.Join(err.InvalidVars, ", "),
+	)
+}
+
+func (err *TaskRequiredStrictVarsLimitFail) Code() int {
+	return CodeTaskRequiredStrictVarsLimitFail
+}

--- a/requires.go
+++ b/requires.go
@@ -1,13 +1,13 @@
 package task
 
 import (
-	"context"
+	"golang.org/x/exp/slices"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/taskfile"
 )
 
-func (e *Executor) areTaskRequiredVarsSet(ctx context.Context, t *taskfile.Task, call taskfile.Call) error {
+func (e *Executor) areTaskRequiredVarsSet(t *taskfile.Task, call taskfile.Call) error {
 	if t.Requires == nil || len(t.Requires.Vars) == 0 {
 		return nil
 	}
@@ -28,6 +28,67 @@ func (e *Executor) areTaskRequiredVarsSet(ctx context.Context, t *taskfile.Task,
 		return &errors.TaskMissingRequiredVars{
 			TaskName:    t.Name(),
 			MissingVars: missingVars,
+		}
+	}
+
+	return nil
+}
+
+func (e *Executor) areTaskRequiredStrictVarsValid(t *taskfile.Task, call taskfile.Call) error {
+	if t.RequiresStrict == nil || len(t.RequiresStrict.Vars) == 0 {
+		return nil
+	}
+
+	vars, err := e.Compiler.GetVariables(t, call)
+	if err != nil {
+		return err
+	}
+
+	var missingVars []string
+	var emptyVars []string
+	var failedLimitVars []string
+	for _, requiredVar := range t.RequiresStrict.Vars {
+		if !vars.Exists(requiredVar) {
+			missingVars = append(missingVars, requiredVar)
+			continue
+		}
+
+		// Check for empty vars
+		m := vars.Get(requiredVar)
+		if len(m.Static) == 0 {
+			emptyVars = append(emptyVars, requiredVar)
+			continue
+		}
+
+		// Get the valid values from the filter
+		if t.RequiresStrict.LimitValues != nil || len(t.RequiresStrict.LimitValues) > 0 {
+			if values, found := t.RequiresStrict.LimitValues[requiredVar]; found {
+				if !slices.Contains(values, m.Static) {
+					failedLimitVars = append(failedLimitVars, requiredVar)
+				}
+			}
+		}
+
+	}
+
+	if len(missingVars) > 0 {
+		return &errors.TaskMissingRequiredVars{
+			TaskName:    t.Name(),
+			MissingVars: missingVars,
+		}
+	}
+
+	if len(emptyVars) > 0 {
+		return &errors.TaskRequiredStrictVarsEmpty{
+			TaskName:    t.Name(),
+			InvalidVars: emptyVars,
+		}
+	}
+
+	if len(failedLimitVars) > 0 {
+		return &errors.TaskRequiredStrictVarsLimitFail{
+			TaskName:    t.Name(),
+			InvalidVars: failedLimitVars,
 		}
 	}
 

--- a/task.go
+++ b/task.go
@@ -201,7 +201,11 @@ func (e *Executor) RunTask(ctx context.Context, call taskfile.Call) error {
 				return err
 			}
 
-			if err := e.areTaskRequiredVarsSet(ctx, t, call); err != nil {
+			if err := e.areTaskRequiredVarsSet(t, call); err != nil {
+				return err
+			}
+
+			if err := e.areTaskRequiredStrictVarsValid(t, call); err != nil {
 				return err
 			}
 

--- a/task_test.go
+++ b/task_test.go
@@ -2307,3 +2307,34 @@ func TestFor(t *testing.T) {
 		})
 	}
 }
+
+func TestRequireStrictVars(t *testing.T) {
+	const dir = "testdata/vars/v3"
+	const entry = "TaskfileRequireStrict.yml"
+
+	var buff bytes.Buffer
+	e := &task.Executor{
+		Dir:        dir,
+		Entrypoint: entry,
+		Force:      true,
+		Stdout:     &buff,
+		Stderr:     &buff,
+	}
+
+	require.NoError(t, e.Setup())
+
+	tests := []struct {
+		exe    *task.Executor
+		target string
+		err    error
+	}{
+		{exe: e, target: "require_strict_empty", err: &errors.TaskRequiredStrictVarsEmpty{}},
+		{exe: e, target: "require_strict_ok", err: nil},
+		{exe: e, target: "requires_strict_limit", err: nil},
+		{exe: e, target: "requires_strict_limit_fail", err: &errors.TaskRequiredStrictVarsLimitFail{}},
+	}
+	for _, test := range tests {
+		err := e.Run(context.Background(), taskfile.Call{Task: test.target})
+		assert.IsType(t, test.err, err)
+	}
+}

--- a/taskfile/requires_strict.go
+++ b/taskfile/requires_strict.go
@@ -1,0 +1,22 @@
+package taskfile
+
+import (
+	"github.com/go-task/task/v3/internal/deepcopy"
+)
+
+// RequiresStrict represents a set of required variables necessary for a task to run
+type RequiresStrict struct {
+	Vars        []string
+	LimitValues map[string][]string `yaml:"limit_values"`
+}
+
+func (r *RequiresStrict) DeepCopy() *RequiresStrict {
+	if r == nil {
+		return nil
+	}
+
+	return &RequiresStrict{
+		Vars:        deepcopy.Slice(r.Vars),
+		LimitValues: deepcopy.Map(r.LimitValues),
+	}
+}

--- a/taskfile/task.go
+++ b/taskfile/task.go
@@ -3,7 +3,7 @@ package taskfile
 import (
 	"fmt"
 
-	"gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 
 	"github.com/go-task/task/v3/internal/deepcopy"
 )
@@ -18,6 +18,7 @@ type Task struct {
 	Prompt               string
 	Summary              string
 	Requires             *Requires
+	RequiresStrict       *RequiresStrict
 	Aliases              []string
 	Sources              []string
 	Generates            []string
@@ -75,34 +76,35 @@ func (t *Task) UnmarshalYAML(node *yaml.Node) error {
 	// Full task object
 	case yaml.MappingNode:
 		var task struct {
-			Cmds          []*Cmd
-			Cmd           *Cmd
-			Deps          []*Dep
-			Label         string
-			Desc          string
-			Prompt        string
-			Summary       string
-			Aliases       []string
-			Sources       []string
-			Generates     []string
-			Status        []string
-			Preconditions []*Precondition
-			Dir           string
-			Set           []string
-			Shopt         []string
-			Vars          *Vars
-			Env           *Vars
-			Dotenv        []string
-			Silent        bool
-			Interactive   bool
-			Internal      bool
-			Method        string
-			Prefix        string
-			IgnoreError   bool `yaml:"ignore_error"`
-			Run           string
-			Platforms     []*Platform
-			Requires      *Requires
-			Watch         bool
+			Cmds           []*Cmd
+			Cmd            *Cmd
+			Deps           []*Dep
+			Label          string
+			Desc           string
+			Prompt         string
+			Summary        string
+			Aliases        []string
+			Sources        []string
+			Generates      []string
+			Status         []string
+			Preconditions  []*Precondition
+			Dir            string
+			Set            []string
+			Shopt          []string
+			Vars           *Vars
+			Env            *Vars
+			Dotenv         []string
+			Silent         bool
+			Interactive    bool
+			Internal       bool
+			Method         string
+			Prefix         string
+			IgnoreError    bool `yaml:"ignore_error"`
+			Run            string
+			Platforms      []*Platform
+			Requires       *Requires
+			RequiresStrict *RequiresStrict `yaml:"requires_strict"`
+			Watch          bool
 		}
 		if err := node.Decode(&task); err != nil {
 			return err
@@ -140,6 +142,7 @@ func (t *Task) UnmarshalYAML(node *yaml.Node) error {
 		t.Run = task.Run
 		t.Platforms = task.Platforms
 		t.Requires = task.Requires
+		t.RequiresStrict = task.RequiresStrict
 		t.Watch = task.Watch
 		return nil
 	}
@@ -185,6 +188,7 @@ func (t *Task) DeepCopy() *Task {
 		Platforms:            deepcopy.Slice(t.Platforms),
 		Location:             t.Location.DeepCopy(),
 		Requires:             t.Requires.DeepCopy(),
+		RequiresStrict:       t.RequiresStrict.DeepCopy(),
 	}
 	return c
 }

--- a/testdata/vars/v3/TaskfileRequireStrict.yml
+++ b/testdata/vars/v3/TaskfileRequireStrict.yml
@@ -1,0 +1,44 @@
+version: '3'
+
+vars:
+  VAR_EMPTY: ""
+  VAR_OK: "Testing123"
+  VAR_ONE: "one"
+  VAR_TWO: "two"
+  VAR_THREE: "three"
+
+tasks:
+  require_strict_ok:
+    requires_strict:
+      vars: [VAR_OK]
+    cmds:
+      - echo '{{.VAR_OK}}'
+
+  # Will return an error because the value of VAR_EMPTY is an empty string
+  require_strict_empty:
+    requires_strict:
+      vars: [ VAR_EMPTY ]
+    cmds:
+      - echo '{{.VAR_EMPTY}}'
+
+  requires_strict_limit:
+    requires_strict:
+      vars: [VAR_ONE, VAR_THREE, VAR_TWO]
+      limit_values:
+        VAR_TWO:
+          - "foo"
+          - "bar"
+          - "two"
+    cmds:
+      - echo '{{.VAR_TWO}}'
+
+  requires_strict_limit_fail:
+    requires_strict:
+      vars: [VAR_ONE, VAR_THREE, VAR_TWO]
+      limit_values:
+        VAR_TWO:
+          - "foo"
+          - "bar"
+    cmds:
+      - echo '{{.VAR_TWO}}'
+

--- a/variables.go
+++ b/variables.go
@@ -70,6 +70,7 @@ func (e *Executor) compiledTask(call taskfile.Call, evaluateShVars bool) (*taskf
 		Platforms:            origTask.Platforms,
 		Location:             origTask.Location,
 		Requires:             origTask.Requires,
+		RequiresStrict:       origTask.RequiresStrict,
 		Watch:                origTask.Watch,
 	}
 	new.Dir, err = execext.Expand(new.Dir)


### PR DESCRIPTION
This PR adds a new attribute called `requires_strict` which by default mimics the `requires` behaviour but will fail if the values are empty strings and provides an option called `limit_values` which can function like an enum:
```
  task-example:
    requires_strict:
      vars: [VAR_ONE, VAR_THREE, VAR_TWO]
      limit_values:
        VAR_TWO:
          - "foo"
          - "bar"
          - "two"
    cmds:
      - echo '{{.VAR_TWO}}'
```

Examples can be seen here: https://github.com/go-task/task/pull/1370/files#diff-62762ddb42701438813445ff0303d0f357cfe2d0d6f38969c45224befb143ea4