### PR TITLE
Support tilde home directory auto completion and spaces in directories

### DIFF
--- a/completion/zsh/_task
+++ b/completion/zsh/_task
@@ -12,7 +12,9 @@ function __task_list() {
     local taskfile item task desc
 
     cmd=(task)
-    taskfile="${(v)opt_args[(i)-t|--taskfile]}"
+    taskfile=${(Qv)opt_args[(i)-t|--taskfile]}
+    taskfile=${taskfile//\~/$HOME}
+
 
     if [[ -n "$taskfile" && -f "$taskfile" ]]; then
         enabled=1


### PR DESCRIPTION
taskfile specified with ~ are not expanding properly so -f check is failing.
taskfile with "some path/that has paces/Taskfile.yml" does not work because it is being double quoted


and if you want to preserve behavior for parent dir searches, we could also add this snip:
```
+    local curdir

     cmd=(task)
     taskfile=${(Qv)opt_args[(i)-t|--taskfile]}
@@ -19,12 +20,17 @@ function __task_list() {
         enabled=1
         cmd+=(--taskfile "$taskfile")
     else
+      curdir=`pwd`
+      while [ "$enabled" -eq 0 -a `pwd` != '/' ]; do
         for taskfile in {T,t}askfile{,.dist}.{yaml,yml}; do
             if [[ -f "$taskfile" ]]; then
                 enabled=1
                 break
             fi
         done
+        cd ..
```