### PR TITLE
chore(docs): fix downlaoded typo

### DIFF
--- a/docs/docs/api_reference.md
+++ b/docs/docs/api_reference.md
@@ -70,7 +70,7 @@ A full list of the exit codes and their descriptions can be found below:
 | 100  | No Taskfile was found                                        |
 | 101  | A Taskfile already exists when trying to initialize one      |
 | 102  | The Taskfile is invalid or cannot be parsed                  |
-| 103  | A remote Taskfile could not be downlaoded                    |
+| 103  | A remote Taskfile could not be downloaded                    |
 | 104  | A remote Taskfile was not trusted by the user                |
 | 105  | A remote Taskfile was could not be fetched securely          |
 | 106  | No cache was found for a remote Taskfile in offline mode     |

--- a/docs/i18n/es-ES/docusaurus-plugin-content-docs/current/api_reference.md
+++ b/docs/i18n/es-ES/docusaurus-plugin-content-docs/current/api_reference.md
@@ -68,7 +68,7 @@ A full list of the exit codes and their descriptions can be found below:
 | 100  | No Taskfile was found                                        |
 | 101  | A Taskfile already exists when trying to initialize one      |
 | 102  | The Taskfile is invalid or cannot be parsed                  |
-| 103  | A remote Taskfile could not be downlaoded                    |
+| 103  | A remote Taskfile could not be downloaded                    |
 | 104  | A remote Taskfile was not trusted by the user                |
 | 105  | A remote Taskfile was could not be fetched securely          |
 | 106  | No cache was found for a remote Taskfile in offline mode     |

--- a/docs/i18n/fr-FR/docusaurus-plugin-content-docs/current/api_reference.md
+++ b/docs/i18n/fr-FR/docusaurus-plugin-content-docs/current/api_reference.md
@@ -68,7 +68,7 @@ A full list of the exit codes and their descriptions can be found below:
 | 100  | No Taskfile was found                                        |
 | 101  | A Taskfile already exists when trying to initialize one      |
 | 102  | The Taskfile is invalid or cannot be parsed                  |
-| 103  | A remote Taskfile could not be downlaoded                    |
+| 103  | A remote Taskfile could not be downloaded                    |
 | 104  | A remote Taskfile was not trusted by the user                |
 | 105  | A remote Taskfile was could not be fetched securely          |
 | 106  | No cache was found for a remote Taskfile in offline mode     |

--- a/docs/i18n/ja-JP/docusaurus-plugin-content-docs/current/api_reference.md
+++ b/docs/i18n/ja-JP/docusaurus-plugin-content-docs/current/api_reference.md
@@ -68,7 +68,7 @@ A full list of the exit codes and their descriptions can be found below:
 | 100 | No Taskfile was found                                        |
 | 101 | A Taskfile already exists when trying to initialize one      |
 | 102 | The Taskfile is invalid or cannot be parsed                  |
-| 103 | A remote Taskfile could not be downlaoded                    |
+| 103 | A remote Taskfile could not be downloaded                    |
 | 104 | A remote Taskfile was not trusted by the user                |
 | 105 | A remote Taskfile was could not be fetched securely          |
 | 106 | No cache was found for a remote Taskfile in offline mode     |

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/api_reference.md
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/api_reference.md
@@ -68,7 +68,7 @@ Uma lista completa dos códigos de saída e suas descrições podem ser encontra
 | 100    | Nenhum Arquivo foi encontrado                               |
 | 101    | Um arquivo Taskfile já existe ao tentar inicializar um      |
 | 102    | O arquivo Taskfile é inválido ou não pode ser analisado     |
-| 103    | A remote Taskfile could not be downlaoded                   |
+| 103    | A remote Taskfile could not be downloaded                   |
 | 104    | A remote Taskfile was not trusted by the user               |
 | 105    | A remote Taskfile was could not be fetched securely         |
 | 106    | No cache was found for a remote Taskfile in offline mode    |

--- a/docs/i18n/ru-RU/docusaurus-plugin-content-docs/current/api_reference.md
+++ b/docs/i18n/ru-RU/docusaurus-plugin-content-docs/current/api_reference.md
@@ -68,7 +68,7 @@ A full list of the exit codes and their descriptions can be found below:
 | 100  | No Taskfile was found                                        |
 | 101  | A Taskfile already exists when trying to initialize one      |
 | 102  | The Taskfile is invalid or cannot be parsed                  |
-| 103  | A remote Taskfile could not be downlaoded                    |
+| 103  | A remote Taskfile could not be downloaded                    |
 | 104  | A remote Taskfile was not trusted by the user                |
 | 105  | A remote Taskfile was could not be fetched securely          |
 | 106  | No cache was found for a remote Taskfile in offline mode     |

--- a/docs/i18n/tr-TR/docusaurus-plugin-content-docs/current/api_reference.md
+++ b/docs/i18n/tr-TR/docusaurus-plugin-content-docs/current/api_reference.md
@@ -68,7 +68,7 @@ A full list of the exit codes and their descriptions can be found below:
 | 100  | No Taskfile was found                                        |
 | 101  | A Taskfile already exists when trying to initialize one      |
 | 102  | The Taskfile is invalid or cannot be parsed                  |
-| 103  | A remote Taskfile could not be downlaoded                    |
+| 103  | A remote Taskfile could not be downloaded                    |
 | 104  | A remote Taskfile was not trusted by the user                |
 | 105  | A remote Taskfile was could not be fetched securely          |
 | 106  | No cache was found for a remote Taskfile in offline mode     |

--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api_reference.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/api_reference.md
@@ -68,7 +68,7 @@ Task 有时会以特定的退出代码退出。 These codes are split into three
 | 100 | 找不到 Taskfile                                             |
 | 101 | 尝试初始化一个 Taskfile 时已经存在                                   |
 | 102 | Taskfile 无效或无法解析                                         |
-| 103 | A remote Taskfile could not be downlaoded                |
+| 103 | A remote Taskfile could not be downloaded                |
 | 104 | A remote Taskfile was not trusted by the user            |
 | 105 | A remote Taskfile was could not be fetched securely      |
 | 106 | No cache was found for a remote Taskfile in offline mode |


### PR DESCRIPTION
Fixed typo `downlaoded` in the docs