### PR TITLE
feat: support looping over map variables

### DIFF
--- a/docs/docs/experiments/any_variables.md
+++ b/docs/docs/experiments/any_variables.md
@@ -63,8 +63,7 @@ tasks:
 ```
 
 There are many more templating functions which can be used with the new types of
-variables. For a full list, see the
-[slim-sprig][slim-sprig] documentation.
+variables. For a full list, see the [slim-sprig][slim-sprig] documentation.
 
 ## Looping over variables
 
@@ -102,8 +101,10 @@ tasks:
         cmd: echo {{.ITEM}}
 ```
 
-This also works for maps. However, remember that maps are unordered, so the
-order in which the items are looped over is random:
+This also works for maps. When looping over a map we also make an additional
+`{{.KEY}}` variable availabe that holds the string value of the map key.
+Remember that maps are unordered, so the order in which the items are looped
+over is random:
 
 ```yaml
 version: 3
@@ -121,7 +122,7 @@ tasks:
     cmds:
       - for:
           var: MAP
-        cmd: echo {{.ITEM.SUBKEY}}
+        cmd: echo {{.KEY}} {{.ITEM.SUBKEY}}
 ```
 
 String splitting is still supported and remember that for simple cases, you have

--- a/docs/docs/experiments/any_variables.md
+++ b/docs/docs/experiments/any_variables.md
@@ -86,8 +86,8 @@ tasks:
         cmd: echo {{.ITEM}}
 ```
 
-Because this experiment adds support for array variables, the `for` keyword has
-been updated to support looping over arrays directly:
+Because this experiment adds support for "collection-type" variables, the `for`
+keyword has been updated to support looping over arrays directly:
 
 ```yaml
 version: 3
@@ -100,6 +100,28 @@ tasks:
       - for:
           var: LIST
         cmd: echo {{.ITEM}}
+```
+
+This also works for maps. However, remember that maps are unordered, so the
+order in which the items are looped over is random:
+
+```yaml
+version: 3
+
+tasks:
+  foo:
+    vars:
+      MAP:
+        KEY_1:
+          SUBKEY: sub_value_1
+        KEY_2:
+          SUBKEY: sub_value_2
+        KEY_3:
+          SUBKEY: sub_value_3
+    cmds:
+      - for:
+          var: MAP
+        cmd: echo {{.ITEM.SUBKEY}}
 ```
 
 String splitting is still supported and remember that for simple cases, you have

--- a/testdata/vars/any/Taskfile.yml
+++ b/testdata/vars/any/Taskfile.yml
@@ -9,6 +9,8 @@ tasks:
     - task: string-array
     - task: for-string
     - task: for-int
+    - task: for-map
+    - task: for-multi-layer-map
 
   dynamic:
     vars:
@@ -78,3 +80,27 @@ tasks:
           var: LIST
         cmd: echo {{add .ITEM 100}}
 
+  for-map:
+    vars:
+      MAP:
+        KEY_1: value_1
+        KEY_2: value_2
+        KEY_3: value_3
+    cmds:
+      - for:
+          var: MAP
+        cmd: echo {{.ITEM}}
+
+  for-multi-layer-map:
+    vars:
+      MAP:
+        KEY_1:
+          SUBKEY: sub_value_1
+        KEY_2:
+          SUBKEY: sub_value_2
+        KEY_3:
+          SUBKEY: sub_value_3
+    cmds:
+      - for:
+          var: MAP
+        cmd: echo {{.ITEM.SUBKEY}}

--- a/testdata/vars/any/Taskfile.yml
+++ b/testdata/vars/any/Taskfile.yml
@@ -89,7 +89,7 @@ tasks:
     cmds:
       - for:
           var: MAP
-        cmd: echo {{.ITEM}}
+        cmd: echo {{.KEY}} {{.ITEM}}
 
   for-multi-layer-map:
     vars:
@@ -103,4 +103,4 @@ tasks:
     cmds:
       - for:
           var: MAP
-        cmd: echo {{.ITEM.SUBKEY}}
+        cmd: echo {{.KEY}} {{.ITEM.SUBKEY}}

--- a/variables.go
+++ b/variables.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/joho/godotenv"
+	"golang.org/x/exp/maps"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/execext"
@@ -170,10 +171,7 @@ func (e *Executor) compiledTask(call taskfile.Call, evaluateShVars bool) (*taskf
 							case []any:
 								list = value
 							case map[string]any:
-								return &taskfile.Task{}, errors.TaskfileInvalidError{
-									URI: origTask.Location.Taskfile,
-									Err: errors.New("sh is not supported with the 'Any Variables' experiment enabled.\nSee https://taskfile.dev/experiments/any-variables for more information."),
-								}
+								list = maps.Values(value)
 							default:
 								return nil, errors.TaskfileInvalidError{
 									URI: origTask.Location.Taskfile,


### PR DESCRIPTION
Adds support for looping over a map-type variable using the `for` syntax. Since Go maps are unordered, the order of the loop will be random.

This also fixes a bug where specifying a map variable when looping over a variable would give an invalid error about using `sh` with the Any Variables experiment.