### PR TITLE
feat: parse templates in collection-type variables

### DIFF
--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -61,13 +61,7 @@ func (c *Compiler) getVariables(t *ast.Task, call *ast.Call, evaluateShVars bool
 		return func(k string, v ast.Var) error {
 			cache := &templater.Cache{Vars: result}
 			// Replace values
-			newVar := ast.Var{}
-			newVar.Value = templater.Replace(v.Value, cache)
-			newVar.Sh = templater.Replace(v.Sh, cache)
-			newVar.Ref = v.Ref
-			newVar.Json = templater.Replace(v.Json, cache)
-			newVar.Yaml = templater.Replace(v.Yaml, cache)
-			newVar.Dir = v.Dir
+			newVar := templater.ReplaceVar(v, cache)
 			// If the variable is a reference, we can resolve it
 			if newVar.Ref != "" {
 				newVar.Value = result.Get(newVar.Ref).Value

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -62,12 +62,7 @@ func (c *Compiler) getVariables(t *ast.Task, call *ast.Call, evaluateShVars bool
 			cache := &templater.Cache{Vars: result}
 			// Replace values
 			newVar := ast.Var{}
-			switch value := v.Value.(type) {
-			case string:
-				newVar.Value = templater.Replace(value, cache)
-			default:
-				newVar.Value = value
-			}
+			newVar.Value = templater.Replace(v.Value, cache)
 			newVar.Sh = templater.Replace(v.Sh, cache)
 			newVar.Ref = v.Ref
 			newVar.Json = templater.Replace(v.Json, cache)

--- a/internal/deepcopy/deepcopy.go
+++ b/internal/deepcopy/deepcopy.go
@@ -76,9 +76,9 @@ func TraverseStringsFunc[T any](v T, fn func(v string) (string, error)) (T, erro
 				return nil
 			}
 			// Create an empty copy from the original value's type
-			copyValue := reflect.New(originalValue.Type())
+			copyValue := reflect.New(originalValue.Type()).Elem()
 			// Unwrap the newly created pointer and call traverseFunc recursively
-			if err := traverseFunc(copyValue.Elem(), originalValue); err != nil {
+			if err := traverseFunc(copyValue, originalValue); err != nil {
 				return err
 			}
 			copy.Set(copyValue)

--- a/internal/deepcopy/deepcopy.go
+++ b/internal/deepcopy/deepcopy.go
@@ -1,5 +1,9 @@
 package deepcopy
 
+import (
+	"reflect"
+)
+
 type Copier[T any] interface {
 	DeepCopy() T
 }
@@ -32,4 +36,106 @@ func Map[K comparable, V any](orig map[K]V) map[K]V {
 		}
 	}
 	return c
+}
+
+// TraverseStringsFunc runs the given function on every string in the given
+// value by traversing it recursively. If the given value is a string, the
+// function will run on a copy of the string and return it. If the value is a
+// struct, map or a slice, the function will recursively call itself for each
+// field or element of the struct, map or slice until all strings inside the
+// struct or slice are replaced.
+func TraverseStringsFunc[T any](v T, fn func(v string) (string, error)) (T, error) {
+	original := reflect.ValueOf(v)
+	if original.Kind() == reflect.Invalid || !original.IsValid() {
+		return v, nil
+	}
+	copy := reflect.New(original.Type()).Elem()
+
+	var traverseFunc func(copy, v reflect.Value) error
+	traverseFunc = func(copy, v reflect.Value) error {
+		switch v.Kind() {
+
+		case reflect.Ptr:
+			// Unwrap the pointer
+			originalValue := v.Elem()
+			// If the pointer is nil, do nothing
+			if !originalValue.IsValid() {
+				return nil
+			}
+			// Create an empty copy from the original value's type
+			copy.Set(reflect.New(originalValue.Type()))
+			// Unwrap the newly created pointer and call traverseFunc recursively
+			if err := traverseFunc(copy.Elem(), originalValue); err != nil {
+				return err
+			}
+
+		case reflect.Interface:
+			// Unwrap the interface
+			originalValue := v.Elem()
+			if !originalValue.IsValid() {
+				return nil
+			}
+			// Create an empty copy from the original value's type
+			copyValue := reflect.New(originalValue.Type())
+			// Unwrap the newly created pointer and call traverseFunc recursively
+			if err := traverseFunc(copyValue.Elem(), originalValue); err != nil {
+				return err
+			}
+			copy.Set(copyValue)
+
+		case reflect.Struct:
+			// Loop over each field and call traverseFunc recursively
+			for i := 0; i < v.NumField(); i += 1 {
+				if err := traverseFunc(copy.Field(i), v.Field(i)); err != nil {
+					return err
+				}
+			}
+
+		case reflect.Slice:
+			// Create an empty copy from the original value's type
+			copy.Set(reflect.MakeSlice(v.Type(), v.Len(), v.Cap()))
+			// Loop over each element and call traverseFunc recursively
+			for i := 0; i < v.Len(); i += 1 {
+				if err := traverseFunc(copy.Index(i), v.Index(i)); err != nil {
+					return err
+				}
+			}
+
+		case reflect.Map:
+			// Create an empty copy from the original value's type
+			copy.Set(reflect.MakeMap(v.Type()))
+			// Loop over each key
+			for _, key := range v.MapKeys() {
+				// Create a copy of each map index
+				originalValue := v.MapIndex(key)
+				if originalValue.IsNil() {
+					continue
+				}
+				copyValue := reflect.New(originalValue.Type()).Elem()
+				// Call traverseFunc recursively
+				if err := traverseFunc(copyValue, originalValue); err != nil {
+					return err
+				}
+				copy.SetMapIndex(key, copyValue)
+			}
+
+		case reflect.String:
+			rv, err := fn(v.String())
+			if err != nil {
+				return err
+			}
+			copy.Set(reflect.ValueOf(rv))
+
+		default:
+			copy.Set(v)
+		}
+
+		return nil
+	}
+
+	if err := traverseFunc(copy, original); err != nil {
+		return v, err
+	}
+
+	return copy.Interface().(T), nil
 }

--- a/internal/output/group.go
+++ b/internal/output/group.go
@@ -3,6 +3,8 @@ package output
 import (
 	"bytes"
 	"io"
+
+	"github.com/go-task/task/v3/internal/templater"
 )
 
 type Group struct {
@@ -10,13 +12,13 @@ type Group struct {
 	ErrorOnly  bool
 }
 
-func (g Group) WrapWriter(stdOut, _ io.Writer, _ string, tmpl Templater) (io.Writer, io.Writer, CloseFunc) {
+func (g Group) WrapWriter(stdOut, _ io.Writer, _ string, cache *templater.Cache) (io.Writer, io.Writer, CloseFunc) {
 	gw := &groupWriter{writer: stdOut}
 	if g.Begin != "" {
-		gw.begin = tmpl.Replace(g.Begin) + "\n"
+		gw.begin = templater.Replace(g.Begin, cache) + "\n"
 	}
 	if g.End != "" {
-		gw.end = tmpl.Replace(g.End) + "\n"
+		gw.end = templater.Replace(g.End, cache) + "\n"
 	}
 	return gw, gw, func(err error) error {
 		if g.ErrorOnly && err == nil {

--- a/internal/output/interleaved.go
+++ b/internal/output/interleaved.go
@@ -2,10 +2,12 @@ package output
 
 import (
 	"io"
+
+	"github.com/go-task/task/v3/internal/templater"
 )
 
 type Interleaved struct{}
 
-func (Interleaved) WrapWriter(stdOut, stdErr io.Writer, _ string, _ Templater) (io.Writer, io.Writer, CloseFunc) {
+func (Interleaved) WrapWriter(stdOut, stdErr io.Writer, _ string, _ *templater.Cache) (io.Writer, io.Writer, CloseFunc) {
 	return stdOut, stdErr, func(error) error { return nil }
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -4,18 +4,12 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-task/task/v3/internal/templater"
 	"github.com/go-task/task/v3/taskfile/ast"
 )
 
-// Templater executes a template engine.
-// It is provided by the templater.Templater package.
-type Templater interface {
-	// Replace replaces the provided template string with a rendered string.
-	Replace(tmpl string) string
-}
-
 type Output interface {
-	WrapWriter(stdOut, stdErr io.Writer, prefix string, tmpl Templater) (io.Writer, io.Writer, CloseFunc)
+	WrapWriter(stdOut, stdErr io.Writer, prefix string, cache *templater.Cache) (io.Writer, io.Writer, CloseFunc)
 }
 
 type CloseFunc func(err error) error

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -46,7 +46,7 @@ func TestGroup(t *testing.T) {
 }
 
 func TestGroupWithBeginEnd(t *testing.T) {
-	tmpl := templater.Templater{
+	tmpl := templater.Cache{
 		Vars: &ast.Vars{
 			OrderedMap: omap.FromMap(map[string]ast.Var{
 				"VAR1": {Value: "example-value"},

--- a/internal/output/prefixed.go
+++ b/internal/output/prefixed.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/go-task/task/v3/internal/templater"
 )
 
 type Prefixed struct{}
 
-func (Prefixed) WrapWriter(stdOut, _ io.Writer, prefix string, _ Templater) (io.Writer, io.Writer, CloseFunc) {
+func (Prefixed) WrapWriter(stdOut, _ io.Writer, prefix string, _ *templater.Cache) (io.Writer, io.Writer, CloseFunc) {
 	pw := &prefixWriter{writer: stdOut, prefix: prefix}
 	return pw, pw, func(error) error { return pw.close() }
 }

--- a/internal/templater/templater.go
+++ b/internal/templater/templater.go
@@ -3,10 +3,10 @@ package templater
 import (
 	"bytes"
 	"maps"
-	"reflect"
 	"strings"
 	"text/template"
 
+	"github.com/go-task/task/v3/internal/deepcopy"
 	"github.com/go-task/task/v3/taskfile/ast"
 )
 
@@ -51,16 +51,24 @@ func ReplaceWithExtra[T any](v T, cache *Cache, extra map[string]any) T {
 		maps.Copy(data, extra)
 	}
 
-	original := reflect.ValueOf(&v)
-	copy := reflect.New(original.Type()).Elem()
-
-	// Replace the variables in the value
-	if err := replaceValue(copy, original, data); err != nil {
+	// Traverse the value and parse any template variables
+	copy, err := deepcopy.TraverseStringsFunc(v, func(v string) (string, error) {
+		tpl, err := template.New("").Funcs(templateFuncs).Parse(v)
+		if err != nil {
+			return v, err
+		}
+		var b bytes.Buffer
+		if err := tpl.Execute(&b, data); err != nil {
+			return v, err
+		}
+		return strings.ReplaceAll(b.String(), "<no value>", ""), nil
+	})
+	if err != nil {
 		cache.err = err
 		return v
 	}
 
-	return copy.Elem().Interface().(T)
+	return copy
 }
 
 func ReplaceGlobs(globs []*ast.Glob, cache *Cache) []*ast.Glob {
@@ -104,93 +112,4 @@ func ReplaceVarsWithExtra(vars *ast.Vars, cache *Cache, extra map[string]any) *a
 	})
 
 	return &newVars
-}
-
-// replaceValue is a recursive function that replaces all the string template
-// variables in the given value with the values in the data map. If the value is
-// a string, the function will replace the variables in the string and return
-// the new string. If the value is a struct or a slice, the function will
-// recursively call itself for each field or element of the struct or slice
-// until all strings inside the struct or slice are replaced.
-func replaceValue(copy, v reflect.Value, data map[string]any) error {
-	switch v.Kind() {
-
-	case reflect.Ptr:
-		// Unwrap the pointer
-		originalValue := v.Elem()
-		// If the pointer is nil, do nothing
-		if !originalValue.IsValid() {
-			return nil
-		}
-		// Create an empty copy from the original value's type
-		copy.Set(reflect.New(originalValue.Type()))
-		// Unwrap the newly created pointer and call replaceValue recursively
-		if err := replaceValue(copy.Elem(), originalValue, data); err != nil {
-			return err
-		}
-
-	case reflect.Interface:
-		// Unwrap the interface
-		originalValue := v.Elem()
-		// Create an empty copy from the original value's type
-		copyValue := reflect.New(originalValue.Type())
-		// Unwrap the newly created pointer and call replaceValue recursively
-		if err := replaceValue(copyValue.Elem(), originalValue, data); err != nil {
-			return err
-		}
-		copy.Set(copyValue)
-
-	case reflect.Struct:
-		// Loop over each field and call replaceValue recursively
-		for i := 0; i < v.NumField(); i += 1 {
-			if err := replaceValue(copy.Field(i), v.Field(i), data); err != nil {
-				return err
-			}
-		}
-
-	case reflect.Slice:
-		// Create an empty copy from the original value's type
-		copy.Set(reflect.MakeSlice(v.Type(), v.Len(), v.Cap()))
-		// Loop over each element and call replaceValue recursively
-		for i := 0; i < v.Len(); i += 1 {
-			if err := replaceValue(copy.Index(i), v.Index(i), data); err != nil {
-				return err
-			}
-		}
-
-	case reflect.Map:
-		// Create an empty copy from the original value's type
-		copy.Set(reflect.MakeMap(v.Type()))
-		// Loop over each key
-		for _, key := range v.MapKeys() {
-			// Create a copy of each map index
-			originalValue := v.MapIndex(key)
-			if originalValue.IsNil() {
-				continue
-			}
-			copyValue := reflect.New(originalValue.Type()).Elem()
-			// Call replaceValue recursively
-			if err := replaceValue(copyValue, originalValue, data); err != nil {
-				return err
-			}
-			copy.SetMapIndex(key, copyValue)
-		}
-
-	case reflect.String:
-		tpl, err := template.New("").Funcs(templateFuncs).Parse(v.String())
-		if err != nil {
-			return err
-		}
-		var b bytes.Buffer
-		if err := tpl.Execute(&b, data); err != nil {
-			return err
-		}
-		str := strings.ReplaceAll(b.String(), "<no value>", "")
-		copy.SetString(str)
-
-	default:
-		copy.Set(v)
-	}
-
-	return nil
 }

--- a/internal/templater/templater.go
+++ b/internal/templater/templater.go
@@ -98,10 +98,7 @@ func ReplaceVarsWithExtra(vars *ast.Vars, cache *Cache, extra map[string]any) *a
 	var newVars ast.Vars
 	_ = vars.Range(func(k string, v ast.Var) error {
 		var newVar ast.Var
-		switch value := v.Value.(type) {
-		case string:
-			newVar.Value = ReplaceWithExtra(value, cache, extra)
-		}
+		newVar.Value = ReplaceWithExtra(v.Value, cache, extra)
 		newVar.Live = v.Live
 		newVar.Sh = ReplaceWithExtra(v.Sh, cache, extra)
 		newVar.Ref = v.Ref

--- a/internal/templater/templater.go
+++ b/internal/templater/templater.go
@@ -86,6 +86,22 @@ func ReplaceGlobs(globs []*ast.Glob, cache *Cache) []*ast.Glob {
 	return new
 }
 
+func ReplaceVar(v ast.Var, cache *Cache) ast.Var {
+	return ReplaceVarWithExtra(v, cache, nil)
+}
+
+func ReplaceVarWithExtra(v ast.Var, cache *Cache, extra map[string]any) ast.Var {
+	return ast.Var{
+		Value: ReplaceWithExtra(v.Value, cache, extra),
+		Sh:    ReplaceWithExtra(v.Sh, cache, extra),
+		Live:  v.Live,
+		Ref:   v.Ref,
+		Dir:   v.Dir,
+		Json:  ReplaceWithExtra(v.Json, cache, extra),
+		Yaml:  ReplaceWithExtra(v.Yaml, cache, extra),
+	}
+}
+
 func ReplaceVars(vars *ast.Vars, cache *Cache) *ast.Vars {
 	return ReplaceVarsWithExtra(vars, cache, nil)
 }
@@ -97,14 +113,7 @@ func ReplaceVarsWithExtra(vars *ast.Vars, cache *Cache, extra map[string]any) *a
 
 	var newVars ast.Vars
 	_ = vars.Range(func(k string, v ast.Var) error {
-		var newVar ast.Var
-		newVar.Value = ReplaceWithExtra(v.Value, cache, extra)
-		newVar.Live = v.Live
-		newVar.Sh = ReplaceWithExtra(v.Sh, cache, extra)
-		newVar.Ref = v.Ref
-		newVar.Json = ReplaceWithExtra(v.Json, cache, extra)
-		newVar.Yaml = ReplaceWithExtra(v.Yaml, cache, extra)
-		newVars.Set(k, newVar)
+		newVars.Set(k, ReplaceVarWithExtra(v, cache, extra))
 		return nil
 	})
 

--- a/task.go
+++ b/task.go
@@ -348,7 +348,7 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *ast.Call, 
 			outputWrapper = output.Interleaved{}
 		}
 		vars, err := e.Compiler.FastGetVariables(t, call)
-		outputTemplater := &templater.Templater{Vars: vars}
+		outputTemplater := &templater.Cache{Vars: vars}
 		if err != nil {
 			return fmt.Errorf("task: failed to get variables: %w", err)
 		}

--- a/taskfile/dotenv.go
+++ b/taskfile/dotenv.go
@@ -22,11 +22,10 @@ func Dotenv(c *compiler.Compiler, tf *ast.Taskfile, dir string) (*ast.Vars, erro
 	}
 
 	env := &ast.Vars{}
-
-	tr := templater.Templater{Vars: vars}
+	cache := &templater.Cache{Vars: vars}
 
 	for _, dotEnvPath := range tf.Dotenv {
-		dotEnvPath = tr.Replace(dotEnvPath)
+		dotEnvPath = templater.Replace(dotEnvPath, cache)
 		if dotEnvPath == "" {
 			continue
 		}

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -60,11 +60,11 @@ func Read(
 		}
 
 		err = tf.Includes.Range(func(namespace string, include ast.Include) error {
-			tr := templater.Templater{Vars: tf.Vars}
+			cache := &templater.Cache{Vars: tf.Vars}
 			include = ast.Include{
 				Namespace:      include.Namespace,
-				Taskfile:       tr.Replace(include.Taskfile),
-				Dir:            tr.Replace(include.Dir),
+				Taskfile:       templater.Replace(include.Taskfile, cache),
+				Dir:            templater.Replace(include.Dir, cache),
 				Optional:       include.Optional,
 				Internal:       include.Internal,
 				Aliases:        include.Aliases,
@@ -72,7 +72,7 @@ func Read(
 				Vars:           include.Vars,
 				BaseDir:        include.BaseDir,
 			}
-			if err := tr.Err(); err != nil {
+			if err := cache.Err(); err != nil {
 				return err
 			}
 

--- a/testdata/vars/any2/Taskfile.yml
+++ b/testdata/vars/any2/Taskfile.yml
@@ -3,6 +3,8 @@ version: '3'
 tasks:
   default:
     - task: map
+    - task: nested-map
+    - task: slice
     - task: ref
     - task: ref-sh
     - task: ref-dep
@@ -18,6 +20,24 @@ tasks:
         vars:
           VAR:
             ref: MAP
+
+  nested-map:
+    vars:
+      FOO: "foo"
+      nested:
+        map:
+          variables:
+            work: "{{.FOO}}"
+    cmds:
+      - echo {{.nested.variables.work}}
+
+  slice:
+    vars:
+      FOO: "foo"
+      BAR: "bar"
+      slice_variables_work: ["{{.FOO}}","{{.BAR}}"]
+    cmds:
+      - echo {{index .slice_variables_work 0}} {{index .slice_variables_work 1}}
 
   ref:
     vars:


### PR DESCRIPTION
Fixes #1477
Fixes #1511

This PR overhauls the way templating works in Task. Instead of having methods on `templater.Template`, we now have package-level functions instead. This allows us to use generics (as generic methods aren't possible right now) which vastly simplifies the calling API. This is especially useful for the "Any Variables" experiment since many types of variable may need to support templating.

For example, we now have the ability to support collection-type variables (slices/maps) and these might contain strings in which we want to use templates. See example below:

```yml
version: '3'

vars:
  IMAGE_TAG: 'latest'

tasks:
  default:
    vars:
      works: '{{.IMAGE_TAG}}'
      does:
        map:
          not:
            work: '{{.IMAGE_TAG}}'
    cmds:
      - 'echo {{.works}}'
      - 'echo {{.does.not.work}}'
```

Running the above Taskfile in v3.35.0 or lower will result in the following:

```shell
> TASK_X_ANY_VARIABLES=2 task
task: [default] echo latest
latest
task: [default] echo {{.IMAGE_TAG}}
{{.IMAGE_TAG}}
```

Not that the `.does.not.work` variable contains a template, but it is not parsed. After this PR the result will work as expected:

```shell
> TASK_X_ANY_VARIABLES=2 task
task: [default] echo latest
latest
task: [default] echo latest
latest
```

This is possible because any variable can now be passed into the `templater.Replace(...)` function and it will automatically traverse the value and find all strings that need replacing, whether they are raw strings, or nested strings inside a map/slice.

It's worth mentioning that I have not actually removed the old `templater.Template` struct. It is now called `templater.Cache` (as this is its primary use) and it is passed in as a regular function parameter instead. It's possible that we could make changes to this too, but I figured I'd leave that for another day rather than trying to bundle a bunch of error handling changes in the same PR.