### PR TITLE
feat: added basic merge template function

### DIFF
--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -646,9 +646,9 @@ tasks:
 compare the checksum of the source files to determine if it's necessary to run
 the task. If not, it will just print a message like `Task "js" is up to date`.
 
-`exclude:` can also be used to exclude files from fingerprinting.
-Sources are evaluated in order, so `exclude:` must come after the positive
-glob it is negating.
+`exclude:` can also be used to exclude files from fingerprinting. Sources are
+evaluated in order, so `exclude:` must come after the positive glob it is
+negating.
 
 ```yaml
 version: '3'
@@ -1291,6 +1291,9 @@ Task also adds the following functions:
 - `relPath`: Converts an absolute path (second argument) into a relative path,
   based on a base path (first argument). The same as Go's
   [filepath.Rel](https://pkg.go.dev/path/filepath#Rel).
+- `merge`: Creates a new map that is a copy of the first map with the keys of
+  the second map merged into it. If there are duplicate keys, the value of the
+  second map is used.
 - `spew`: Returns the Go representation of a specific variable. Useful for
   debugging. Uses the [davecgh/go-spew](https://github.com/davecgh/go-spew)
   package.
@@ -1489,8 +1492,8 @@ task: "This is a dangerous command... Do you want to continue?" [y/N]
 ```
 
 Warning prompts are called before executing a task. If a prompt is denied Task
-will exit with [exit code](/api#exit-codes) 205. If approved, Task
-will continue as normal.
+will exit with [exit code](/api#exit-codes) 205. If approved, Task will continue
+as normal.
 
 ```bash
 ❯ task example
@@ -1844,7 +1847,7 @@ tasks:
     sources:
       - '**/*.go'
     cmds:
-      - go build  # ...
+      - go build # ...
 ```
 
 :::info

--- a/internal/templater/funcs.go
+++ b/internal/templater/funcs.go
@@ -6,10 +6,9 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/davecgh/go-spew/spew"
 	"mvdan.cc/sh/v3/shell"
 	"mvdan.cc/sh/v3/syntax"
-
-	"github.com/davecgh/go-spew/spew"
 
 	sprig "github.com/go-task/slim-sprig/v3"
 )
@@ -53,6 +52,16 @@ func init() {
 		},
 		"relPath": func(basePath, targetPath string) (string, error) {
 			return filepath.Rel(basePath, targetPath)
+		},
+		"merge": func(a, b map[string]any) map[string]any {
+			m := make(map[string]any, len(a)+len(b))
+			for k, v := range a {
+				m[k] = v
+			}
+			for k, v := range b {
+				m[k] = v
+			}
+			return m
 		},
 		"spew": func(v any) string {
 			return spew.Sdump(v)

--- a/testdata/vars/any/Taskfile.yml
+++ b/testdata/vars/any/Taskfile.yml
@@ -7,6 +7,7 @@ tasks:
     - task: bool
     - task: int
     - task: string-array
+    - task: map
     - task: for-string
     - task: for-int
     - task: for-map


### PR DESCRIPTION
Adds a very basic `merge` template function that will iterate over maps A and B and put all their elements into a new map M. Map B will overwrite map A if a key conflicts. The new map M is returned leaving the original maps unchanged.

Not sure where functions like this should be documented as we seem to have 3 sources for template functions:

- Go templating itself
- Slim Sprig
- Task