### PR TITLE
feat: invert call.Direct

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -13,7 +13,7 @@ func Parse(args ...string) ([]ast.Call, *ast.Vars) {
 
 	for _, arg := range args {
 		if !strings.Contains(arg, "=") {
-			calls = append(calls, ast.Call{Task: arg, Direct: true})
+			calls = append(calls, ast.Call{Task: arg})
 			continue
 		}
 

--- a/args/args_test.go
+++ b/args/args_test.go
@@ -20,17 +20,17 @@ func TestArgs(t *testing.T) {
 		{
 			Args: []string{"task-a", "task-b", "task-c"},
 			ExpectedCalls: []ast.Call{
-				{Task: "task-a", Direct: true},
-				{Task: "task-b", Direct: true},
-				{Task: "task-c", Direct: true},
+				{Task: "task-a"},
+				{Task: "task-b"},
+				{Task: "task-c"},
 			},
 		},
 		{
 			Args: []string{"task-a", "FOO=bar", "task-b", "task-c", "BAR=baz", "BAZ=foo"},
 			ExpectedCalls: []ast.Call{
-				{Task: "task-a", Direct: true},
-				{Task: "task-b", Direct: true},
-				{Task: "task-c", Direct: true},
+				{Task: "task-a"},
+				{Task: "task-b"},
+				{Task: "task-c"},
 			},
 			ExpectedGlobals: &ast.Vars{
 				OrderedMap: orderedmap.FromMapWithOrder(
@@ -46,7 +46,7 @@ func TestArgs(t *testing.T) {
 		{
 			Args: []string{"task-a", "CONTENT=with some spaces"},
 			ExpectedCalls: []ast.Call{
-				{Task: "task-a", Direct: true},
+				{Task: "task-a"},
 			},
 			ExpectedGlobals: &ast.Vars{
 				OrderedMap: orderedmap.FromMapWithOrder(
@@ -60,8 +60,8 @@ func TestArgs(t *testing.T) {
 		{
 			Args: []string{"FOO=bar", "task-a", "task-b"},
 			ExpectedCalls: []ast.Call{
-				{Task: "task-a", Direct: true},
-				{Task: "task-b", Direct: true},
+				{Task: "task-a"},
+				{Task: "task-b"},
 			},
 			ExpectedGlobals: &ast.Vars{
 				OrderedMap: orderedmap.FromMapWithOrder(

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -304,7 +304,7 @@ func run() error {
 
 	// If there are no calls, run the default task instead
 	if len(calls) == 0 {
-		calls = append(calls, ast.Call{Task: "default", Direct: true})
+		calls = append(calls, ast.Call{Task: "default"})
 	}
 
 	globals.Set("CLI_ARGS", ast.Var{Value: cliArgs})

--- a/task.go
+++ b/task.go
@@ -199,7 +199,7 @@ func (e *Executor) RunTask(ctx context.Context, call ast.Call) error {
 			return err
 		}
 
-		skipFingerprinting := e.ForceAll || (call.Direct && e.Force)
+		skipFingerprinting := e.ForceAll || (!call.Indirect && e.Force)
 		if !skipFingerprinting {
 			if err := ctx.Err(); err != nil {
 				return err
@@ -258,7 +258,7 @@ func (e *Executor) RunTask(ctx context.Context, call ast.Call) error {
 					continue
 				}
 
-				if !call.Direct {
+				if call.Indirect {
 					return err
 				}
 
@@ -296,7 +296,7 @@ func (e *Executor) runDeps(ctx context.Context, t *ast.Task) error {
 	for _, d := range t.Deps {
 		d := d
 		g.Go(func() error {
-			err := e.RunTask(ctx, ast.Call{Task: d.Task, Vars: d.Vars, Silent: d.Silent})
+			err := e.RunTask(ctx, ast.Call{Task: d.Task, Vars: d.Vars, Silent: d.Silent, Indirect: true})
 			if err != nil {
 				return err
 			}
@@ -324,7 +324,7 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call ast.Call, i
 		reacquire := e.releaseConcurrencyLimit()
 		defer reacquire()
 
-		err := e.RunTask(ctx, ast.Call{Task: cmd.Task, Vars: cmd.Vars, Silent: cmd.Silent})
+		err := e.RunTask(ctx, ast.Call{Task: cmd.Task, Vars: cmd.Vars, Silent: cmd.Silent, Indirect: true})
 		if err != nil {
 			return err
 		}

--- a/task_test.go
+++ b/task_test.go
@@ -1789,7 +1789,7 @@ func TestErrorCode(t *testing.T) {
 			}
 			require.NoError(t, e.Setup())
 
-			err := e.Run(context.Background(), ast.Call{Task: test.task, Direct: true})
+			err := e.Run(context.Background(), ast.Call{Task: test.task})
 			require.Error(t, err)
 			taskRunErr, ok := err.(*errors.TaskRunError)
 			assert.True(t, ok, "cannot cast returned error to *task.TaskRunError")
@@ -2183,7 +2183,7 @@ func TestForce(t *testing.T) {
 				ForceAll: tt.forceAll,
 			}
 			require.NoError(t, e.Setup())
-			require.NoError(t, e.Run(context.Background(), ast.Call{Task: "task-with-dep", Direct: true}))
+			require.NoError(t, e.Run(context.Background(), ast.Call{Task: "task-with-dep"}))
 		})
 	}
 }
@@ -2238,7 +2238,7 @@ func TestFor(t *testing.T) {
 				Force:  true,
 			}
 			require.NoError(t, e.Setup())
-			require.NoError(t, e.Run(context.Background(), ast.Call{Task: test.name, Direct: true}))
+			require.NoError(t, e.Run(context.Background(), ast.Call{Task: test.name}))
 			assert.Equal(t, test.expectedOutput, buff.String())
 		})
 	}

--- a/taskfile/ast/call.go
+++ b/taskfile/ast/call.go
@@ -2,8 +2,8 @@ package ast
 
 // Call is the parameters to a task call
 type Call struct {
-	Task   string
-	Vars   *Vars
-	Silent bool
-	Direct bool // Was the task called directly or via another task?
+	Task     string
+	Vars     *Vars
+	Silent   bool
+	Indirect bool // True if the task was called by another task
 }


### PR DESCRIPTION
The API for `taskfile/ast.Call.Direct` isn't great when using Task as a Go package. Creating a task as if it were being called from the CLI means you have to write something like this:

```go
call := ast.Call{Task: "default", Direct: true}
```

I can't think of many situations where you would want to set `Direct: false` from an API as this mainly intended for internal use when parsing a `ast.Cmd` or `ast.Dep`. Additionally, it's easy to forget to add `Direct: true` and omitting it is probably not the behaviour you want.

If we invert the property name from `Direct` to `Indirect`, the default value becomes `false` and so when calling a task with the API you would simply need to do:

```go
call := ast.Call{Task: "default"}
```