### PR TITLE
feat: version checks

### DIFF
--- a/docs/static/schema.json
+++ b/docs/static/schema.json
@@ -531,14 +531,14 @@
       "properties": {
         "version": {
           "description": "Specify the Taskfile format that this file conforms to.",
-          "anyOf": [
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^(0|[1-9]\\d*)(?:\\.(0|[1-9]\\d*))?(?:\\.(0|[1-9]\\d*))?(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+            },
             {
               "type": "number",
               "enum": [3]
-            },
-            {
-              "type": "string",
-              "enum": ["3"]
             }
           ]
         },

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -17,7 +17,7 @@ const (
 	CodeTaskfileNotTrusted
 	CodeTaskfileNotSecure
 	CodeTaskfileCacheNotFound
-	CodeTaskfileVersionNotDefined
+	CodeTaskfileVersionCheckError
 	CodeTaskfileNetworkTimeout
 )
 

--- a/errors/errors_taskfile.go
+++ b/errors/errors_taskfile.go
@@ -107,20 +107,20 @@ func (err *TaskfileNotSecureError) Code() int {
 	return CodeTaskfileNotSecure
 }
 
-// TaskfileCacheNotFound is returned when the user attempts to use an offline
+// TaskfileCacheNotFoundError is returned when the user attempts to use an offline
 // (cached) Taskfile but the files does not exist in the cache.
-type TaskfileCacheNotFound struct {
+type TaskfileCacheNotFoundError struct {
 	URI string
 }
 
-func (err *TaskfileCacheNotFound) Error() string {
+func (err *TaskfileCacheNotFoundError) Error() string {
 	return fmt.Sprintf(
 		`task: Taskfile %q was not found in the cache. Remove the --offline flag to use a remote copy or download it using the --download flag`,
 		err.URI,
 	)
 }
 
-func (err *TaskfileCacheNotFound) Code() int {
+func (err *TaskfileCacheNotFoundError) Code() int {
 	return CodeTaskfileCacheNotFound
 }
 
@@ -152,15 +152,15 @@ func (err *TaskfileVersionCheckError) Code() int {
 	return CodeTaskfileVersionCheckError
 }
 
-// TaskfileNetworkTimeout is returned when the user attempts to use a remote
+// TaskfileNetworkTimeoutError is returned when the user attempts to use a remote
 // Taskfile but a network connection could not be established within the timeout.
-type TaskfileNetworkTimeout struct {
+type TaskfileNetworkTimeoutError struct {
 	URI          string
 	Timeout      time.Duration
 	CheckedCache bool
 }
 
-func (err *TaskfileNetworkTimeout) Error() string {
+func (err *TaskfileNetworkTimeoutError) Error() string {
 	var cacheText string
 	if err.CheckedCache {
 		cacheText = " and no offline copy was found in the cache"
@@ -171,6 +171,6 @@ func (err *TaskfileNetworkTimeout) Error() string {
 	)
 }
 
-func (err *TaskfileNetworkTimeout) Code() int {
+func (err *TaskfileNetworkTimeoutError) Code() int {
 	return CodeTaskfileNetworkTimeout
 }

--- a/task_test.go
+++ b/task_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"testing"
@@ -1421,7 +1422,7 @@ func TestDisplaysErrorOnVersion1Schema(t *testing.T) {
 	}
 	err := e.Setup()
 	require.Error(t, err)
-	assert.Equal(t, "task: Taskfile schemas prior to v3 are no longer supported", err.Error())
+	assert.Regexp(t, regexp.MustCompile(`task: Invalid schema version in Taskfile \".*testdata\/version\/v1\/Taskfile\.yml\":\nSchema version \(1\.0\.0\) no longer supported\. Please use v3 or above`), err.Error())
 }
 
 func TestDisplaysErrorOnVersion2Schema(t *testing.T) {
@@ -1433,7 +1434,7 @@ func TestDisplaysErrorOnVersion2Schema(t *testing.T) {
 	}
 	err := e.Setup()
 	require.Error(t, err)
-	assert.Equal(t, "task: Taskfile schemas prior to v3 are no longer supported", err.Error())
+	assert.Regexp(t, regexp.MustCompile(`task: Invalid schema version in Taskfile \".*testdata\/version\/v2\/Taskfile\.yml\":\nSchema version \(2\.0\.0\) no longer supported\. Please use v3 or above`), err.Error())
 }
 
 func TestShortTaskNotation(t *testing.T) {

--- a/taskfile/ast/taskfile.go
+++ b/taskfile/ast/taskfile.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"gopkg.in/yaml.v3"
-
-	"github.com/go-task/task/v3/errors"
 )
 
 var V3 = semver.MustParse("3")
@@ -64,9 +62,6 @@ func (tf *Taskfile) UnmarshalYAML(node *yaml.Node) error {
 		tf.Dotenv = taskfile.Dotenv
 		tf.Run = taskfile.Run
 		tf.Interval = taskfile.Interval
-		if tf.Version == nil {
-			return errors.New("task: 'version' is required")
-		}
 		if tf.Vars == nil {
 			tf.Vars = &Vars{}
 		}

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -45,7 +45,7 @@ func Read(
 
 		// Check that the Taskfile is set and has a schema version
 		if t == nil || t.Version == nil {
-			return nil, &errors.TaskfileVersionNotDefined{URI: node.Location()}
+			return nil, &errors.TaskfileVersionCheckError{URI: node.Location()}
 		}
 
 		// Annotate any included Taskfile reference with a base directory for resolving relative paths

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -189,7 +189,7 @@ func readTaskfile(
 	// If the file is remote and we're in offline mode, check if we have a cached copy
 	if node.Remote() && offline {
 		if b, err = cache.read(node); errors.Is(err, os.ErrNotExist) {
-			return nil, &errors.TaskfileCacheNotFound{URI: node.Location()}
+			return nil, &errors.TaskfileCacheNotFoundError{URI: node.Location()}
 		} else if err != nil {
 			return nil, err
 		}
@@ -207,11 +207,11 @@ func readTaskfile(
 		if node.Remote() && errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			// If a download was requested, then we can't use a cached copy
 			if download {
-				return nil, &errors.TaskfileNetworkTimeout{URI: node.Location(), Timeout: timeout}
+				return nil, &errors.TaskfileNetworkTimeoutError{URI: node.Location(), Timeout: timeout}
 			}
 			// Search for any cached copies
 			if b, err = cache.read(node); errors.Is(err, os.ErrNotExist) {
-				return nil, &errors.TaskfileNetworkTimeout{URI: node.Location(), Timeout: timeout, CheckedCache: true}
+				return nil, &errors.TaskfileNetworkTimeoutError{URI: node.Location(), Timeout: timeout, CheckedCache: true}
 			} else if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
- feat: version checks
- refactor: consistent naming for errors
- feat: update schema to accept semver strings

Task's current version checking is a bit out of date and unused. It's a lot of work for us to maintain a list of features and which schema versions they work in, but it's quite trivial to let a user specify a minimum version of task as their schema version and then error if the version of the binary is lower.

This PR extends the existing `TaskfileVersionNotDefined` error (exit code 107) and renames it to the more generic `TaskfileVersionCheckError`. This error is then used whenever we come across a problem with schema/binary versions. In this PR, this happens in 3 places:

1. When reading a Taskfile, if the `version` key is not provided:

```
task: Missing schema version in Taskfile "/path/to/Taskfile.yml"
```

2. In `doVersionChecks`, if the `version` key is less than v3:

```
task: Invalid schema version in Taskfile "/path/to/Taskfile.yml":
Schema version (2.0.0) no longer supported. Please use v3 or above
```

3. In `doVersionChecks`, if the `version` key is greater than the installed version of Task

```
task: Invalid schema version in Taskfile "/path/to/Taskfile.yml":
Schema version (4.0.0) is greater than the current version of Task (3.33.0)
```
