### PR TITLE
fix: panic when using --list and --silent

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -265,8 +265,7 @@ func run() error {
 	}
 
 	if (listOptions.ShouldListTasks()) && flags.silent {
-		e.ListTaskNames(flags.listAll)
-		return nil
+		return e.ListTaskNames(flags.listAll)
 	}
 
 	if err := e.Setup(); err != nil {

--- a/help.go
+++ b/help.go
@@ -122,6 +122,10 @@ func (e *Executor) ListTasks(o ListOptions) (bool, error) {
 // Only tasks with a non-empty description are printed if allTasks is false.
 // Otherwise, all task names are printed.
 func (e *Executor) ListTaskNames(allTasks bool) {
+	// if called from cmd/task.go, e.Logger has not yet been initialized
+	if e.Logger == nil {
+		e.setupLogger()
+	}
 	// if called from cmd/task.go, e.Taskfile has not yet been parsed
 	if e.Taskfile == nil {
 		if err := e.readTaskfile(); err != nil {

--- a/help.go
+++ b/help.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -121,7 +120,7 @@ func (e *Executor) ListTasks(o ListOptions) (bool, error) {
 // ListTaskNames prints only the task names in a Taskfile.
 // Only tasks with a non-empty description are printed if allTasks is false.
 // Otherwise, all task names are printed.
-func (e *Executor) ListTaskNames(allTasks bool) {
+func (e *Executor) ListTaskNames(allTasks bool) error {
 	// if called from cmd/task.go, e.Logger has not yet been initialized
 	if e.Logger == nil {
 		e.setupLogger()
@@ -129,8 +128,7 @@ func (e *Executor) ListTaskNames(allTasks bool) {
 	// if called from cmd/task.go, e.Taskfile has not yet been parsed
 	if e.Taskfile == nil {
 		if err := e.readTaskfile(); err != nil {
-			log.Fatal(err)
-			return
+			return err
 		}
 	}
 	// use stdout if no output defined
@@ -161,6 +159,7 @@ func (e *Executor) ListTaskNames(allTasks bool) {
 	for _, t := range taskNames {
 		fmt.Fprintln(w, t)
 	}
+	return nil
 }
 
 func (e *Executor) ToEditorOutput(tasks []*ast.Task, noStatus bool) (*editors.Taskfile, error) {


### PR DESCRIPTION
Fixes #1509

- fix: setup logger if nil when listing task names
- refactor: bubble errors from ListTaskNames

@andreynering An alternative approach to fixing this would be the following diff. It would simplify the code as we no longer have to conditionally load the taskfile/logger in `ListTaskNames()`. This obviously comes with a slight performance cost.

```diff
diff --git a/cmd/task/task.go b/cmd/task/task.go
index f3144703..17f9884c 100644
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -264,15 +264,15 @@ func run() error {
                return err
        }
 
+       if err := e.Setup(); err != nil {
+               return err
+       }
+
        if (listOptions.ShouldListTasks()) && flags.silent {
                e.ListTaskNames(flags.listAll)
                return nil
        }
 
-       if err := e.Setup(); err != nil {
-               return err
-       }
-
        // If the download flag is specified, we should stop execution as soon as
        // taskfile is downloaded
        if flags.download {
```