### PR TITLE
Recalculate cmds if deps change sources.

### DIFF
--- a/task.go
+++ b/task.go
@@ -238,7 +238,7 @@ func (e *Executor) RunTask(ctx context.Context, call *ast.Call) error {
 			}
 		}
 
-		// Update cmds for case where deps many have changed sources (and 'for' needs re-evaluation).
+		// Update cmds for case where deps may have changed sources (and 'for' needs re-evaluation).
 		if len(t.Deps) > 0 && len(t.Sources) > 0 {
 			if err = e.UpdateCompiledTask(call, t); err != nil {
 				return err

--- a/task.go
+++ b/task.go
@@ -238,6 +238,13 @@ func (e *Executor) RunTask(ctx context.Context, call *ast.Call) error {
 			}
 		}
 
+		// Update cmds for case where deps many have changed sources (and 'for' needs re-evaluation).
+		if len(t.Deps) > 0 && len(t.Sources) > 0 {
+			if err = e.UpdateCompiledTask(call, t); err != nil {
+				return err
+			}
+		}
+
 		if err := e.mkdir(t); err != nil {
 			e.Logger.Errf(logger.Red, "task: cannot make directory %q: %v\n", t.Dir, err)
 		}


### PR DESCRIPTION
Life cycle of a task is somewhat like this:

compile(generates cmds) -> run deps -> fingerprint(on sources) -> run

Cmds generated by 'for', and based on sources, are calculated at compile time. Unfortunately, if sources are generated by a dependency, then the cmds will be out-of-date by the time the task runs.

This PR regenerates the cmds in such a case. There might be a few other edge cases where a task needs to be updated between compile and run


#1494 