### PR TITLE
fix(remote): include a Taskfile in a remote's one

### DIFF
--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -3,7 +3,9 @@ package taskfile
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -76,6 +78,17 @@ func Read(
 				return err
 			}
 
+			//If we include a taskfile in a remote taskfile, then this taskfile is also remote
+			if node.Remote() {
+				nodeUrl, err := url.Parse(node.Location())
+				if err != nil {
+					return err
+				}
+				split := strings.Split(nodeUrl.Path, "/")
+				split[len(split)-1] = include.Taskfile
+				nodeUrl.Path = strings.Join(split, "/")
+				include.Taskfile = nodeUrl.String()
+			}
 			uri, err := include.FullTaskfilePath()
 			if err != nil {
 				return err


### PR DESCRIPTION
Fixes : 
- https://github.com/go-task/task/issues/1531

It's my first contribution to this project (at least in the go's part), I'm totally open to comment.
What I did : if a Taskfile is included in a remote one, I changed the URI to match the remote's one

I was not sure where to do it, I've put it in the reader
