### PR TITLE
feat(taskfile): add post tasks feature

### DIFF
--- a/docs/docs/api_reference.md
+++ b/docs/docs/api_reference.md
@@ -234,6 +234,7 @@ vars:
 | --------------- | ---------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `cmds`          | [`[]Command`](#command)            |                                                       | A list of shell commands to be executed.                                                                                                                                                                                                                                                                 |
 | `deps`          | [`[]Dependency`](#dependency)      |                                                       | A list of dependencies of this task. Tasks defined here will run in parallel before this task.                                                                                                                                                                                                           |
+| `posts`         | [`[]Post`](#post)                  |                                                       | A list of post tasks of this task. Tasks defined here will run in parallel after this task.                                                                                                                                                                                                              |
 | `label`         | `string`                           |                                                       | Overrides the name of the task in the output when a task is run. Supports variables.                                                                                                                                                                                                                     |
 | `desc`          | `string`                           |                                                       | A short description of the task. This is displayed when calling `task --list`.                                                                                                                                                                                                                           |
 | `prompt`        | `string`                           |                                                       | A prompt that will be presented before a task is run. Declining will cancel running the current and any subsequent tasks.                                                                                                                                                                                |
@@ -324,6 +325,27 @@ dependency as a list of strings (they will be assigned to `task`):
 tasks:
   foo:
     deps: [foo, bar]
+```
+
+:::
+
+#### Post
+
+| Attribute | Type                               | Default | Description                                                                                                      |
+| --------- | ---------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------- |
+| `task`    | `string`                           |         | The task to be execute as a post task.                                                                           |
+| `vars`    | [`map[string]Variable`](#variable) |         | Optional additional variables to be passed to this task.                                                         |
+| `silent`  | `bool`                             | `false` | Hides task name and command from output. The command's output will still be redirected to `STDOUT` and `STDERR`. |
+
+:::tip
+
+If you don't want to set additional variables, it's enough to declare the
+posts as a list of strings (they will be assigned to `task`):
+
+```yaml
+tasks:
+  foo:
+    posts: [foo, bar]
 ```
 
 :::

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -521,6 +521,23 @@ tasks:
 If you want to pass information to dependencies, you can do that the same manner
 as you would to [call another task](#calling-another-task):
 
+```yaml
+tasks:
+  default:
+    cmds:
+      - echo "after"
+    posts:
+      - task: echo_sth
+        vars: { TEXT: 'before 1' }
+      - task: echo_sth
+        vars: { TEXT: 'before 2' }
+        silent: true
+
+  echo_sth:
+    cmds:
+      - echo {{.TEXT}}
+```
+
 ## Platform specific tasks and commands
 
 If you want to restrict the running of tasks to explicit platforms, this can be

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -493,6 +493,34 @@ tasks:
       - echo {{.TEXT}}
 ```
 
+## Post Tasks
+
+You may want to run other tasks at the end of a task. Just pointing them on `posts` will make
+them run automatically after running the current task:
+
+```yaml
+version: '3'
+
+tasks:
+  build-and-push:
+    deps: [assets]
+    cmds:
+      - go build -v -i main.go
+    posts:
+      - publish
+
+  assets:
+    cmds:
+      - esbuild --bundle --minify css/index.css > public/bundle.css
+  
+  publish:
+    cmds:
+      - npm publish --access public
+```
+
+If you want to pass information to dependencies, you can do that the same manner
+as you would to [call another task](#calling-another-task):
+
 ## Platform specific tasks and commands
 
 If you want to restrict the running of tasks to explicit platforms, this can be

--- a/docs/static/schema.json
+++ b/docs/static/schema.json
@@ -60,6 +60,20 @@
             ]
           }
         },
+        "posts": {
+          "description": "A list of tasks to run after this task has completed.",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/definitions/task_call"
+              }
+            ]
+          }
+        },
         "label": {
           "description": "Overrides the name of the task in the output when a task is run. Supports variables.",
           "type": "string"
@@ -162,7 +176,11 @@
         "method": {
           "description": "Defines which method is used to check the task is up-to-date. `timestamp` will compare the timestamp of the sources and generates files. `checksum` will check the checksum (You probably want to ignore the .task folder in your .gitignore file). `none` skips any validation and always run the task.",
           "type": "string",
-          "enum": ["none", "checksum", "timestamp"],
+          "enum": [
+            "none",
+            "checksum",
+            "timestamp"
+          ],
           "default": "none"
         },
         "prefix": {
@@ -240,7 +258,11 @@
     },
     "shopt": {
       "type": "string",
-      "enum": ["expand_aliases", "globstar", "nullglob"]
+      "enum": [
+        "expand_aliases",
+        "globstar",
+        "nullglob"
+      ]
     },
     "vars": {
       "type": "object",
@@ -248,7 +270,15 @@
         "^.*$": {
           "anyOf": [
             {
-              "type": ["boolean", "integer", "null", "number", "string", "object", "array"]
+              "type": [
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "string",
+                "object",
+                "array"
+              ]
             },
             {
               "$ref": "#/definitions/var_subkey"
@@ -300,7 +330,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["task"]
+      "required": [
+        "task"
+      ]
     },
     "cmd_call": {
       "type": "object",
@@ -340,7 +372,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["cmd"]
+      "required": [
+        "cmd"
+      ]
     },
     "defer_call": {
       "type": "object",
@@ -365,7 +399,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["defer"]
+      "required": [
+        "defer"
+      ]
     },
     "for_call": {
       "type": "object",
@@ -401,11 +437,21 @@
         }
       },
       "oneOf": [
-        {"required": ["cmd"]},
-        {"required": ["task"]}
+        {
+          "required": [
+            "cmd"
+          ]
+        },
+        {
+          "required": [
+            "task"
+          ]
+        }
       ],
       "additionalProperties": false,
-      "required": ["for"]
+      "required": [
+        "for"
+      ]
     },
     "for_list": {
       "description": "A list of values to iterate over",
@@ -417,7 +463,9 @@
     "for_attribute": {
       "description": "The task attribute to iterate over",
       "type": "string",
-      "enum": ["sources"]
+      "enum": [
+        "sources"
+      ]
     },
     "for_var": {
       "description": "Which variables to iterate over. The variable will be split using any whitespace character by default. This can be changed by using the `split` attribute.",
@@ -438,7 +486,9 @@
         }
       },
       "additionalProperties": false,
-      "required": ["var"]
+      "required": [
+        "var"
+      ]
     },
     "precondition": {
       "anyOf": [
@@ -484,11 +534,19 @@
     },
     "run": {
       "type": "string",
-      "enum": ["always", "once", "when_changed"]
+      "enum": [
+        "always",
+        "once",
+        "when_changed"
+      ]
     },
     "outputString": {
       "type": "string",
-      "enum": ["interleaved", "prefixed", "group"],
+      "enum": [
+        "interleaved",
+        "prefixed",
+        "group"
+      ],
       "default": "interleaved"
     },
     "outputObject": {
@@ -538,21 +596,31 @@
             },
             {
               "type": "number",
-              "enum": [3]
+              "enum": [
+                3
+              ]
             }
           ]
         },
         "output": {
           "description": "Defines how the STDOUT and STDERR are printed when running tasks in parallel. The interleaved output prints lines in real time (default). The group output will print the entire output of a command once, after it finishes, so you won't have live feedback for commands that take a long time to run. The prefix output will prefix every line printed by a command with [task-name] as the prefix, but you can customize the prefix for a command with the prefix: attribute.",
           "anyOf": [
-            { "$ref": "#/definitions/outputString" },
-            { "$ref": "#/definitions/outputObject" }
+            {
+              "$ref": "#/definitions/outputString"
+            },
+            {
+              "$ref": "#/definitions/outputObject"
+            }
           ]
         },
         "method": {
           "description": "Defines which method is used to check the task is up-to-date. (default: checksum)",
           "type": "string",
-          "enum": ["none", "checksum", "timestamp"],
+          "enum": [
+            "none",
+            "checksum",
+            "timestamp"
+          ],
           "default": "checksum"
         },
         "includes": {
@@ -648,16 +716,25 @@
         }
       },
       "additionalProperties": false,
-      "required": ["version"],
+      "required": [
+        "version"
+      ],
       "anyOf": [
         {
-          "required": ["includes"]
+          "required": [
+            "includes"
+          ]
         },
         {
-          "required": ["tasks"]
+          "required": [
+            "tasks"
+          ]
         },
         {
-          "required": ["includes", "tasks"]
+          "required": [
+            "includes",
+            "tasks"
+          ]
         }
       ]
     }

--- a/task_test.go
+++ b/task_test.go
@@ -227,6 +227,34 @@ func TestDeps(t *testing.T) {
 	}
 }
 
+func TestPosts(t *testing.T) {
+	const dir = "testdata/posts"
+
+	files := []string{
+		"d1.txt",
+		"d2.txt",
+	}
+
+	for _, f := range files {
+		_ = os.Remove(filepathext.SmartJoin(dir, f))
+	}
+
+	e := &task.Executor{
+		Dir:    dir,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	}
+	require.NoError(t, e.Setup())
+	require.NoError(t, e.Run(context.Background(), &ast.Call{Task: "default"}))
+
+	for _, f := range files {
+		f = filepathext.SmartJoin(dir, f)
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("File %s should exist", f)
+		}
+	}
+}
+
 func TestStatus(t *testing.T) {
 	const dir = "testdata/status"
 

--- a/taskfile/ast/post.go
+++ b/taskfile/ast/post.go
@@ -1,0 +1,55 @@
+package ast
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Dep is a task dependency
+type Post struct {
+	Task   string
+	Vars   *Vars
+	Silent bool
+	Always bool
+}
+
+func (p *Post) DeepCopy() *Post {
+	if p == nil {
+		return nil
+	}
+	return &Post{
+		Task:   p.Task,
+		Vars:   p.Vars.DeepCopy(),
+		Silent: p.Silent,
+	}
+}
+
+func (p *Post) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+
+	case yaml.ScalarNode:
+		var task string
+		if err := node.Decode(&task); err != nil {
+			return err
+		}
+		p.Task = task
+		return nil
+
+	case yaml.MappingNode:
+		var taskCall struct {
+			Task   string
+			Vars   *Vars
+			Silent bool
+		}
+		if err := node.Decode(&taskCall); err != nil {
+			return err
+		}
+		p.Task = taskCall.Task
+		p.Vars = taskCall.Vars
+		p.Silent = taskCall.Silent
+		return nil
+	}
+
+	return fmt.Errorf("cannot unmarshal %s into dependency", node.ShortTag())
+}

--- a/taskfile/ast/task.go
+++ b/taskfile/ast/task.go
@@ -15,6 +15,7 @@ type Task struct {
 	Task                 string
 	Cmds                 []*Cmd
 	Deps                 []*Dep
+	Posts                []*Post
 	Label                string
 	Desc                 string
 	Prompt               string
@@ -103,6 +104,7 @@ func (t *Task) UnmarshalYAML(node *yaml.Node) error {
 			Cmds          []*Cmd
 			Cmd           *Cmd
 			Deps          []*Dep
+			Posts         []*Post
 			Label         string
 			Desc          string
 			Prompt        string
@@ -141,6 +143,7 @@ func (t *Task) UnmarshalYAML(node *yaml.Node) error {
 			t.Cmds = task.Cmds
 		}
 		t.Deps = task.Deps
+		t.Posts = task.Posts
 		t.Label = task.Label
 		t.Desc = task.Desc
 		t.Prompt = task.Prompt
@@ -182,6 +185,7 @@ func (t *Task) DeepCopy() *Task {
 		Task:                 t.Task,
 		Cmds:                 deepcopy.Slice(t.Cmds),
 		Deps:                 deepcopy.Slice(t.Deps),
+		Posts:                deepcopy.Slice(t.Posts),
 		Label:                t.Label,
 		Desc:                 t.Desc,
 		Prompt:               t.Prompt,

--- a/taskfile/ast/taskfile_test.go
+++ b/taskfile/ast/taskfile_test.go
@@ -23,6 +23,7 @@ vars:
 `
 		yamlDeferredCall = `defer: { task: some_task, vars: { PARAM1: "var" } }`
 		yamlDeferredCmd  = `defer: echo 'test'`
+		yamlPost         = `post-task-name`
 	)
 	tests := []struct {
 		content  string
@@ -88,6 +89,11 @@ vars:
 					),
 				},
 			},
+		},
+		{
+			yamlPost,
+			&ast.Post{},
+			&ast.Post{Task: "post-task-name"},
 		},
 	}
 	for _, test := range tests {

--- a/testdata/posts/Taskfile.yml
+++ b/testdata/posts/Taskfile.yml
@@ -1,0 +1,18 @@
+version: "3"
+
+tasks:
+  default:
+    cmds:
+      - echo 'Text' > d0.txt
+    posts:
+      - d1
+
+  d1:
+    cmds:
+      - echo 'Text' > d1.txt
+    posts:
+      - task: d2
+
+  d2:
+    cmds:
+      - echo 'Text' > d2.txt


### PR DESCRIPTION
Hi, while using go-task I found that a post-tasks like feature would be cool, in my case it would be nice to use it as a teardown for my test environments.

I used `posts` as a keyword for implementing this feature, if you find something more suitable I will be more than happy to refactor it.

Thank you!