### PR TITLE
Add silent to for_call schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix bug where dynamic `vars:` and `env:` were being executed when they should
   actually be skipped by `platforms:` (#1273, #1377 by @andreynering).
+- Fix `schema.json` to make `silent` valid in `cmds` that use `for` (#1385, #1386 by @iainvm).
 
 ## v3.31.0 - 2023-10-07
 

--- a/docs/static/schema.json
+++ b/docs/static/schema.json
@@ -370,6 +370,10 @@
             "description": "Command to run",
             "type": "string"
           },
+          "silent": {
+            "description": "Silent mode disables echoing of command before Task runs it",
+            "type": "boolean"
+          },
           "task": {
             "description": "Task to run",
             "type": "string"


### PR DESCRIPTION
Fixes #1385 

It seems that the `for_call` schema doesn't contain many of the elements from a normal `cmd_call` though I'm not sure which parts are valid for the `for_call` other than the `silent` element so didn't copy those across