### PR TITLE
feat: add aliases to --json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added `aliases` to `--json` flag output (#1430, #1431 by @pd93)
+
 ## v3.32.0 - 2023-11-29
 
 - Added ability to exclude some files from `sources:` by using `exclude:` (#225,

--- a/help.go
+++ b/help.go
@@ -168,11 +168,16 @@ func (e *Executor) ToEditorOutput(tasks []*taskfile.Task, noStatus bool) (*edito
 	for i := range tasks {
 		task := tasks[i]
 		j := i
+		aliases := []string{}
+		if len(task.Aliases) > 0 {
+			aliases = task.Aliases
+		}
 		g.Go(func() error {
 			o.Tasks[j] = editors.Task{
 				Name:     task.Name(),
 				Desc:     task.Desc,
 				Summary:  task.Summary,
+				Aliases:  aliases,
 				UpToDate: false,
 				Location: &editors.Location{
 					Line:     task.Location.Line,

--- a/internal/editors/output.go
+++ b/internal/editors/output.go
@@ -11,6 +11,7 @@ type (
 		Name     string    `json:"name"`
 		Desc     string    `json:"desc"`
 		Summary  string    `json:"summary"`
+		Aliases  []string  `json:"aliases"`
 		UpToDate bool      `json:"up_to_date"`
 		Location *Location `json:"location"`
 	}


### PR DESCRIPTION
Fixes #1430 

Only point of note - I decided that when `aliases` is empty, it should marshal to `[]` instead of `null` or being omitted. Welcome to opinions on this, but an empty array makes the most sense to me.