### PR TITLE
feat: add support for multiple includes on a graph edge

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -19,7 +19,7 @@ const (
 	CodeTaskfileCacheNotFound
 	CodeTaskfileVersionCheckError
 	CodeTaskfileNetworkTimeout
-	CodeTaskfileDuplicateInclude
+	_ // CodeTaskfileDuplicateInclude
 	CodeTaskfileCycle
 )
 

--- a/errors/errors_taskfile.go
+++ b/errors/errors_taskfile.go
@@ -3,7 +3,6 @@ package errors
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -174,22 +173,6 @@ func (err *TaskfileNetworkTimeoutError) Error() string {
 
 func (err *TaskfileNetworkTimeoutError) Code() int {
 	return CodeTaskfileNetworkTimeout
-}
-
-type TaskfileDuplicateIncludeError struct {
-	URI         string
-	IncludedURI string
-	Namespaces  []string
-}
-
-func (err *TaskfileDuplicateIncludeError) Error() string {
-	return fmt.Sprintf(
-		`task: Taskfile %q attempted to include %q multiple times with namespaces: %s`, err.URI, err.IncludedURI, strings.Join(err.Namespaces, ", "),
-	)
-}
-
-func (err *TaskfileDuplicateIncludeError) Code() int {
-	return CodeTaskfileDuplicateInclude
 }
 
 // TaskfileCycleError is returned when we detect that a Taskfile includes a

--- a/task_test.go
+++ b/task_test.go
@@ -981,8 +981,8 @@ func TestIncludes(t *testing.T) {
 			"included_directory.txt":                    "included_directory",
 			"included_directory_without_dir.txt":        "included_directory_without_dir",
 			"included_taskfile_without_dir.txt":         "included_taskfile_without_dir",
-			"./module3/included_taskfile_with_dir.txt":  "included_taskfile_with_dir",
-			"./module4/included_directory_with_dir.txt": "included_directory_with_dir",
+			"./module2/included_directory_with_dir.txt": "included_directory_with_dir",
+			"./module2/included_taskfile_with_dir.txt":  "included_taskfile_with_dir",
 			"os_include.txt":                            "os",
 		},
 	}

--- a/taskfile/ast/graph.go
+++ b/taskfile/ast/graph.go
@@ -79,7 +79,7 @@ func (tfg *TaskfileGraph) Merge() (*Taskfile, error) {
 				}
 
 				// Get the merge options
-				include, ok := edge.Properties.Data.(Include)
+				include, ok := edge.Properties.Data.(*Include)
 				if !ok {
 					return fmt.Errorf("task: Failed to get merge options")
 				}
@@ -87,7 +87,7 @@ func (tfg *TaskfileGraph) Merge() (*Taskfile, error) {
 				// Merge the included Taskfile into the parent Taskfile
 				if err := vertex.Taskfile.Merge(
 					includedVertex.Taskfile,
-					&include,
+					include,
 				); err != nil {
 					return err
 				}

--- a/taskfile/ast/graph.go
+++ b/taskfile/ast/graph.go
@@ -79,17 +79,19 @@ func (tfg *TaskfileGraph) Merge() (*Taskfile, error) {
 				}
 
 				// Get the merge options
-				include, ok := edge.Properties.Data.(*Include)
+				includes, ok := edge.Properties.Data.([]*Include)
 				if !ok {
 					return fmt.Errorf("task: Failed to get merge options")
 				}
 
-				// Merge the included Taskfile into the parent Taskfile
-				if err := vertex.Taskfile.Merge(
-					includedVertex.Taskfile,
-					include,
-				); err != nil {
-					return err
+				// Merge the included Taskfiles into the parent Taskfile
+				for _, include := range includes {
+					if err := vertex.Taskfile.Merge(
+						includedVertex.Taskfile,
+						include,
+					); err != nil {
+						return err
+					}
 				}
 
 				return nil

--- a/taskfile/ast/graph.go
+++ b/taskfile/ast/graph.go
@@ -3,6 +3,7 @@ package ast
 import (
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/dominikbraun/graph"
 	"github.com/dominikbraun/graph/draw"
@@ -10,6 +11,7 @@ import (
 )
 
 type TaskfileGraph struct {
+	sync.Mutex
 	graph.Graph[string, *TaskfileVertex]
 }
 
@@ -25,6 +27,7 @@ func taskfileHash(vertex *TaskfileVertex) string {
 
 func NewTaskfileGraph() *TaskfileGraph {
 	return &TaskfileGraph{
+		sync.Mutex{},
 		graph.New(taskfileHash,
 			graph.Directed(),
 			graph.PreventCycles(),

--- a/taskfile/ast/include.go
+++ b/taskfile/ast/include.go
@@ -22,7 +22,7 @@ type Include struct {
 
 // Includes represents information about included tasksfiles
 type Includes struct {
-	omap.OrderedMap[string, Include]
+	omap.OrderedMap[string, *Include]
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
@@ -41,7 +41,7 @@ func (includes *Includes) UnmarshalYAML(node *yaml.Node) error {
 				return err
 			}
 			v.Namespace = keyNode.Value
-			includes.Set(keyNode.Value, v)
+			includes.Set(keyNode.Value, &v)
 		}
 		return nil
 	}
@@ -58,7 +58,7 @@ func (includes *Includes) Len() int {
 }
 
 // Wrapper around OrderedMap.Set to ensure we don't get nil pointer errors
-func (includes *Includes) Range(f func(k string, v Include) error) error {
+func (includes *Includes) Range(f func(k string, v *Include) error) error {
 	if includes == nil {
 		return nil
 	}

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -140,6 +140,8 @@ func (r *Reader) include(node Node) error {
 			}
 
 			// Create an edge between the Taskfiles
+			r.graph.Lock()
+			defer r.graph.Unlock()
 			edge, err := r.graph.Edge(node.Location(), includeNode.Location())
 			if err == graph.ErrEdgeNotFound {
 				// If the edge doesn't exist, create it

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -96,11 +96,11 @@ func (r *Reader) include(node Node) error {
 	var g errgroup.Group
 
 	// Loop over each included taskfile
-	_ = vertex.Taskfile.Includes.Range(func(namespace string, include ast.Include) error {
+	_ = vertex.Taskfile.Includes.Range(func(namespace string, include *ast.Include) error {
 		// Start a goroutine to process each included Taskfile
 		g.Go(func() error {
 			cache := &templater.Cache{Vars: vertex.Taskfile.Vars}
-			include = ast.Include{
+			include = &ast.Include{
 				Namespace:      include.Namespace,
 				Taskfile:       templater.Replace(include.Taskfile, cache),
 				Dir:            templater.Replace(include.Dir, cache),

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -147,13 +147,16 @@ func (r *Reader) include(node Node) error {
 					node.Location(),
 					includeNode.Location(),
 					graph.EdgeData([]*ast.Include{include}),
+					graph.EdgeWeight(1),
 				)
 			} else {
 				// If the edge already exists
+				edgeData := append(edge.Properties.Data.([]*ast.Include), include)
 				err = r.graph.UpdateEdge(
 					node.Location(),
 					includeNode.Location(),
-					graph.EdgeData(append(edge.Properties.Data.([]*ast.Include), include)),
+					graph.EdgeData(edgeData),
+					graph.EdgeWeight(len(edgeData)),
 				)
 			}
 			if errors.Is(err, graph.ErrEdgeCreatesCycle) {

--- a/testdata/includes/Taskfile.yml
+++ b/testdata/includes/Taskfile.yml
@@ -6,13 +6,13 @@ includes:
   included_without_dir:
     taskfile:  ./module1
   included_taskfile_without_dir:
-    taskfile:  ./module2/Taskfile.yml
+    taskfile:  ./module1/Taskfile.yml
   included_with_dir:
-    taskfile:  ./module3
-    dir:  ./module3
+    taskfile:  ./module2
+    dir:  ./module2
   included_taskfile_with_dir:
-    taskfile:  ./module4/Taskfile.yml
-    dir:  ./module4
+    taskfile:  ./module2/Taskfile.yml
+    dir:  ./module2
   included_os: ./Taskfile_{{OS}}.yml
 
 tasks:

--- a/testdata/includes/module1/Taskfile.yml
+++ b/testdata/includes/module1/Taskfile.yml
@@ -1,6 +1,10 @@
 version: '3'
 
 tasks:
+  gen_dir:
+    cmds:
+      - echo included_directory_without_dir > included_directory_without_dir.txt
+
   gen_file:
     cmds:
       - echo included_taskfile_without_dir > included_taskfile_without_dir.txt

--- a/testdata/includes/module2/Taskfile.yml
+++ b/testdata/includes/module2/Taskfile.yml
@@ -3,4 +3,8 @@ version: '3'
 tasks:
   gen_dir:
     cmds:
-      - echo included_directory_without_dir > included_directory_without_dir.txt
+      - echo included_directory_with_dir > included_directory_with_dir.txt
+
+  gen_file:
+    cmds:
+      - echo included_taskfile_with_dir > included_taskfile_with_dir.txt

--- a/testdata/includes/module3/Taskfile.yml
+++ b/testdata/includes/module3/Taskfile.yml
@@ -1,6 +1,0 @@
-version: '3'
-
-tasks:
-  gen_file:
-    cmds:
-      - echo included_taskfile_with_dir > included_taskfile_with_dir.txt

--- a/testdata/includes/module4/Taskfile.yml
+++ b/testdata/includes/module4/Taskfile.yml
@@ -1,6 +1,0 @@
-version: '3'
-
-tasks:
-  gen_dir:
-    cmds:
-      - echo included_directory_with_dir > included_directory_with_dir.txt


### PR DESCRIPTION
Fixes #1606

Allows someone to create multiple includes to/from the same Taskfiles. This was restricted when we moved to the DAG reader implementation. The DAG library we use does not support adding multiple edges between nodes. However, the problem is easily solved by changing the edge data from `*ast.Include` to `[]*ast.Include`. This also allows us to easily calculate the weight (number of connections) of any edge by calculating the length of the slice.

I've also undone the changes to some of the tests that used to use multiple includes that were changed when the DAG reader was implemented.