### PR TITLE
fix: taskfile directory

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -109,6 +109,7 @@ func TestVars(t *testing.T) {
 
 func TestSpecialVars(t *testing.T) {
 	const dir = "testdata/special_vars"
+	const subdir = "testdata/special_vars/subdir"
 	toAbs := func(rel string) string {
 		abs, err := filepath.Abs(rel)
 		assert.NoError(t, err)
@@ -122,28 +123,32 @@ func TestSpecialVars(t *testing.T) {
 		// Root
 		{target: "print-task", expected: "print-task"},
 		{target: "print-root-dir", expected: toAbs(dir)},
+		{target: "print-taskfile", expected: toAbs(dir) + "/Taskfile.yml"},
 		{target: "print-taskfile-dir", expected: toAbs(dir)},
 		{target: "print-task-version", expected: "unknown"},
 		// Included
 		{target: "included:print-task", expected: "included:print-task"},
 		{target: "included:print-root-dir", expected: toAbs(dir)},
+		{target: "included:print-taskfile", expected: toAbs(dir) + "/included/Taskfile.yml"},
 		{target: "included:print-taskfile-dir", expected: toAbs(dir) + "/included"},
 		{target: "included:print-task-version", expected: "unknown"},
 	}
 
-	for _, test := range tests {
-		t.Run(test.target, func(t *testing.T) {
-			var buff bytes.Buffer
-			e := &task.Executor{
-				Dir:    dir,
-				Stdout: &buff,
-				Stderr: &buff,
-				Silent: true,
-			}
-			require.NoError(t, e.Setup())
-			require.NoError(t, e.Run(context.Background(), &ast.Call{Task: test.target}))
-			assert.Equal(t, test.expected+"\n", buff.String())
-		})
+	for _, dir := range []string{dir, subdir} {
+		for _, test := range tests {
+			t.Run(test.target, func(t *testing.T) {
+				var buff bytes.Buffer
+				e := &task.Executor{
+					Dir:    dir,
+					Stdout: &buff,
+					Stderr: &buff,
+					Silent: true,
+				}
+				require.NoError(t, e.Setup())
+				require.NoError(t, e.Run(context.Background(), &ast.Call{Task: test.target}))
+				assert.Equal(t, test.expected+"\n", buff.String())
+			})
+		}
 	}
 }
 

--- a/taskfile/node.go
+++ b/taskfile/node.go
@@ -24,6 +24,7 @@ func NewRootNode(
 	entrypoint string,
 	insecure bool,
 ) (Node, error) {
+	dir = getDefaultDir(entrypoint, dir)
 	// Check if there is something to read on STDIN
 	stat, _ := os.Stdin.Stat()
 	if (stat.Mode()&os.ModeCharDevice) == 0 && stat.Size() > 0 {
@@ -67,4 +68,27 @@ func getScheme(uri string) string {
 		return uri[:i]
 	}
 	return ""
+}
+
+func getDefaultDir(entrypoint, dir string) string {
+	// If the entrypoint and dir are empty, we default the directory to the current working directory
+	if dir == "" {
+		if entrypoint == "" {
+			wd, err := os.Getwd()
+			if err != nil {
+				return ""
+			}
+			dir = wd
+		}
+		return dir
+	}
+
+	// If the directory is set, ensure it is an absolute path
+	var err error
+	dir, err = filepath.Abs(dir)
+	if err != nil {
+		return ""
+	}
+
+	return dir
 }

--- a/testdata/special_vars/Taskfile.yml
+++ b/testdata/special_vars/Taskfile.yml
@@ -8,5 +8,6 @@ includes:
 tasks:
   print-task: echo {{.TASK}}
   print-root-dir: echo {{.ROOT_DIR}}
+  print-taskfile: echo {{.TASKFILE}}
   print-taskfile-dir: echo {{.TASKFILE_DIR}}
   print-task-version: echo {{.TASK_VERSION}}

--- a/testdata/special_vars/included/Taskfile.yml
+++ b/testdata/special_vars/included/Taskfile.yml
@@ -3,5 +3,6 @@ version: '3'
 tasks:
   print-task: echo {{.TASK}}
   print-root-dir: echo {{.ROOT_DIR}}
+  print-taskfile: echo {{.TASKFILE}}
   print-taskfile-dir: echo {{.TASKFILE_DIR}}
   print-task-version: echo {{.TASK_VERSION}}


### PR DESCRIPTION
Fixes #1529

This issue was caused by a change in #1483 that moved where the Taskfile directory was calculated. This resulted in Task behaving weirdly in situations where a Taskfile is located in a parent directory to the user's current working directory. This was partly fixed in #1522. However, the core issue still remained.

This PR fixes any remaining related issues by moving the directory calculation entirely into the `NewRootNode()` function and then fetching the calculated dir from the resulting node in `e.Setup()`. The node creation has also been moved earlier in the executor setup in order to fix another unreported bug where the temporary `.task` directory was created in the wrong place.