### PR TITLE
feat: warn about move from any variables to map variables

### DIFF
--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -27,6 +27,7 @@ type Experiment struct {
 var (
 	GentleForce     Experiment
 	RemoteTaskfiles Experiment
+	AnyVariables    Experiment
 	MapVariables    Experiment
 )
 
@@ -34,6 +35,7 @@ func init() {
 	readDotEnv()
 	GentleForce = New("GENTLE_FORCE")
 	RemoteTaskfiles = New("REMOTE_TASKFILES")
+	AnyVariables = New("ANY_VARIABLES", "1", "2")
 	MapVariables = New("MAP_VARIABLES", "1", "2")
 }
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -3,6 +3,7 @@ package flags
 import (
 	"errors"
 	"log"
+	"os"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -68,6 +69,8 @@ var (
 )
 
 func init() {
+	log.SetFlags(0)
+	log.SetOutput(os.Stderr)
 	pflag.Usage = func() {
 		log.Print(usage)
 		pflag.PrintDefaults()

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -138,6 +138,10 @@ func (l *Logger) VerboseErrf(color Color, s string, args ...any) {
 	}
 }
 
+func (l *Logger) Warnf(message string, args ...any) {
+	l.Errf(Yellow, message, args...)
+}
+
 func (l *Logger) Prompt(color Color, prompt string, defaultValue string, continueValues ...string) error {
 	if l.AssumeYes {
 		l.Outf(color, "%s [assuming yes]\n", prompt)


### PR DESCRIPTION
Prints a warning when `TASK_X_ANY_VARIABLES` is set informing the user that it is no longer required. It will pointer users who require map variables to the new `TASX_X_MAP_VARIABLES` experiment instead.