### PR TITLE
fix(completions): support lowercase filename for Taskfile

### DIFF
--- a/completion/zsh/_task
+++ b/completion/zsh/_task
@@ -18,7 +18,7 @@ function __task_list() {
         enabled=1
         cmd+=(--taskfile "$taskfile")
     else
-        for taskfile in Taskfile{,.dist}.{yaml,yml}; do
+        for taskfile in {T,t}askfile{,.dist}.{yaml,yml}; do
             if [[ -f "$taskfile" ]]; then
                 enabled=1
                 break


### PR DESCRIPTION
Allow Taskfiles starting with lowercase characters in zsh completion since it is supported since v3.27.0 - 2023-06-29