### PR TITLE
feat(remote): replace env variable in include remote URL

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -1200,8 +1200,10 @@ func TestIncludesInterpolation(t *testing.T) {
 		expectedOutput string
 	}{
 		{"include", "include", false, "include\n"},
+		{"include_with_env_variable", "include-with-env-variable", false, "include_with_env_variable\n"},
 		{"include_with_dir", "include-with-dir", false, "included\n"},
 	}
+	t.Setenv("MODULE", "included")
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/taskfile/node_http.go
+++ b/taskfile/node_http.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -29,7 +30,8 @@ func NewHTTPNode(
 	opts ...NodeOption,
 ) (*HTTPNode, error) {
 	base := NewBaseNode(dir, opts...)
-	url, err := url.Parse(entrypoint)
+	entrypointWithEnv := os.ExpandEnv(entrypoint)
+	url, err := url.Parse(entrypointWithEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/taskfile/node_http.go
+++ b/taskfile/node_http.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -30,8 +29,7 @@ func NewHTTPNode(
 	opts ...NodeOption,
 ) (*HTTPNode, error) {
 	base := NewBaseNode(dir, opts...)
-	entrypointWithEnv := os.ExpandEnv(entrypoint)
-	url, err := url.Parse(entrypointWithEnv)
+	url, err := url.Parse(entrypoint)
 	if err != nil {
 		return nil, err
 	}

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -3,6 +3,7 @@ package taskfile
 import (
 	"context"
 	"fmt"
+	"github.com/go-task/task/v3/internal/compiler"
 	"os"
 	"time"
 
@@ -97,9 +98,11 @@ func (r *Reader) include(node Node) error {
 
 	// Loop over each included taskfile
 	_ = vertex.Taskfile.Includes.Range(func(namespace string, include *ast.Include) error {
+		vars := compiler.GetEnviron()
+		vars.Merge(vertex.Taskfile.Vars, nil)
 		// Start a goroutine to process each included Taskfile
 		g.Go(func() error {
-			cache := &templater.Cache{Vars: vertex.Taskfile.Vars}
+			cache := &templater.Cache{Vars: vars}
 			include = &ast.Include{
 				Namespace:      include.Namespace,
 				Taskfile:       templater.Replace(include.Taskfile, cache),

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -3,7 +3,6 @@ package taskfile
 import (
 	"context"
 	"fmt"
-	"github.com/go-task/task/v3/internal/compiler"
 	"os"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/go-task/task/v3/errors"
+	"github.com/go-task/task/v3/internal/compiler"
 	"github.com/go-task/task/v3/internal/filepathext"
 	"github.com/go-task/task/v3/internal/logger"
 	"github.com/go-task/task/v3/internal/templater"

--- a/testdata/includes_interpolation/include_with_env_variable/Taskfile.yml
+++ b/testdata/includes_interpolation/include_with_env_variable/Taskfile.yml
@@ -1,0 +1,4 @@
+version: "3"
+
+includes:
+  include-with-env-variable: '../{{.MODULE}}/Taskfile.yml'

--- a/website/docs/experiments/remote_taskfiles.mdx
+++ b/website/docs/experiments/remote_taskfiles.mdx
@@ -48,13 +48,13 @@ tasks:
 and you run `task my-remote-namespace:hello`, it will print the text: "Hello
 from the remote Taskfile!" to your console.
 
-You can also reference environment variable in your URL to have authentication, for example :
+URL is processed by the templating system, so you can reference environment variable in your URL to have authentication, for example :
 
 ```yaml
 version: '3'
 
 includes:
-  my-remote-namespace: https://${TOKEN}@raw.githubusercontent.com/my-org/my-repo/main/Taskfile.yml
+  my-remote-namespace: https://{{.TOKEN}}@raw.githubusercontent.com/my-org/my-repo/main/Taskfile.yml
 ```
 
 `TOKEN=my-token task my-remote-namespace:hello` will be resolved by Task to `https://my-token@raw.githubusercontent.com/my-org/my-repo/main/Taskfile.yml`

--- a/website/docs/experiments/remote_taskfiles.mdx
+++ b/website/docs/experiments/remote_taskfiles.mdx
@@ -48,6 +48,17 @@ tasks:
 and you run `task my-remote-namespace:hello`, it will print the text: "Hello
 from the remote Taskfile!" to your console.
 
+You can also reference environment variable in your URL to have authentication, for example :
+
+```yaml
+version: '3'
+
+includes:
+  my-remote-namespace: https://${TOKEN}@raw.githubusercontent.com/my-org/my-repo/main/Taskfile.yml
+```
+
+`TOKEN=my-token task my-remote-namespace:hello` will be resolved by Task to `https://my-token@raw.githubusercontent.com/my-org/my-repo/main/Taskfile.yml`
+
 ## Security
 
 Running commands from sources that you do not control is always a potential


### PR DESCRIPTION
I've added the support of env variable in include remote. All env variable presents in the URL (${ENV}) will be replaced.

Related to : https://github.com/go-task/task/discussions/1420#discussioncomment-7752658
