### PR TITLE
feat: add spew function to templater

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
+	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.16.0
 	github.com/go-task/slim-sprig/v3 v3.0.0
 	github.com/joho/godotenv v1.5.1
@@ -22,7 +23,6 @@ require (
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/internal/templater/funcs.go
+++ b/internal/templater/funcs.go
@@ -9,6 +9,8 @@ import (
 	"mvdan.cc/sh/v3/shell"
 	"mvdan.cc/sh/v3/syntax"
 
+	"github.com/davecgh/go-spew/spew"
+
 	sprig "github.com/go-task/slim-sprig/v3"
 )
 
@@ -51,6 +53,9 @@ func init() {
 		},
 		"relPath": func(basePath, targetPath string) (string, error) {
 			return filepath.Rel(basePath, targetPath)
+		},
+		"spew": func(v any) string {
+			return spew.Sdump(v)
 		},
 	}
 	// Deprecated aliases for renamed functions.


### PR DESCRIPTION
Adds the spew function to templater which lets you print the details of a variable. This is really useful for debugging now that we have multiple variable types.