### PR TITLE
feat: wildcard matching for task names

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -7,13 +7,13 @@ import (
 )
 
 // Parse parses command line argument: tasks and global variables
-func Parse(args ...string) ([]ast.Call, *ast.Vars) {
-	calls := []ast.Call{}
+func Parse(args ...string) ([]*ast.Call, *ast.Vars) {
+	calls := []*ast.Call{}
 	globals := &ast.Vars{}
 
 	for _, arg := range args {
 		if !strings.Contains(arg, "=") {
-			calls = append(calls, ast.Call{Task: arg})
+			calls = append(calls, &ast.Call{Task: arg})
 			continue
 		}
 

--- a/args/args_test.go
+++ b/args/args_test.go
@@ -14,12 +14,12 @@ import (
 func TestArgs(t *testing.T) {
 	tests := []struct {
 		Args            []string
-		ExpectedCalls   []ast.Call
+		ExpectedCalls   []*ast.Call
 		ExpectedGlobals *ast.Vars
 	}{
 		{
 			Args: []string{"task-a", "task-b", "task-c"},
-			ExpectedCalls: []ast.Call{
+			ExpectedCalls: []*ast.Call{
 				{Task: "task-a"},
 				{Task: "task-b"},
 				{Task: "task-c"},
@@ -27,7 +27,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			Args: []string{"task-a", "FOO=bar", "task-b", "task-c", "BAR=baz", "BAZ=foo"},
-			ExpectedCalls: []ast.Call{
+			ExpectedCalls: []*ast.Call{
 				{Task: "task-a"},
 				{Task: "task-b"},
 				{Task: "task-c"},
@@ -45,7 +45,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			Args: []string{"task-a", "CONTENT=with some spaces"},
-			ExpectedCalls: []ast.Call{
+			ExpectedCalls: []*ast.Call{
 				{Task: "task-a"},
 			},
 			ExpectedGlobals: &ast.Vars{
@@ -59,7 +59,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			Args: []string{"FOO=bar", "task-a", "task-b"},
-			ExpectedCalls: []ast.Call{
+			ExpectedCalls: []*ast.Call{
 				{Task: "task-a"},
 				{Task: "task-b"},
 			},
@@ -74,15 +74,15 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			Args:          nil,
-			ExpectedCalls: []ast.Call{},
+			ExpectedCalls: []*ast.Call{},
 		},
 		{
 			Args:          []string{},
-			ExpectedCalls: []ast.Call{},
+			ExpectedCalls: []*ast.Call{},
 		},
 		{
 			Args:          []string{"FOO=bar", "BAR=baz"},
-			ExpectedCalls: []ast.Call{},
+			ExpectedCalls: []*ast.Call{},
 			ExpectedGlobals: &ast.Vars{
 				OrderedMap: omap.FromMapWithOrder(
 					map[string]ast.Var{

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -291,7 +291,7 @@ func run() error {
 	}
 
 	var (
-		calls   []ast.Call
+		calls   []*ast.Call
 		globals *ast.Vars
 	)
 
@@ -304,7 +304,7 @@ func run() error {
 
 	// If there are no calls, run the default task instead
 	if len(calls) == 0 {
-		calls = append(calls, ast.Call{Task: "default"})
+		calls = append(calls, &ast.Call{Task: "default"})
 	}
 
 	globals.Set("CLI_ARGS", ast.Var{Value: cliArgs})

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -1249,8 +1249,8 @@ $ task run-foo-bar
 foo bar
 ```
 
-If multiple matching tasks are found, the first one listed in the Taskfile will
-be used. If you are using included Taskfiles,
+If multiple matching tasks are found, an error occurs. If you are using included
+Taskfiles, tasks in parent files will be considered first.
 
 ## Doing task cleanup with `defer`
 

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -1205,6 +1205,53 @@ tasks:
       - yarn {{.CLI_ARGS}}
 ```
 
+## Wildcard arguments
+
+Another way to parse arguments into a task is to use a wildcard in your task's
+name. Wildcards are denoted by an asterisk (`*`) and can be used multiple times
+in a task's name to pass in multiple arguments.
+
+Matching arguments will be captured and stored in the `.MATCH` variable and can
+then be used in your task's commands like any other variable. This variable is
+an array of strings and so will need to be indexed to access the individual
+arguments. We suggest creating a named variable for each argument to make it
+clear what they contain:
+
+```yaml
+version: '3'
+
+tasks:
+  echo-*:
+    vars:
+      TEXT: '{{index .MATCH 0}}'
+    cmds:
+      - echo {{.TEXT}}
+
+  run-*-*:
+    vars:
+      ARG_1: '{{index .MATCH 0}}'
+      ARG_2: '{{index .MATCH 1}}'
+    cmds:
+      - echo {{.ARG_1}} {{.ARG_2}}
+```
+
+```shell
+# This call matches the "echo-*" task and the string "hello" is captured by the
+# wildcard and stored in the .MATCH variable. We then index the .MATCH array and
+# store the result in the .TEXT variable which is then echoed out in the cmds.
+$ task echo-hello
+hello
+# You can use whitespace in your arguments as long as you quote the task name
+$ task "echo-hello world"
+hello world
+# And you can pass multiple arguments
+$ task run-foo-bar
+foo bar
+```
+
+If multiple matching tasks are found, the first one listed in the Taskfile will
+be used. If you are using included Taskfiles,
+
 ## Doing task cleanup with `defer`
 
 With the `defer` keyword, it's possible to schedule cleanup to be run once the

--- a/errors/errors_task.go
+++ b/errors/errors_task.go
@@ -65,15 +65,15 @@ func (err *TaskInternalError) Code() int {
 	return CodeTaskInternal
 }
 
-// TaskNameConflictError is returned when multiple tasks with the same name or
+// TaskNameConflictError is returned when multiple tasks with a matching name or
 // alias are found.
 type TaskNameConflictError struct {
-	AliasName string
+	Call      string
 	TaskNames []string
 }
 
 func (err *TaskNameConflictError) Error() string {
-	return fmt.Sprintf(`task: Multiple tasks (%s) with alias %q found`, strings.Join(err.TaskNames, ", "), err.AliasName)
+	return fmt.Sprintf(`task: Found multiple tasks (%s) that match %q`, strings.Join(err.TaskNames, ", "), err.Call)
 }
 
 func (err *TaskNameConflictError) Code() int {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -36,12 +36,12 @@ func (c *Compiler) GetTaskfileVariables() (*ast.Vars, error) {
 	return c.getVariables(nil, nil, true)
 }
 
-func (c *Compiler) GetVariables(t *ast.Task, call ast.Call) (*ast.Vars, error) {
-	return c.getVariables(t, &call, true)
+func (c *Compiler) GetVariables(t *ast.Task, call *ast.Call) (*ast.Vars, error) {
+	return c.getVariables(t, call, true)
 }
 
-func (c *Compiler) FastGetVariables(t *ast.Task, call ast.Call) (*ast.Vars, error) {
-	return c.getVariables(t, &call, false)
+func (c *Compiler) FastGetVariables(t *ast.Task, call *ast.Call) (*ast.Vars, error) {
+	return c.getVariables(t, call, false)
 }
 
 func (c *Compiler) getVariables(t *ast.Task, call *ast.Call, evaluateShVars bool) (*ast.Vars, error) {

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -10,7 +10,7 @@ import (
 func PrintTasks(l *logger.Logger, t *ast.Taskfile, c []*ast.Call) {
 	for i, call := range c {
 		PrintSpaceBetweenSummaries(l, i)
-		PrintTask(l, t.Tasks.Get(call))
+		PrintTask(l, t.Tasks.Get(call.Task))
 	}
 }
 

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -7,10 +7,10 @@ import (
 	"github.com/go-task/task/v3/taskfile/ast"
 )
 
-func PrintTasks(l *logger.Logger, t *ast.Taskfile, c []ast.Call) {
+func PrintTasks(l *logger.Logger, t *ast.Taskfile, c []*ast.Call) {
 	for i, call := range c {
 		PrintSpaceBetweenSummaries(l, i)
-		PrintTask(l, t.Tasks.Get(call.Task))
+		PrintTask(l, t.Tasks.Get(call))
 	}
 }
 

--- a/internal/summary/summary_test.go
+++ b/internal/summary/summary_test.go
@@ -163,7 +163,7 @@ func TestPrintAllWithSpaces(t *testing.T) {
 
 	summary.PrintTasks(&l,
 		&ast.Taskfile{Tasks: tasks},
-		[]ast.Call{{Task: "t1"}, {Task: "t2"}, {Task: "t3"}})
+		[]*ast.Call{{Task: "t1"}, {Task: "t2"}, {Task: "t3"}})
 
 	assert.True(t, strings.HasPrefix(buffer.String(), "task: t1"))
 	assert.Contains(t, buffer.String(), "\n(task does not have description or summary)\n\n\ntask: t2")

--- a/requires.go
+++ b/requires.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-task/task/v3/taskfile/ast"
 )
 
-func (e *Executor) areTaskRequiredVarsSet(ctx context.Context, t *ast.Task, call ast.Call) error {
+func (e *Executor) areTaskRequiredVarsSet(ctx context.Context, t *ast.Task, call *ast.Call) error {
 	if t.Requires == nil || len(t.Requires.Vars) == 0 {
 		return nil
 	}

--- a/status.go
+++ b/status.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Status returns an error if any the of given tasks is not up-to-date
-func (e *Executor) Status(ctx context.Context, calls ...ast.Call) error {
+func (e *Executor) Status(ctx context.Context, calls ...*ast.Call) error {
 	for _, call := range calls {
 
 		// Compile the task

--- a/task_test.go
+++ b/task_test.go
@@ -2249,3 +2249,52 @@ func TestFor(t *testing.T) {
 		})
 	}
 }
+
+func TestWildcard(t *testing.T) {
+	tests := []struct {
+		name           string
+		expectedOutput string
+		wantErr        bool
+	}{
+		{
+			name:           "wildcard-foo",
+			expectedOutput: "Hello foo\n",
+		},
+		{
+			name:           "foo-wildcard-bar",
+			expectedOutput: "Hello foo bar\n",
+		},
+		{
+			name:           "start-foo",
+			expectedOutput: "Starting foo\n",
+		},
+		{
+			name:           "matches-exactly-*",
+			expectedOutput: "I don't consume matches: \n",
+		},
+		{
+			name:    "no-match",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var buff bytes.Buffer
+			e := task.Executor{
+				Dir:    "testdata/wildcards",
+				Stdout: &buff,
+				Stderr: &buff,
+				Silent: true,
+				Force:  true,
+			}
+			require.NoError(t, e.Setup())
+			if test.wantErr {
+				require.Error(t, e.Run(context.Background(), &ast.Call{Task: test.name}))
+				return
+			}
+			require.NoError(t, e.Run(context.Background(), &ast.Call{Task: test.name}))
+			assert.Equal(t, test.expectedOutput, buff.String())
+		})
+	}
+}

--- a/task_test.go
+++ b/task_test.go
@@ -2253,33 +2253,44 @@ func TestFor(t *testing.T) {
 func TestWildcard(t *testing.T) {
 	tests := []struct {
 		name           string
+		call           string
 		expectedOutput string
 		wantErr        bool
 	}{
 		{
-			name:           "wildcard-foo",
+			name:           "basic wildcard",
+			call:           "wildcard-foo",
 			expectedOutput: "Hello foo\n",
 		},
 		{
-			name:           "foo-wildcard-bar",
+			name:           "double wildcard",
+			call:           "foo-wildcard-bar",
 			expectedOutput: "Hello foo bar\n",
 		},
 		{
-			name:           "start-foo",
+			name:           "store wildcard",
+			call:           "start-foo",
 			expectedOutput: "Starting foo\n",
 		},
 		{
-			name:           "matches-exactly-*",
-			expectedOutput: "I don't consume matches: \n",
+			name:           "matches exactly",
+			call:           "matches-exactly-*",
+			expectedOutput: "I don't consume matches: []\n",
 		},
 		{
-			name:    "no-match",
+			name:    "no matches",
+			call:    "no-match",
+			wantErr: true,
+		},
+		{
+			name:    "multiple matches",
+			call:    "wildcard-foo-bar",
 			wantErr: true,
 		},
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(test.call, func(t *testing.T) {
 			var buff bytes.Buffer
 			e := task.Executor{
 				Dir:    "testdata/wildcards",
@@ -2290,10 +2301,10 @@ func TestWildcard(t *testing.T) {
 			}
 			require.NoError(t, e.Setup())
 			if test.wantErr {
-				require.Error(t, e.Run(context.Background(), &ast.Call{Task: test.name}))
+				require.Error(t, e.Run(context.Background(), &ast.Call{Task: test.call}))
 				return
 			}
-			require.NoError(t, e.Run(context.Background(), &ast.Call{Task: test.name}))
+			require.NoError(t, e.Run(context.Background(), &ast.Call{Task: test.call}))
 			assert.Equal(t, test.expectedOutput, buff.String())
 		})
 	}

--- a/taskfile/ast/task.go
+++ b/taskfile/ast/task.go
@@ -2,6 +2,8 @@ package ast
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -49,6 +51,30 @@ func (t *Task) Name() string {
 		return t.Label
 	}
 	return t.Task
+}
+
+// WildcardMatch will check if the given string matches the name of the Task and returns any wildcard values.
+func (t *Task) WildcardMatch(name string) (bool, []string) {
+	// Convert the name into a regex string
+	regexStr := fmt.Sprintf("^%s$", strings.ReplaceAll(t.Task, "*", "(.*)"))
+	regex := regexp.MustCompile(regexStr)
+	wildcards := regex.FindStringSubmatch(name)
+	wildcardCount := strings.Count(t.Task, "*")
+
+	// If there are no wildcards, return false
+	if len(wildcards) == 0 {
+		return false, nil
+	}
+
+	// Remove the first match, which is the full string
+	wildcards = wildcards[1:]
+
+	// If there are more/less wildcards than matches, return false
+	if len(wildcards) != wildcardCount {
+		return false, wildcards
+	}
+
+	return true, wildcards
 }
 
 func (t *Task) UnmarshalYAML(node *yaml.Node) error {

--- a/taskfile/ast/tasks.go
+++ b/taskfile/ast/tasks.go
@@ -61,10 +61,11 @@ func (t1 *Tasks) Merge(t2 Tasks, include *Include) {
 	// run the included Taskfile's default task without specifying its full
 	// name. If the parent namespace has aliases, we add another alias for each
 	// of them.
-	if t2.Get("default") != nil && t1.Get(include.Namespace) == nil {
+	if t2.Get(&Call{Task: "default"}) != nil && t1.Get(&Call{Task: include.Namespace}) == nil {
 		defaultTaskName := fmt.Sprintf("%s:default", include.Namespace)
-		t1.Get(defaultTaskName).Aliases = append(t1.Get(defaultTaskName).Aliases, include.Namespace)
-		t1.Get(defaultTaskName).Aliases = append(t1.Get(defaultTaskName).Aliases, include.Aliases...)
+		defaultTaskCall := &Call{Task: defaultTaskName}
+		t1.Get(defaultTaskCall).Aliases = append(t1.Get(defaultTaskCall).Aliases, include.Namespace)
+		t1.Get(defaultTaskCall).Aliases = append(t1.Get(defaultTaskCall).Aliases, include.Aliases...)
 	}
 }
 

--- a/testdata/wildcards/Taskfile.yml
+++ b/testdata/wildcards/Taskfile.yml
@@ -9,6 +9,11 @@ tasks:
     cmds:
       - echo "Hello {{index .MATCH 0}} {{index .MATCH 1}}"
 
+  # Matches is empty when you call the task name exactly (i.e. `task matches-exactly-*`)
+  matches-exactly-*:
+    cmds:
+      - "echo \"I don't consume matches: {{.MATCH}}\""
+
   start-*:
     vars:
       SERVICE: "{{index .MATCH 0}}"

--- a/testdata/wildcards/Taskfile.yml
+++ b/testdata/wildcards/Taskfile.yml
@@ -1,0 +1,16 @@
+version: 3
+
+tasks:
+  wildcard-*:
+    cmds:
+      - echo "Hello {{index .MATCH 0}}"
+
+  '*-wildcard-*':
+    cmds:
+      - echo "Hello {{index .MATCH 0}} {{index .MATCH 1}}"
+
+  start-*:
+    vars:
+      SERVICE: "{{index .MATCH 0}}"
+    cmds:
+      - echo "Starting {{.SERVICE}}"

--- a/testdata/wildcards/Taskfile.yml
+++ b/testdata/wildcards/Taskfile.yml
@@ -5,6 +5,10 @@ tasks:
     cmds:
       - echo "Hello {{index .MATCH 0}}"
 
+  wildcard-*-*:
+    cmds:
+      - echo "Hello {{index .MATCH 0}}"
+
   '*-wildcard-*':
     cmds:
       - echo "Hello {{index .MATCH 0}} {{index .MATCH 1}}"

--- a/variables.go
+++ b/variables.go
@@ -17,16 +17,16 @@ import (
 
 // CompiledTask returns a copy of a task, but replacing variables in almost all
 // properties using the Go template package.
-func (e *Executor) CompiledTask(call ast.Call) (*ast.Task, error) {
+func (e *Executor) CompiledTask(call *ast.Call) (*ast.Task, error) {
 	return e.compiledTask(call, true)
 }
 
 // FastCompiledTask is like CompiledTask, but it skippes dynamic variables.
-func (e *Executor) FastCompiledTask(call ast.Call) (*ast.Task, error) {
+func (e *Executor) FastCompiledTask(call *ast.Call) (*ast.Task, error) {
 	return e.compiledTask(call, false)
 }
 
-func (e *Executor) compiledTask(call ast.Call, evaluateShVars bool) (*ast.Task, error) {
+func (e *Executor) compiledTask(call *ast.Call, evaluateShVars bool) (*ast.Task, error) {
 	origTask, err := e.GetTask(call)
 	if err != nil {
 		return nil, err

--- a/watch.go
+++ b/watch.go
@@ -21,7 +21,7 @@ import (
 const defaultWatchInterval = 5 * time.Second
 
 // watchTasks start watching the given tasks
-func (e *Executor) watchTasks(calls ...ast.Call) error {
+func (e *Executor) watchTasks(calls ...*ast.Call) error {
 	tasks := make([]string, len(calls))
 	for i, c := range calls {
 		tasks[i] = c.Task
@@ -119,24 +119,24 @@ func closeOnInterrupt(w *watcher.Watcher) {
 	}()
 }
 
-func (e *Executor) registerWatchedFiles(w *watcher.Watcher, calls ...ast.Call) error {
+func (e *Executor) registerWatchedFiles(w *watcher.Watcher, calls ...*ast.Call) error {
 	watchedFiles := w.WatchedFiles()
 
-	var registerTaskFiles func(ast.Call) error
-	registerTaskFiles = func(c ast.Call) error {
+	var registerTaskFiles func(*ast.Call) error
+	registerTaskFiles = func(c *ast.Call) error {
 		task, err := e.CompiledTask(c)
 		if err != nil {
 			return err
 		}
 
 		for _, d := range task.Deps {
-			if err := registerTaskFiles(ast.Call{Task: d.Task, Vars: d.Vars}); err != nil {
+			if err := registerTaskFiles(&ast.Call{Task: d.Task, Vars: d.Vars}); err != nil {
 				return err
 			}
 		}
 		for _, c := range task.Cmds {
 			if c.Task != "" {
-				if err := registerTaskFiles(ast.Call{Task: c.Task, Vars: c.Vars}); err != nil {
+				if err := registerTaskFiles(&ast.Call{Task: c.Task, Vars: c.Vars}); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
Fixes #836

## Context

This PR is a proposal for a design that would allow basic wildcard matching for task names. At the moment, if users want to make a generic task that performs a common set of operations on many different services or directories (etc) they must either:

1. Pass a variable into Task using environment variables
2. Use `.CLI_ARGS` and the `--` operator

Both of these methods can be clunky to type into a CLI and are not very intuitive. `make` has the option to do wildcard matching (using `%`). This PR is a proposal to do the equivalent in Task.

## Proposal

When a Taskfile has a task with a name that contains a wildcard (`*`) and the user calls `task` with a task name that "matches" a wildcard task, that task will be run. Matches will occur by replacing any instances of `*` with the `(.*)` regex string and doing a regex match. The captured variables will be made available to the Task via the `MATCH` variable in the form of an array. For example:

```yaml
version: 3

tasks:
  # A task that starts any service
  start-*:
    vars:
      SERVICE: "{{index .MATCH 0}}"
    cmds:
      - echo "Starting {{.SERVICE}}"
      - ...
```

```shell
> task start-foo
Starting foo
...
```

## Implementation

The first commit updates all usages of `ast.Call` to be passed by reference. Doing this allows methods that accept a call to update the call's variables. This means we can add any wildcard matches into the `call.Vars` without have to propagate them and change a bunch of function signatures.

Other than this, the implementation is very simple, we are simply overriding the `omap.Get()` method by adding a `Get()` method directly on `ast.Tasks` and then adding a simple `WildcardMatch()` function to `ast.Task` which will work out if a Task matches the call and retrieve the wildcard variables

## Notes

I haven't written any docs yet since I'd like some feedback on the design/implementation. I'll add this once we've decided we're happy with it. What do people think about the naming? i.e. `*` and `MATCH`. There were some other ideas discussed in #836, but I think starting with simple wildcard matching is probably a good start. I personally, would find this to be more than enough for my use cases.

Final note. The `omap.Range()` function doesn't support yielding right now so there is a bit of a hack to get around this (see `TODO` in code). There is an interesting [iterator proposal](https://medium.com/eureka-engineering/a-look-at-iterators-in-go-f8e86062937c) that will be introduced to Golang 1.22 as an experiment. This would be a really good solution to this, but we probably won't be able to add this until it is added to the language permanently (probably 1.23) and we drop support for 1.22 (so around a year from now).
