### PR TITLE
Fix Type inference error in ordered map sort

### DIFF
--- a/internal/orderedmap/orderedmap.go
+++ b/internal/orderedmap/orderedmap.go
@@ -90,8 +90,8 @@ func (om *OrderedMap[K, V]) Sort() {
 }
 
 // SortFunc will sort the map using the given function.
-func (om *OrderedMap[K, V]) SortFunc(less func(i, j K) bool) {
-	slices.SortFunc(om.s, less)
+func (om *OrderedMap[K, V]) SortFunc[T comparable](less func(i, j T) bool) {
+  slices.SortFunc(om.s, less)
 }
 
 // Keys will return a slice of the map's keys in order.


### PR DESCRIPTION
Changed the sort function to take in a generic type rather than the inferred type

> Thanks for your pull request, we really appreciate contributions!
>
> Please understand that it may take some time to be reviewed.
>
> Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).
