### PR TITLE
feat(remote): prefix checksums/cached files with the filename

### DIFF
--- a/taskfile/cache.go
+++ b/taskfile/cache.go
@@ -50,9 +50,9 @@ func (c *Cache) key(node Node) string {
 }
 
 func (c *Cache) cacheFilePath(node Node) string {
-	return filepath.Join(c.dir, fmt.Sprintf("%s.yaml", c.key(node)))
+	return filepath.Join(c.dir, fmt.Sprintf("%s.%s.yaml", node.Filename(), c.key(node)))
 }
 
 func (c *Cache) checksumFilePath(node Node) string {
-	return filepath.Join(c.dir, fmt.Sprintf("%s.checksum", c.key(node)))
+	return filepath.Join(c.dir, fmt.Sprintf("%s.%s.checksum", node.Filename(), c.key(node)))
 }

--- a/taskfile/cache.go
+++ b/taskfile/cache.go
@@ -50,9 +50,19 @@ func (c *Cache) key(node Node) string {
 }
 
 func (c *Cache) cacheFilePath(node Node) string {
-	return filepath.Join(c.dir, fmt.Sprintf("%s.%s.yaml", node.Filename(), c.key(node)))
+	return c.filePath(node, "yaml")
 }
 
 func (c *Cache) checksumFilePath(node Node) string {
-	return filepath.Join(c.dir, fmt.Sprintf("%s.%s.checksum", node.Filename(), c.key(node)))
+	return c.filePath(node, "checksum")
+}
+
+func (c *Cache) filePath(node Node, suffix string) string {
+	lastDir, filename := node.FilenameAndLastDir()
+	prefix := filename
+	// Means it's not "", nor "." nor "/", so it's a valid directory
+	if len(lastDir) > 1 {
+		prefix = fmt.Sprintf("%s-%s", lastDir, filename)
+	}
+	return filepath.Join(c.dir, fmt.Sprintf("%s.%s.%s", prefix, c.key(node), suffix))
 }

--- a/taskfile/node.go
+++ b/taskfile/node.go
@@ -20,7 +20,7 @@ type Node interface {
 	Remote() bool
 	ResolveEntrypoint(entrypoint string) (string, error)
 	ResolveDir(dir string) (string, error)
-	Filename() string
+	FilenameAndLastDir() (string, string)
 }
 
 func NewRootNode(

--- a/taskfile/node.go
+++ b/taskfile/node.go
@@ -20,6 +20,7 @@ type Node interface {
 	Remote() bool
 	ResolveEntrypoint(entrypoint string) (string, error)
 	ResolveDir(dir string) (string, error)
+	Filename() string
 }
 
 func NewRootNode(

--- a/taskfile/node_file.go
+++ b/taskfile/node_file.go
@@ -113,6 +113,6 @@ func (node *FileNode) ResolveDir(dir string) (string, error) {
 	return filepathext.SmartJoin(entrypointDir, path), nil
 }
 
-func (node *FileNode) Filename() string {
-	return filepath.Base(node.Entrypoint)
+func (node *FileNode) FilenameAndLastDir() (string, string) {
+	return "", filepath.Base(node.Entrypoint)
 }

--- a/taskfile/node_file.go
+++ b/taskfile/node_file.go
@@ -112,3 +112,7 @@ func (node *FileNode) ResolveDir(dir string) (string, error) {
 	entrypointDir := filepath.Dir(node.Entrypoint)
 	return filepathext.SmartJoin(entrypointDir, path), nil
 }
+
+func (node *FileNode) Filename() string {
+	return filepath.Base(node.Entrypoint)
+}

--- a/taskfile/node_http.go
+++ b/taskfile/node_http.go
@@ -111,6 +111,7 @@ func (node *HTTPNode) ResolveDir(dir string) (string, error) {
 	return filepathext.SmartJoin(entrypointDir, path), nil
 }
 
-func (node *HTTPNode) Filename() string {
-	return filepath.Base(node.URL.Path)
+func (node *HTTPNode) FilenameAndLastDir() (string, string) {
+	dir, filename := filepath.Split(node.URL.Path)
+	return filepath.Base(dir), filename
 }

--- a/taskfile/node_http.go
+++ b/taskfile/node_http.go
@@ -110,3 +110,7 @@ func (node *HTTPNode) ResolveDir(dir string) (string, error) {
 	entrypointDir := filepath.Dir(node.Dir())
 	return filepathext.SmartJoin(entrypointDir, path), nil
 }
+
+func (node *HTTPNode) Filename() string {
+	return filepath.Base(node.URL.Path)
+}

--- a/taskfile/node_stdin.go
+++ b/taskfile/node_stdin.go
@@ -73,6 +73,6 @@ func (node *StdinNode) ResolveDir(dir string) (string, error) {
 	return filepathext.SmartJoin(node.Dir(), path), nil
 }
 
-func (node *StdinNode) Filename() string {
-	return "__stdin__"
+func (node *StdinNode) FilenameAndLastDir() (string, string) {
+	return "", "__stdin__"
 }

--- a/taskfile/node_stdin.go
+++ b/taskfile/node_stdin.go
@@ -72,3 +72,7 @@ func (node *StdinNode) ResolveDir(dir string) (string, error) {
 
 	return filepathext.SmartJoin(node.Dir(), path), nil
 }
+
+func (node *StdinNode) Filename() string {
+	return "__stdin__"
+}


### PR DESCRIPTION
I've introduce a new concept in node, the `filename`. This will allow us to store remote checksums/cached files with a more user-friendly filename

Linked to : 
- https://github.com/go-task/task/issues/1317