### PR TITLE
fix(remote): do not display prompt if it's empty

### DIFF
--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -242,7 +242,7 @@ func (r *Reader) readNode(node Node) (*ast.Taskfile, error) {
 				// If there is a cached hash, but it doesn't match the expected hash, prompt the user to continue
 				prompt = fmt.Sprintf(taskfileChangedPrompt, node.Location())
 			}
-			if prompt == "" {
+			if prompt != "" {
 				if err := r.logger.Prompt(logger.Yellow, prompt, "n", "y", "yes"); err != nil {
 					return nil, &errors.TaskfileNotTrustedError{URI: node.Location()}
 				}


### PR DESCRIPTION
I think there is a bug introduced during the [PR introducing DAG](https://github.com/go-task/task/pull/1563).

The prompt is still displayed when it's empty.

cf : 
![image](https://github.com/go-task/task/assets/9110126/c4fba8a2-23bb-42f9-91ea-d3382d636d6d)
