### PR TITLE
docs: specify that variable declaration order is respected

### DIFF
--- a/docs/docs/api_reference.md
+++ b/docs/docs/api_reference.md
@@ -214,6 +214,19 @@ vars:
 
 :::
 
+:::info
+
+In a variables map, variables defined later may reference variables defined
+earlier (declaration order is respected):
+
+```yaml
+vars:
+  FIRST_VAR: "hello"
+  SECOND_VAR: "{{.FIRST_VAR}} world"
+```
+
+:::
+
 ### Task
 
 | Attribute       | Type                               | Default                                               | Description                                                                                                                                                                                                                                                                                              |


### PR DESCRIPTION
https://github.com/go-task/task/commit/6ed30f1addf85dcf015e3586008e3f9bdf59041d ensures that variable declaration order is respected, but this wasn't documented as far as I could tell. This PR adds a note about it to the API reference.