### PR TITLE
Support any variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added
+  [Any Variables experiment](https://taskfile.dev/experiments/any_variables)
+  (#1415, #1421 by @pd93).
 - Added `aliases` to `--json` flag output (#1430, #1431 by @pd93)
 
 ## v3.32.0 - 2023-11-29

--- a/args/args.go
+++ b/args/args.go
@@ -18,7 +18,7 @@ func ParseV3(args ...string) ([]taskfile.Call, *taskfile.Vars) {
 		}
 
 		name, value := splitVar(arg)
-		globals.Set(name, taskfile.Var{Static: value})
+		globals.Set(name, taskfile.Var{Value: value})
 	}
 
 	return calls, globals
@@ -37,13 +37,13 @@ func ParseV2(args ...string) ([]taskfile.Call, *taskfile.Vars) {
 
 		if len(calls) < 1 {
 			name, value := splitVar(arg)
-			globals.Set(name, taskfile.Var{Static: value})
+			globals.Set(name, taskfile.Var{Value: value})
 		} else {
 			if calls[len(calls)-1].Vars == nil {
 				calls[len(calls)-1].Vars = &taskfile.Vars{}
 			}
 			name, value := splitVar(arg)
-			calls[len(calls)-1].Vars.Set(name, taskfile.Var{Static: value})
+			calls[len(calls)-1].Vars.Set(name, taskfile.Var{Value: value})
 		}
 	}
 

--- a/args/args_test.go
+++ b/args/args_test.go
@@ -35,9 +35,9 @@ func TestArgsV3(t *testing.T) {
 			ExpectedGlobals: &taskfile.Vars{
 				OrderedMap: orderedmap.FromMapWithOrder(
 					map[string]taskfile.Var{
-						"FOO": {Static: "bar"},
-						"BAR": {Static: "baz"},
-						"BAZ": {Static: "foo"},
+						"FOO": {Value: "bar"},
+						"BAR": {Value: "baz"},
+						"BAZ": {Value: "foo"},
 					},
 					[]string{"FOO", "BAR", "BAZ"},
 				),
@@ -51,7 +51,7 @@ func TestArgsV3(t *testing.T) {
 			ExpectedGlobals: &taskfile.Vars{
 				OrderedMap: orderedmap.FromMapWithOrder(
 					map[string]taskfile.Var{
-						"CONTENT": {Static: "with some spaces"},
+						"CONTENT": {Value: "with some spaces"},
 					},
 					[]string{"CONTENT"},
 				),
@@ -66,7 +66,7 @@ func TestArgsV3(t *testing.T) {
 			ExpectedGlobals: &taskfile.Vars{
 				OrderedMap: orderedmap.FromMapWithOrder(
 					map[string]taskfile.Var{
-						"FOO": {Static: "bar"},
+						"FOO": {Value: "bar"},
 					},
 					[]string{"FOO"},
 				),
@@ -86,8 +86,8 @@ func TestArgsV3(t *testing.T) {
 			ExpectedGlobals: &taskfile.Vars{
 				OrderedMap: orderedmap.FromMapWithOrder(
 					map[string]taskfile.Var{
-						"FOO": {Static: "bar"},
-						"BAR": {Static: "baz"},
+						"FOO": {Value: "bar"},
+						"BAR": {Value: "baz"},
 					},
 					[]string{"FOO", "BAR"},
 				),
@@ -130,7 +130,7 @@ func TestArgsV2(t *testing.T) {
 					Vars: &taskfile.Vars{
 						OrderedMap: orderedmap.FromMapWithOrder(
 							map[string]taskfile.Var{
-								"FOO": {Static: "bar"},
+								"FOO": {Value: "bar"},
 							},
 							[]string{"FOO"},
 						),
@@ -143,8 +143,8 @@ func TestArgsV2(t *testing.T) {
 					Vars: &taskfile.Vars{
 						OrderedMap: orderedmap.FromMapWithOrder(
 							map[string]taskfile.Var{
-								"BAR": {Static: "baz"},
-								"BAZ": {Static: "foo"},
+								"BAR": {Value: "baz"},
+								"BAZ": {Value: "foo"},
 							},
 							[]string{"BAR", "BAZ"},
 						),
@@ -161,7 +161,7 @@ func TestArgsV2(t *testing.T) {
 					Vars: &taskfile.Vars{
 						OrderedMap: orderedmap.FromMapWithOrder(
 							map[string]taskfile.Var{
-								"CONTENT": {Static: "with some spaces"},
+								"CONTENT": {Value: "with some spaces"},
 							},
 							[]string{"CONTENT"},
 						),
@@ -178,7 +178,7 @@ func TestArgsV2(t *testing.T) {
 			ExpectedGlobals: &taskfile.Vars{
 				OrderedMap: orderedmap.FromMapWithOrder(
 					map[string]taskfile.Var{
-						"FOO": {Static: "bar"},
+						"FOO": {Value: "bar"},
 					},
 					[]string{"FOO"},
 				),
@@ -198,8 +198,8 @@ func TestArgsV2(t *testing.T) {
 			ExpectedGlobals: &taskfile.Vars{
 				OrderedMap: orderedmap.FromMapWithOrder(
 					map[string]taskfile.Var{
-						"FOO": {Static: "bar"},
-						"BAR": {Static: "baz"},
+						"FOO": {Value: "bar"},
+						"BAR": {Value: "baz"},
 					},
 					[]string{"FOO", "BAR"},
 				),

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -311,7 +311,7 @@ func run() error {
 		calls = append(calls, taskfile.Call{Task: "default", Direct: true})
 	}
 
-	globals.Set("CLI_ARGS", taskfile.Var{Static: cliArgs})
+	globals.Set("CLI_ARGS", taskfile.Var{Value: cliArgs})
 	e.Taskfile.Vars.Merge(globals)
 
 	if !flags.watch {

--- a/docs/docs/experiments/any_variables.md
+++ b/docs/docs/experiments/any_variables.md
@@ -1,0 +1,105 @@
+---
+slug: /experiments/any-variables/
+---
+
+# Any Variables
+
+- Issue: [#1415](https://github.com/go-task/task/issues/1415)
+- Environment variable: `TASK_X_ANY_VARIABLES=1`
+- Breaks:
+  - Dynamically defined variables (using the `sh` keyword)
+
+Currently, Task only supports string variables. This experiment allows you to
+specify and use the following variable types:
+
+- `string`
+- `bool`
+- `int`
+- `float`
+- `array`
+- `map`
+
+This allows you to have a lot more flexibility in how you use variables in
+Task's templating engine. For example:
+
+Evaluating booleans:
+
+```yaml
+version: 3
+
+tasks:
+  foo:
+    vars:
+      BOOL: false
+    cmds:
+      - '{{ if .BOOL }}echo foo{{ end}}'
+```
+
+Arithmetic:
+
+```yaml
+version: 3
+
+tasks:
+  foo:
+    vars:
+      INT: 10
+      FLOAT: 3.14159
+    cmds:
+      - 'echo {{ add .INT .FLOAT }}'
+```
+
+Loops:
+
+```yaml
+version: 3
+
+tasks:
+  foo:
+    vars:
+      ARRAY: [1, 2, 3]
+    cmds:
+      - 'echo {{ range .ARRAY }}{{ . }}{{ end }}'
+```
+
+etc.
+
+## Migration
+
+Taskfiles with dynamically defined variables via the `sh` subkey will no longer
+work with this experiment enabled. In order to keep using dynamically defined
+variables, you will need to migrate your Taskfile to use the new syntax.
+
+Previously, you might have defined a dynamic variable like this:
+
+```yaml
+version: 3
+
+task:
+  foo:
+    vars:
+      CALCULATED_VAR:
+        sh: 'echo hello'
+    cmds:
+      - 'echo {{ .CALCULATED_VAR }}'
+```
+
+With this experiment enabled, you will need to remove the `sh` subkey and define
+your command as a string that begins with a `$`. This will instruct Task to
+interpret the string as a command instead of a literal value and the variable
+will be populated with the output of the command. For example:
+
+```yaml
+version: 3
+
+task:
+  foo:
+    vars:
+      CALCULATED_VAR: '$echo hello'
+    cmds:
+      - 'echo {{ .CALCULATED_VAR }}'
+```
+
+If your current Taskfile contains a string variable that begins with a `$`, you
+will now need to escape the `$` with a backslash (`\`) to stop Task from
+executing it as a command.

--- a/docs/static/schema.json
+++ b/docs/static/schema.json
@@ -249,7 +249,7 @@
           "^.*$": {
             "anyOf": [
               {
-                "type": ["boolean", "integer", "null", "number", "string"]
+                "type": ["boolean", "integer", "null", "number", "string", "object", "array"]
               },
               {
                 "$ref": "#/definitions/3/dynamic_var"

--- a/internal/compiler/env.go
+++ b/internal/compiler/env.go
@@ -14,7 +14,7 @@ func GetEnviron() *taskfile.Vars {
 	for _, e := range os.Environ() {
 		keyVal := strings.SplitN(e, "=", 2)
 		key, val := keyVal[0], keyVal[1]
-		m.Set(key, taskfile.Var{Static: val})
+		m.Set(key, taskfile.Var{Value: val})
 	}
 	return m
 }

--- a/internal/compiler/v2/compiler_v2.go
+++ b/internal/compiler/v2/compiler_v2.go
@@ -50,7 +50,7 @@ func (c *CompilerV2) GetVariables(t *taskfile.Task, call taskfile.Call) (*taskfi
 		c:    c,
 		vars: compiler.GetEnviron(),
 	}
-	vr.vars.Set("TASK", taskfile.Var{Static: t.Task})
+	vr.vars.Set("TASK", taskfile.Var{Value: t.Task})
 
 	for _, vars := range []*taskfile.Vars{c.Taskvars, c.TaskfileVars, call.Vars, t.Vars} {
 		for i := 0; i < c.Expansions; i++ {
@@ -73,23 +73,23 @@ func (vr *varResolver) merge(vars *taskfile.Vars) {
 	tr := templater.Templater{Vars: vr.vars}
 	_ = vars.Range(func(k string, v taskfile.Var) error {
 		v = taskfile.Var{
-			Static: tr.Replace(v.Static),
-			Sh:     tr.Replace(v.Sh),
+			Value: tr.Replace(v.Value),
+			Sh:    tr.Replace(v.Sh),
 		}
 		static, err := vr.c.HandleDynamicVar(v, "")
 		if err != nil {
 			vr.err = err
 			return err
 		}
-		vr.vars.Set(k, taskfile.Var{Static: static})
+		vr.vars.Set(k, taskfile.Var{Value: static})
 		return nil
 	})
 	vr.err = tr.Err()
 }
 
 func (c *CompilerV2) HandleDynamicVar(v taskfile.Var, _ string) (string, error) {
-	if v.Static != "" || v.Sh == "" {
-		return v.Static, nil
+	if v.Value != "" || v.Sh == "" {
+		return v.Value, nil
 	}
 
 	c.muDynamicCache.Lock()

--- a/internal/compiler/v3/compiler_v3.go
+++ b/internal/compiler/v3/compiler_v3.go
@@ -71,6 +71,12 @@ func (c *CompilerV3) getVariables(t *taskfile.Task, call *taskfile.Call, evaluat
 			if err := tr.Err(); err != nil {
 				return err
 			}
+			// If the variable should not be evaluated, but is nil, set it to an empty string
+			// This stops empty interface errors when using the templater to replace values later
+			if !evaluateShVars && newVar.Value == nil {
+				result.Set(k, taskfile.Var{Value: ""})
+				return nil
+			}
 			// If the variable is not dynamic, we can set it and return
 			if !evaluateShVars || newVar.Value != nil || newVar.Sh == "" {
 				result.Set(k, taskfile.Var{Value: newVar.Value})

--- a/internal/compiler/v3/compiler_v3.go
+++ b/internal/compiler/v3/compiler_v3.go
@@ -51,7 +51,7 @@ func (c *CompilerV3) getVariables(t *taskfile.Task, call *taskfile.Call, evaluat
 			return nil, err
 		}
 		for k, v := range specialVars {
-			result.Set(k, taskfile.Var{Static: v})
+			result.Set(k, taskfile.Var{Value: v})
 		}
 	}
 
@@ -60,14 +60,14 @@ func (c *CompilerV3) getVariables(t *taskfile.Task, call *taskfile.Call, evaluat
 			tr := templater.Templater{Vars: result, RemoveNoValue: true}
 
 			if !evaluateShVars {
-				result.Set(k, taskfile.Var{Static: tr.Replace(v.Static)})
+				result.Set(k, taskfile.Var{Value: tr.Replace(v.Value)})
 				return nil
 			}
 
 			v = taskfile.Var{
-				Static: tr.Replace(v.Static),
-				Sh:     tr.Replace(v.Sh),
-				Dir:    v.Dir,
+				Value: tr.Replace(v.Value),
+				Sh:    tr.Replace(v.Sh),
+				Dir:   v.Dir,
 			}
 			if err := tr.Err(); err != nil {
 				return err
@@ -76,7 +76,7 @@ func (c *CompilerV3) getVariables(t *taskfile.Task, call *taskfile.Call, evaluat
 			if err != nil {
 				return err
 			}
-			result.Set(k, taskfile.Var{Static: static})
+			result.Set(k, taskfile.Var{Value: static})
 			return nil
 		}
 	}
@@ -125,8 +125,8 @@ func (c *CompilerV3) getVariables(t *taskfile.Task, call *taskfile.Call, evaluat
 }
 
 func (c *CompilerV3) HandleDynamicVar(v taskfile.Var, dir string) (string, error) {
-	if v.Static != "" || v.Sh == "" {
-		return v.Static, nil
+	if v.Value != "" || v.Sh == "" {
+		return v.Value, nil
 	}
 
 	c.muDynamicCache.Lock()

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -18,12 +18,14 @@ const envPrefix = "TASK_X_"
 var (
 	GentleForce     bool
 	RemoteTaskfiles bool
+	AnyVariables    bool
 )
 
 func init() {
 	readDotEnv()
 	GentleForce = parseEnv("GENTLE_FORCE")
 	RemoteTaskfiles = parseEnv("REMOTE_TASKFILES")
+	AnyVariables = parseEnv("ANY_VARIABLES")
 }
 
 func parseEnv(xName string) bool {
@@ -51,5 +53,6 @@ func List(l *logger.Logger) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 0, ' ', 0)
 	printExperiment(w, l, "GENTLE_FORCE", GentleForce)
 	printExperiment(w, l, "REMOTE_TASKFILES", RemoteTaskfiles)
+	printExperiment(w, l, "ANY_VARIABLES", AnyVariables)
 	return w.Flush()
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -49,7 +49,7 @@ func TestGroupWithBeginEnd(t *testing.T) {
 	tmpl := templater.Templater{
 		Vars: &taskfile.Vars{
 			OrderedMap: orderedmap.FromMap(map[string]taskfile.Var{
-				"VAR1": {Static: "example-value"},
+				"VAR1": {Value: "example-value"},
 			}),
 		},
 	}

--- a/internal/templater/templater.go
+++ b/internal/templater/templater.go
@@ -108,17 +108,20 @@ func (r *Templater) replaceVars(vars *taskfile.Vars, extra map[string]any) *task
 		return nil
 	}
 
-	var new taskfile.Vars
+	var newVars taskfile.Vars
 	_ = vars.Range(func(k string, v taskfile.Var) error {
-		new.Set(k, taskfile.Var{
-			Value: r.ReplaceWithExtra(v.Value, extra),
-			Live:  v.Live,
-			Sh:    r.ReplaceWithExtra(v.Sh, extra),
-		})
+		var newVar taskfile.Var
+		switch value := v.Value.(type) {
+		case string:
+			newVar.Value = r.ReplaceWithExtra(value, extra)
+		}
+		newVar.Live = v.Live
+		newVar.Sh = r.ReplaceWithExtra(v.Sh, extra)
+		newVars.Set(k, newVar)
 		return nil
 	})
 
-	return &new
+	return &newVars
 }
 
 func (r *Templater) Err() error {

--- a/internal/templater/templater.go
+++ b/internal/templater/templater.go
@@ -111,9 +111,9 @@ func (r *Templater) replaceVars(vars *taskfile.Vars, extra map[string]any) *task
 	var new taskfile.Vars
 	_ = vars.Range(func(k string, v taskfile.Var) error {
 		new.Set(k, taskfile.Var{
-			Static: r.ReplaceWithExtra(v.Static, extra),
-			Live:   v.Live,
-			Sh:     r.ReplaceWithExtra(v.Sh, extra),
+			Value: r.ReplaceWithExtra(v.Value, extra),
+			Live:  v.Live,
+			Sh:    r.ReplaceWithExtra(v.Sh, extra),
 		})
 		return nil
 	})

--- a/task.go
+++ b/task.go
@@ -478,8 +478,8 @@ func (e *Executor) GetTaskList(filters ...FilterFunc) ([]*taskfile.Task, error) 
 		task := tasks[idx]
 		g.Go(func() error {
 			compiledTask, err := e.FastCompiledTask(taskfile.Call{Task: task.Task})
-			if err == nil {
-				task = compiledTask
+			if err != nil {
+				return err
 			}
 			tasks[idx] = compiledTask
 			return nil

--- a/task_test.go
+++ b/task_test.go
@@ -2111,7 +2111,7 @@ func TestSplitArgs(t *testing.T) {
 	require.NoError(t, e.Setup())
 
 	vars := &taskfile.Vars{}
-	vars.Set("CLI_ARGS", taskfile.Var{Static: "foo bar 'foo bar baz'"})
+	vars.Set("CLI_ARGS", taskfile.Var{Value: "foo bar 'foo bar baz'"})
 
 	err := e.Run(context.Background(), taskfile.Call{Task: "default", Vars: vars})
 	require.NoError(t, err)

--- a/taskfile/for.go
+++ b/taskfile/for.go
@@ -10,7 +10,7 @@ import (
 
 type For struct {
 	From  string
-	List  []string
+	List  []any
 	Var   string
 	Split string
 	As    string
@@ -28,7 +28,7 @@ func (f *For) UnmarshalYAML(node *yaml.Node) error {
 		return nil
 
 	case yaml.SequenceNode:
-		var list []string
+		var list []any
 		if err := node.Decode(&list); err != nil {
 			return err
 		}

--- a/taskfile/read/dotenv.go
+++ b/taskfile/read/dotenv.go
@@ -42,7 +42,7 @@ func Dotenv(c compiler.Compiler, tf *taskfile.Taskfile, dir string) (*taskfile.V
 		}
 		for key, value := range envs {
 			if ok := env.Exists(key); !ok {
-				env.Set(key, taskfile.Var{Static: value})
+				env.Set(key, taskfile.Var{Value: value})
 			}
 		}
 	}

--- a/taskfile/taskfile_test.go
+++ b/taskfile/taskfile_test.go
@@ -41,8 +41,8 @@ vars:
 				Task: "another-task", Vars: &taskfile.Vars{
 					OrderedMap: orderedmap.FromMapWithOrder(
 						map[string]taskfile.Var{
-							"PARAM1": {Static: "VALUE1"},
-							"PARAM2": {Static: "VALUE2"},
+							"PARAM1": {Value: "VALUE1"},
+							"PARAM2": {Value: "VALUE2"},
 						},
 						[]string{"PARAM1", "PARAM2"},
 					),
@@ -61,7 +61,7 @@ vars:
 				Task: "some_task", Vars: &taskfile.Vars{
 					OrderedMap: orderedmap.FromMapWithOrder(
 						map[string]taskfile.Var{
-							"PARAM1": {Static: "var"},
+							"PARAM1": {Value: "var"},
 						},
 						[]string{"PARAM1"},
 					),
@@ -81,8 +81,8 @@ vars:
 				Task: "another-task", Vars: &taskfile.Vars{
 					OrderedMap: orderedmap.FromMapWithOrder(
 						map[string]taskfile.Var{
-							"PARAM1": {Static: "VALUE1"},
-							"PARAM2": {Static: "VALUE2"},
+							"PARAM1": {Value: "VALUE1"},
+							"PARAM2": {Value: "VALUE2"},
 						},
 						[]string{"PARAM1", "PARAM2"},
 					),

--- a/taskfile/var.go
+++ b/taskfile/var.go
@@ -71,7 +71,7 @@ func (vs *Vars) DeepCopy() *Vars {
 
 // Var represents either a static or dynamic variable.
 type Var struct {
-	Value string
+	Value any
 	Live  any
 	Sh    string
 	Dir   string

--- a/taskfile/var.go
+++ b/taskfile/var.go
@@ -5,6 +5,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/go-task/task/v3/internal/experiments"
 	"github.com/go-task/task/v3/internal/orderedmap"
 )
 
@@ -78,6 +79,15 @@ type Var struct {
 }
 
 func (v *Var) UnmarshalYAML(node *yaml.Node) error {
+	if experiments.AnyVariables {
+		var value any
+		if err := node.Decode(&value); err != nil {
+			return err
+		}
+		v.Value = value
+		return nil
+	}
+
 	switch node.Kind {
 
 	case yaml.ScalarNode:

--- a/taskfile/var.go
+++ b/taskfile/var.go
@@ -27,7 +27,7 @@ func (vs *Vars) ToCacheMap() (m map[string]any) {
 		if v.Live != nil {
 			m[k] = v.Live
 		} else {
-			m[k] = v.Static
+			m[k] = v.Value
 		}
 		return nil
 	})
@@ -71,10 +71,10 @@ func (vs *Vars) DeepCopy() *Vars {
 
 // Var represents either a static or dynamic variable.
 type Var struct {
-	Static string
-	Live   any
-	Sh     string
-	Dir    string
+	Value string
+	Live  any
+	Sh    string
+	Dir   string
 }
 
 func (v *Var) UnmarshalYAML(node *yaml.Node) error {
@@ -85,7 +85,7 @@ func (v *Var) UnmarshalYAML(node *yaml.Node) error {
 		if err := node.Decode(&str); err != nil {
 			return err
 		}
-		v.Static = str
+		v.Value = str
 		return nil
 
 	case yaml.MappingNode:

--- a/taskfile/var.go
+++ b/taskfile/var.go
@@ -2,6 +2,7 @@ package taskfile
 
 import (
 	"fmt"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -83,6 +84,13 @@ func (v *Var) UnmarshalYAML(node *yaml.Node) error {
 		var value any
 		if err := node.Decode(&value); err != nil {
 			return err
+		}
+		// If the value is a string and it starts with $, then it's a shell command
+		if str, ok := value.(string); ok {
+			if str, ok = strings.CutPrefix(str, "$"); ok {
+				v.Sh = str
+				return nil
+			}
 		}
 		v.Value = value
 		return nil

--- a/testdata/vars/any/Taskfile.yml
+++ b/testdata/vars/any/Taskfile.yml
@@ -1,0 +1,80 @@
+version: '3'
+
+tasks:
+  default:
+    - task: dynamic
+    - task: string
+    - task: bool
+    - task: int
+    - task: string-array
+    - task: for-string
+    - task: for-int
+
+  dynamic:
+    vars:
+      STRING_A: '$echo "A"'
+      STRING_B: '$echo {{.STRING_A}}B'
+      STRING_C: '$echo {{.STRING_B}}C'
+    cmds:
+      - echo '{{.STRING_C}}'
+
+  string:
+    vars:
+      STRING_A: 'A'
+      STRING_B: '{{.STRING_A}}B'
+      STRING_C: '{{.STRING_B}}C'
+    cmds:
+      - echo '{{.STRING_C}}'
+
+  bool:
+    vars:
+      BOOL_TRUE: true
+      BOOL_FALSE: false
+      BOOL_A: '{{and .BOOL_TRUE .BOOL_FALSE}}'
+      BOOL_B: '{{or .BOOL_TRUE .BOOL_FALSE}}'
+      BOOL_C: '{{not .BOOL_TRUE}}'
+    cmds:
+      - echo '{{if .BOOL_TRUE}}A:{{.BOOL_A}} B:{{.BOOL_B}} C:{{.BOOL_C}}{{end}}'
+
+  int:
+    vars:
+      INT_100: 100
+      INT_10: 10
+    cmds:
+      - echo '100 + 10 = {{add .INT_100 .INT_10}}'
+      - echo '100 - 10 = {{sub .INT_100 .INT_10}}'
+      - echo '100 * 10 = {{mul .INT_100 .INT_10}}'
+      - echo '100 / 10 = {{div .INT_100 .INT_10}}'
+
+  string-array:
+    vars:
+      ARRAY_1: ['A', 'B', 'C']
+      ARRAY_2: ['D', 'E', 'F']
+    cmds:
+      - echo '{{append .ARRAY_1 "D"}}'
+      - echo '{{concat .ARRAY_1 .ARRAY_2}}'
+      - echo '{{join " " .ARRAY_1}}'
+
+  map:
+    vars:
+      MAP_1: {A: 1, B: 2, C: 3}
+      MAP_2: {D: 4, E: 5, F: 6}
+    cmds:
+      - echo '{{merge .MAP_1 .MAP_2}}'
+
+  for-string:
+    vars:
+      LIST: [foo, bar, baz]
+    cmds:
+      - for:
+          var: LIST
+        cmd: echo {{.ITEM}}
+
+  for-int:
+    vars:
+      LIST: [1, 2, 3]
+    cmds:
+      - for:
+          var: LIST
+        cmd: echo {{add .ITEM 100}}
+

--- a/variables.go
+++ b/variables.go
@@ -96,7 +96,7 @@ func (e *Executor) compiledTask(call taskfile.Call, evaluateShVars bool) (*taskf
 			}
 			for key, value := range envs {
 				if ok := dotenvEnvs.Exists(key); !ok {
-					dotenvEnvs.Set(key, taskfile.Var{Static: value})
+					dotenvEnvs.Set(key, taskfile.Var{Value: value})
 				}
 			}
 		}
@@ -112,7 +112,7 @@ func (e *Executor) compiledTask(call taskfile.Call, evaluateShVars bool) (*taskf
 			if err != nil {
 				return err
 			}
-			new.Env.Set(k, taskfile.Var{Static: static})
+			new.Env.Set(k, taskfile.Var{Value: static})
 			return nil
 		})
 		if err != nil {
@@ -150,9 +150,9 @@ func (e *Executor) compiledTask(call taskfile.Call, evaluateShVars bool) (*taskf
 					if vars != nil {
 						v := vars.Get(cmd.For.Var)
 						if cmd.For.Split != "" {
-							list = strings.Split(v.Static, cmd.For.Split)
+							list = strings.Split(v.Value, cmd.For.Split)
 						} else {
-							list = strings.Fields(v.Static)
+							list = strings.Fields(v.Value)
 						}
 					}
 				}

--- a/variables.go
+++ b/variables.go
@@ -169,6 +169,11 @@ func (e *Executor) compiledTask(call taskfile.Call, evaluateShVars bool) (*taskf
 								}
 							case []any:
 								list = value
+							case map[string]any:
+								return &taskfile.Task{}, errors.TaskfileInvalidError{
+									URI: origTask.Location.Taskfile,
+									Err: errors.New("sh is not supported with the 'Any Variables' experiment enabled.\nSee https://taskfile.dev/experiments/any-variables for more information."),
+								}
 							default:
 								return nil, errors.TaskfileInvalidError{
 									URI: origTask.Location.Taskfile,


### PR DESCRIPTION
This is the first iteration of the "Any Variables" experiment that allows users to use any type in their Taskfile variables. In this PR:

- Adds the `TASK_X_ANY_VARIABLES` experiment flag
- Renames `Var.Static` -> `Var.Value`
- Changes `Var.Value` to an `any` type
- Unmarshal into `any` type instead of just strings when the experiment flag is enabled.
- Updated schema to support objects and arrays in vars
- Added some experiment docs
- `for` supports arrays when looping over a variable
- Added an error message when trying to use `sh` with the experiment enabled
- Added new syntax for dynamic variables

There are no tests in this PR as its an experiment. However, I have added a Taskfile in `testdata/vars/any` which can be used to try out the functionality:

`go run ./cmd/task --dir testdata/vars/any`

---

The main things I'm looking for feedback on are:

- Bugs/errors (obviously)
- Missing functionality (Is there anything else we could do now that we support `any` variables)
- Dynamic variables
  - Dynamic variables previously used a subkey (`sh`) to define the command. This is incompatible with map variables as they would be defined the same way. This means that dynamic variables are now defined by starting a string variable with the `$` character instead.
  - Do we like/dislike this?
  - An alternative would be to not allow map variables in this experiment and keep the existing `sh` syntax. This would make this change non-breaking and it could be merged into v3 rather than waiting for a major version bump. However, you won't be able to define variables as maps at all.
  - Feedback on how useful map variables are would be help weigh up the pros/cons of each option.
