### PR TITLE
feat: task executable variable

### DIFF
--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -196,6 +197,7 @@ func (c *Compiler) ResetCache() {
 func (c *Compiler) getSpecialVars(t *ast.Task) (map[string]string, error) {
 	return map[string]string{
 		"TASK":             t.Task,
+		"TASK_EXE":         filepath.ToSlash(os.Args[0]),
 		"ROOT_TASKFILE":    filepathext.SmartJoin(c.Dir, c.Entrypoint),
 		"ROOT_DIR":         c.Dir,
 		"TASKFILE":         t.Location.Taskfile,


### PR DESCRIPTION
Fixes #1616

I've gone with `TASK_EXE` instead of `TASK_EXECUTABLE` as suggested simply because its a bit shorter. Thoughts welcome.