### PR TITLE
feat: add ability to disable dynamic variable caching

### DIFF
--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -646,9 +646,9 @@ tasks:
 compare the checksum of the source files to determine if it's necessary to run
 the task. If not, it will just print a message like `Task "js" is up to date`.
 
-`exclude:` can also be used to exclude files from fingerprinting.
-Sources are evaluated in order, so `exclude:` must come after the positive
-glob it is negating.
+`exclude:` can also be used to exclude files from fingerprinting. Sources are
+evaluated in order, so `exclude:` must come after the positive glob it is
+negating.
 
 ```yaml
 version: '3'
@@ -1014,6 +1014,59 @@ tasks:
 ```
 
 This works for all types of variables.
+
+### Dynamic variable caching
+
+By default, the output of dynamic variables is cached. This means that running
+the same command multiple times in the same task, will always give the same
+output:
+
+```yaml
+version: 3
+
+tasks:
+  test:
+    silent: true
+    vars:
+      FOO:
+        sh: mktemp
+      BAR:
+        sh: mktemp
+    cmds:
+      - echo {{ .FOO }}
+      - echo {{ .BAR }}
+```
+
+```txt
+/tmp/tmp.7qbwR3WxBc
+/tmp/tmp.7qbwR3WxBc
+```
+
+If you want to stop the result of a dynamic variable being cached, you can set
+the `cache` key to `false`:
+
+```yaml
+version: 3
+
+tasks:
+  test:
+    silent: true
+    vars:
+      FOO:
+        sh: mktemp
+        cache: false
+      BAR:
+        sh: mktemp
+        cache: false
+    cmds:
+      - echo {{ .FOO }}
+      - echo {{ .BAR }}
+```
+
+```txt
+/tmp/tmp.vGKqfv8fm7
+/tmp/tmp.4Jtfmihw58
+```
 
 ## Looping over values
 
@@ -1481,8 +1534,8 @@ task: "This is a dangerous command... Do you want to continue?" [y/N]
 ```
 
 Warning prompts are called before executing a task. If a prompt is denied Task
-will exit with [exit code](/api#exit-codes) 205. If approved, Task
-will continue as normal.
+will exit with [exit code](/api#exit-codes) 205. If approved, Task will continue
+as normal.
 
 ```bash
 ❯ task example
@@ -1836,7 +1889,7 @@ tasks:
     sources:
       - '**/*.go'
     cmds:
-      - go build  # ...
+      - go build # ...
 ```
 
 :::info

--- a/internal/templater/templater.go
+++ b/internal/templater/templater.go
@@ -110,14 +110,13 @@ func (r *Templater) replaceVars(vars *taskfile.Vars, extra map[string]any) *task
 
 	var newVars taskfile.Vars
 	_ = vars.Range(func(k string, v taskfile.Var) error {
-		var newVar taskfile.Var
+		newVar := v.DeepCopy()
 		switch value := v.Value.(type) {
 		case string:
 			newVar.Value = r.ReplaceWithExtra(value, extra)
 		}
-		newVar.Live = v.Live
 		newVar.Sh = r.ReplaceWithExtra(v.Sh, extra)
-		newVars.Set(k, newVar)
+		newVars.Set(k, *newVar)
 		return nil
 	})
 

--- a/task_test.go
+++ b/task_test.go
@@ -2327,3 +2327,35 @@ func TestFor(t *testing.T) {
 		})
 	}
 }
+
+func TestDynamicVarWithCache(t *testing.T) {
+	const dir = "testdata/dynamic_var"
+	var buff bytes.Buffer
+	e := task.Executor{
+		Dir:    dir,
+		Stdout: &buff,
+		Stderr: &buff,
+		Silent: true,
+	}
+	require.NoError(t, e.Setup())
+	require.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "with-cache"}))
+	results := strings.Split(strings.TrimSpace(buff.String()), "\n")
+	assert.Len(t, results, 2)
+	assert.Equal(t, results[0], results[1])
+}
+
+func TestDynamicVarWithoutCache(t *testing.T) {
+	const dir = "testdata/dynamic_var"
+	var buff bytes.Buffer
+	e := task.Executor{
+		Dir:    dir,
+		Stdout: &buff,
+		Stderr: &buff,
+		Silent: true,
+	}
+	require.NoError(t, e.Setup())
+	require.NoError(t, e.Run(context.Background(), taskfile.Call{Task: "without-cache"}))
+	results := strings.Split(strings.TrimSpace(buff.String()), "\n")
+	assert.Len(t, results, 2)
+	assert.NotEqual(t, results[0], results[1])
+}

--- a/taskfile/var.go
+++ b/taskfile/var.go
@@ -77,6 +77,7 @@ type Var struct {
 	Live  any
 	Sh    string
 	Dir   string
+	Cache bool
 }
 
 func (v *Var) UnmarshalYAML(node *yaml.Node) error {
@@ -108,14 +109,35 @@ func (v *Var) UnmarshalYAML(node *yaml.Node) error {
 
 	case yaml.MappingNode:
 		var sh struct {
-			Sh string
+			Sh    string
+			Cache *bool
 		}
 		if err := node.Decode(&sh); err != nil {
 			return err
+		}
+		if sh.Cache != nil {
+			v.Cache = *sh.Cache
+		} else {
+			v.Cache = true
 		}
 		v.Sh = sh.Sh
 		return nil
 	}
 
 	return fmt.Errorf("yaml: line %d: cannot unmarshal %s into variable", node.Line, node.ShortTag())
+}
+
+// DeepCopy creates a new instance of Var and copies
+// data by value from the source struct.
+func (vs *Var) DeepCopy() *Var {
+	if vs == nil {
+		return nil
+	}
+	return &Var{
+		Value: vs.Value,
+		Live:  vs.Live,
+		Sh:    vs.Sh,
+		Dir:   vs.Dir,
+		Cache: vs.Cache,
+	}
 }

--- a/testdata/dynamic_var/Taskfile.yml
+++ b/testdata/dynamic_var/Taskfile.yml
@@ -1,0 +1,26 @@
+version: 3
+
+tasks:
+  with-cache:
+    silent: true
+    vars:
+      FOO:
+        sh: mktemp
+      BAR:
+        sh: mktemp
+    cmds:
+      - echo {{ .FOO }}
+      - echo {{ .BAR }}
+
+  without-cache:
+    silent: true
+    vars:
+      FOO:
+        sh: mktemp
+        cache: false
+      BAR:
+        sh: mktemp
+        cache: false
+    cmds:
+      - echo {{ .FOO }}
+      - echo {{ .BAR }}


### PR DESCRIPTION
See [comment on discord](https://discord.com/channels/974121106208354339/974121514184085555/1190097443732328588) copied below:

> I came across something strange. 
> ```yml
> test:
>   cmds:
>     - echo {{ .FILE }} == {{ .TEMPFILE }}
>   vars:
>     FILE:
>       sh: mktemp
>     TEMPFILE:
>       sh: mktemp
> ```
> ```
> > task test
> task: [test] echo /var/folders/6s/2k2vd19s7kg20405_blbh7fm0000gn/T/tmp.705g66B7Ku == /var/folders/6s/2k2vd19s7kg20405_blbh7fm0000gn/T/tmp.705g66B7Ku
> /var/folders/6s/2k2vd19s7kg20405_blbh7fm0000gn/T/tmp.705g66B7Ku == /var/folders/6s/2k2vd19s7kg20405_blbh7fm0000gn/T/tmp.705g66B7Ku
> ```
>
> Why FILE and TEMPFILE has the same value?

This is happening because of Task's dynamic variable cache. We should add the ability to disable this on a per-variable basis:

```yml
  without-cache:
    silent: true
    vars:
      FOO:
        sh: mktemp
        cache: false
      BAR:
        sh: mktemp
        cache: false
    cmds:
      - echo {{ .FOO }}
      - echo {{ .BAR }}
```
```
/tmp/tmp.vGKqfv8fm7
/tmp/tmp.4Jtfmihw58
```
