### PR TITLE
feat(remote): add a command to clear the cache

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -146,7 +146,7 @@ func run() error {
 	}
 
 	if flags.ClearCache {
-		cache, err := taskfile.NewCache(e.TempDir)
+		cache, err := taskfile.NewCache(e.TempDir.Remote)
 		if err != nil {
 			return err
 		}

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -150,8 +150,7 @@ func run() error {
 		if err != nil {
 			return err
 		}
-		err = cache.Clear()
-		return err
+		return cache.Clear()
 	}
 
 	if (listOptions.ShouldListTasks()) && flags.Silent {

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-task/task/v3/internal/logger"
 	"github.com/go-task/task/v3/internal/sort"
 	ver "github.com/go-task/task/v3/internal/version"
+	"github.com/go-task/task/v3/taskfile"
 	"github.com/go-task/task/v3/taskfile/ast"
 )
 
@@ -125,7 +126,6 @@ func run() error {
 		OutputStyle: flags.Output,
 		TaskSorter:  taskSorter,
 	}
-
 	listOptions := task.NewListOptions(flags.List, flags.ListAll, flags.ListJson, flags.NoStatus)
 	if err := listOptions.Validate(); err != nil {
 		return err
@@ -135,7 +135,6 @@ func run() error {
 	if err != nil {
 		return err
 	}
-
 	if experiments.AnyVariables.Enabled {
 		logger.Warnf("The 'Any Variables' experiment flag is no longer required to use non-map variable types. If you wish to use map variables, please use 'TASK_X_MAP_VARIABLES' instead. See https://github.com/go-task/task/issues/1585\n")
 	}
@@ -144,6 +143,15 @@ func run() error {
 	// taskfile is downloaded
 	if flags.Download {
 		return nil
+	}
+
+	if flags.ClearCache {
+		cache, err := taskfile.NewCache(e.TempDir)
+		if err != nil {
+			return err
+		}
+		err = cache.Clear()
+		return err
 	}
 
 	if (listOptions.ShouldListTasks()) && flags.Silent {

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -65,6 +65,7 @@ var (
 	Experiments bool
 	Download    bool
 	Offline     bool
+	ClearCache  bool
 	Timeout     time.Duration
 )
 
@@ -119,6 +120,7 @@ func init() {
 		pflag.BoolVar(&Download, "download", false, "Downloads a cached version of a remote Taskfile.")
 		pflag.BoolVar(&Offline, "offline", false, "Forces Task to only use local or cached Taskfiles.")
 		pflag.DurationVar(&Timeout, "timeout", time.Second*10, "Timeout for downloading remote Taskfiles.")
+		pflag.BoolVar(&ClearCache, "clear-cache", false, "Clear the remote cache.")
 	}
 
 	pflag.Parse()
@@ -127,6 +129,10 @@ func init() {
 func Validate() error {
 	if Download && Offline {
 		return errors.New("task: You can't set both --download and --offline flags")
+	}
+
+	if Download && ClearCache {
+		return errors.New("task: You can't set both --download and --clear-cache flags")
 	}
 
 	if Global && Dir != "" {

--- a/taskfile/cache.go
+++ b/taskfile/cache.go
@@ -66,3 +66,7 @@ func (c *Cache) filePath(node Node, suffix string) string {
 	}
 	return filepath.Join(c.dir, fmt.Sprintf("%s.%s.%s", prefix, c.key(node), suffix))
 }
+
+func (c *Cache) Clear() error {
+	return os.RemoveAll(c.dir)
+}

--- a/website/docs/experiments/remote_taskfiles.mdx
+++ b/website/docs/experiments/remote_taskfiles.mdx
@@ -106,6 +106,7 @@ internet, you will still be able to run your tasks by specifying the `--offline`
 flag. This will tell Task to use the latest cached version of the file instead
 of trying to download it. You are able to use the `--download` flag to update
 the cached version of the remote files without running any tasks.
+You are able to use the `--clear-cache` flag to clear all cached version of the remote files without running any tasks.
 
 By default, Task will timeout requests to download remote files after 10 seconds
 and look for a cached copy instead. This timeout can be configured by setting


### PR DESCRIPTION
I've added a command to clear the cache for remote files.

I've made the choice to disallow using download and clear-cache at the same time because clear-cache should be used as standalone.

We could allow using both flags at the same time, but we need to define the bahavior : 
- Clear cache override download (so we clear the cache but not download)
- Download override clear cache (so we download but not clear cache)