### PR TITLE
fix: list tasks

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -264,10 +264,6 @@ func run() error {
 		return err
 	}
 
-	if (listOptions.ShouldListTasks()) && flags.silent {
-		return e.ListTaskNames(flags.listAll)
-	}
-
 	if err := e.Setup(); err != nil {
 		return err
 	}
@@ -276,6 +272,10 @@ func run() error {
 	// taskfile is downloaded
 	if flags.download {
 		return nil
+	}
+
+	if (listOptions.ShouldListTasks()) && flags.silent {
+		return e.ListTaskNames(flags.listAll)
 	}
 
 	if listOptions.ShouldListTasks() {

--- a/help.go
+++ b/help.go
@@ -121,16 +121,6 @@ func (e *Executor) ListTasks(o ListOptions) (bool, error) {
 // Only tasks with a non-empty description are printed if allTasks is false.
 // Otherwise, all task names are printed.
 func (e *Executor) ListTaskNames(allTasks bool) error {
-	// if called from cmd/task.go, e.Logger has not yet been initialized
-	if e.Logger == nil {
-		e.setupLogger()
-	}
-	// if called from cmd/task.go, e.Taskfile has not yet been parsed
-	if e.Taskfile == nil {
-		if err := e.readTaskfile(); err != nil {
-			return err
-		}
-	}
 	// use stdout if no output defined
 	var w io.Writer = os.Stdout
 	if e.Stdout != nil {


### PR DESCRIPTION
Fixes #1514

This change removes an optimisation in favour of reducing complexity. There is nothing particularly time consuming that we are skipping in `e.Setup()` and this code has been the source of several recent bugs including #1514 and #1509.