### PR TITLE
Remove unused problematic method

### DIFF
--- a/internal/orderedmap/orderedmap.go
+++ b/internal/orderedmap/orderedmap.go
@@ -89,11 +89,6 @@ func (om *OrderedMap[K, V]) Sort() {
 	slices.Sort(om.s)
 }
 
-// SortFunc will sort the map using the given function.
-func (om *OrderedMap[K, V]) SortFunc(less func(i, j K) bool) {
-	slices.SortFunc(om.s, less)
-}
-
 // Keys will return a slice of the map's keys in order.
 func (om *OrderedMap[K, V]) Keys() []K {
 	return om.s

--- a/internal/orderedmap/orderedmap_test.go
+++ b/internal/orderedmap/orderedmap_test.go
@@ -37,17 +37,6 @@ func TestSort(t *testing.T) {
 	assert.Equal(t, []int{1, 2, 3}, om.s)
 }
 
-func TestSortFunc(t *testing.T) {
-	om := New[int, string]()
-	om.Set(3, "three")
-	om.Set(1, "one")
-	om.Set(2, "two")
-	om.SortFunc(func(i, j int) bool {
-		return i > j
-	})
-	assert.Equal(t, []int{3, 2, 1}, om.s)
-}
-
 func TestKeysValues(t *testing.T) {
 	om := New[int, string]()
 	om.Set(3, "three")


### PR DESCRIPTION
When the [tools.go](https://go.dev/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module) way of managing dependencies is used, there are occasional problems with incompatible transitive dependencies. Currently, Task suffers from one.

https://github.com/golang/go/issues/61374 changed the signature of the `slices.SortFunc` function to make it compatible with Go 1.21. Currently, Task uses the old version. That makes it impossible to use Task and another tool that uses a newer version of `golang.org/x/exp/slices` in the same `tools.go` file.

Given that `OrderedMap.SortFunc` is not used anywhere, I propose just to remove it. This way, Task can be used with the latest version of `golang.org/x/exp/slices` and with the one currently specified in Task's `go.mod` file.