### PR TITLE
fix: expand task-level dotenv in brackets

### DIFF
--- a/internal/templater/templater.go
+++ b/internal/templater/templater.go
@@ -141,3 +141,11 @@ func ReplaceVarsWithExtra(vars *ast.Vars, cache *Cache, extra map[string]any) *a
 
 	return &newVars
 }
+
+// MergeCacheMap merges a map into the cache
+func (vs *Cache) MergeCacheMap(m map[string]any) {
+	for k, v := range m {
+		vs.cacheMap[k] = v
+	}
+	vs.Vars.MergeCacheMap(vs.cacheMap)
+}

--- a/task_test.go
+++ b/task_test.go
@@ -1563,6 +1563,18 @@ func TestTaskDotenv(t *testing.T) {
 	tt.Run(t)
 }
 
+func TestTaskDotenvWithBrackets(t *testing.T) {
+	tt := fileContentTest{
+		Dir:       "testdata/dotenv_task/default",
+		Target:    "dotenv",
+		TrimSpace: true,
+		Files: map[string]string{
+			"dotenv-2.txt": "foo",
+		},
+	}
+	tt.Run(t)
+}
+
 func TestTaskDotenvFail(t *testing.T) {
 	tt := fileContentTest{
 		Dir:       "testdata/dotenv_task/default",

--- a/task_test.go
+++ b/task_test.go
@@ -1573,6 +1573,26 @@ func TestTaskDotenvWithBrackets(t *testing.T) {
 		},
 	}
 	tt.Run(t)
+
+	tt2 := fileContentTest{
+		Dir:       "testdata/dotenv_task/default",
+		Target:    "dotenv",
+		TrimSpace: true,
+		Files: map[string]string{
+			"dotenv-called.txt": "foo",
+		},
+	}
+	tt2.Run(t)
+
+	tt3 := fileContentTest{
+		Dir:       "testdata/dotenv_task/default",
+		Target:    "dotenv",
+		TrimSpace: true,
+		Files: map[string]string{
+			"dotenv-called-2.txt": "foo",
+		},
+	}
+	tt3.Run(t)
 }
 
 func TestTaskDotenvFail(t *testing.T) {

--- a/taskfile/ast/var.go
+++ b/taskfile/ast/var.go
@@ -36,6 +36,14 @@ func (vs *Vars) ToCacheMap() (m map[string]any) {
 	return
 }
 
+// FromCacheMap converts a map containing only the static variables
+// to Vars
+func (vs *Vars) MergeCacheMap(m map[string]any) {
+	for k, v := range m {
+		vs.Set(k, Var{Value: v})
+	}
+}
+
 // Wrapper around OrderedMap.Set to ensure we don't get nil pointer errors
 func (vs *Vars) Range(f func(k string, v Var) error) error {
 	if vs == nil {

--- a/testdata/dotenv_task/default/Taskfile.yml
+++ b/testdata/dotenv_task/default/Taskfile.yml
@@ -9,6 +9,14 @@ tasks:
     cmds:
       - echo "$FOO" > dotenv.txt
       - echo "{{.FOO}}" > dotenv-2.txt
+      - task: dotenv_called
+        vars:
+          FOO: "{{.FOO}}"
+
+  dotenv_called:
+    cmds:
+      - echo "$FOO" > dotenv-called.txt
+      - echo "{{.FOO}}" > dotenv-called-2.txt
 
   dotenv-overridden-by-env:
     dotenv: ['.env']

--- a/testdata/dotenv_task/default/Taskfile.yml
+++ b/testdata/dotenv_task/default/Taskfile.yml
@@ -8,6 +8,7 @@ tasks:
     dotenv: ['.env']
     cmds:
       - echo "$FOO" > dotenv.txt
+      - echo "{{.FOO}}" > dotenv-2.txt
 
   dotenv-overridden-by-env:
     dotenv: ['.env']

--- a/variables.go
+++ b/variables.go
@@ -125,6 +125,7 @@ func (e *Executor) compiledTask(call *ast.Call, evaluateShVars bool) (*ast.Task,
 			return nil, err
 		}
 	}
+	envCache := new.Env.ToCacheMap()
 
 	if len(origTask.Cmds) > 0 {
 		new.Cmds = make([]*ast.Cmd, 0, len(origTask.Cmds))
@@ -161,7 +162,7 @@ func (e *Executor) compiledTask(call *ast.Call, evaluateShVars bool) (*ast.Task,
 				continue
 			}
 			newCmd := cmd.DeepCopy()
-			newCmd.Cmd = templater.Replace(cmd.Cmd, cache)
+			newCmd.Cmd = templater.ReplaceWithExtra(cmd.Cmd, cache, envCache)
 			newCmd.Task = templater.Replace(cmd.Task, cache)
 			newCmd.Vars = templater.ReplaceVars(cmd.Vars, cache)
 			new.Cmds = append(new.Cmds, newCmd)

--- a/variables.go
+++ b/variables.go
@@ -107,6 +107,7 @@ func (e *Executor) compiledTask(call *ast.Call, evaluateShVars bool) (*ast.Task,
 	new.Env.Merge(templater.ReplaceVars(e.Taskfile.Env, cache), nil)
 	new.Env.Merge(templater.ReplaceVars(dotenvEnvs, cache), nil)
 	new.Env.Merge(templater.ReplaceVars(origTask.Env, cache), nil)
+	new.Env.Merge(templater.ReplaceVars(call.Vars, cache), nil)
 	if evaluateShVars {
 		err = new.Env.Range(func(k string, v ast.Var) error {
 			// If the variable is not dynamic, we can set it and return
@@ -126,6 +127,8 @@ func (e *Executor) compiledTask(call *ast.Call, evaluateShVars bool) (*ast.Task,
 		}
 	}
 	envCache := new.Env.ToCacheMap()
+	// merge envCache with cache
+	cache.MergeCacheMap(envCache)
 
 	if len(origTask.Cmds) > 0 {
 		new.Cmds = make([]*ast.Cmd, 0, len(origTask.Cmds))
@@ -162,7 +165,7 @@ func (e *Executor) compiledTask(call *ast.Call, evaluateShVars bool) (*ast.Task,
 				continue
 			}
 			newCmd := cmd.DeepCopy()
-			newCmd.Cmd = templater.ReplaceWithExtra(cmd.Cmd, cache, envCache)
+			newCmd.Cmd = templater.Replace(cmd.Cmd, cache)
 			newCmd.Task = templater.Replace(cmd.Task, cache)
 			newCmd.Vars = templater.ReplaceVars(cmd.Vars, cache)
 			new.Cmds = append(new.Cmds, newCmd)


### PR DESCRIPTION

Fixes #997

Task level dotenv didn't expand the variables referenced by `{{.var}}` previously This fixes the issue. I added a test for it to prevent the bug from happening again.