### PR TITLE
fix: handle int and float env variable by converting them to string

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -13,19 +13,25 @@ func Get(t *ast.Task) []string {
 	}
 
 	environ := os.Environ()
-
 	for k, v := range t.Env.ToCacheMap() {
-		str, isString := v.(string)
-		if !isString {
+		if !isTypeAllowed(v) {
 			continue
 		}
 
 		if _, alreadySet := os.LookupEnv(k); alreadySet {
 			continue
 		}
-
-		environ = append(environ, fmt.Sprintf("%s=%s", k, str))
+		environ = append(environ, fmt.Sprintf("%s=%v", k, v))
 	}
 
 	return environ
+}
+
+func isTypeAllowed(v any) bool {
+	switch v.(type) {
+	case string, int, float32, float64:
+		return true
+	default:
+		return false
+	}
 }

--- a/task_test.go
+++ b/task_test.go
@@ -101,8 +101,9 @@ func TestEnv(t *testing.T) {
 		Target:    "default",
 		TrimSpace: false,
 		Files: map[string]string{
-			"local.txt":  "GOOS='linux' GOARCH='amd64' CGO_ENABLED='0'\n",
-			"global.txt": "FOO='foo' BAR='overriden' BAZ='baz'\n",
+			"local.txt":         "GOOS='linux' GOARCH='amd64' CGO_ENABLED='0'\n",
+			"global.txt":        "FOO='foo' BAR='overriden' BAZ='baz'\n",
+			"multiple_type.txt": "FOO='1' BAR='' BAZ='1.1'\n",
 		},
 	}
 	tt.Run(t)

--- a/testdata/env/Taskfile.yml
+++ b/testdata/env/Taskfile.yml
@@ -14,6 +14,7 @@ tasks:
     cmds:
       - task: local
       - task: global
+      - task: multiple_type
 
   local:
     vars:
@@ -31,3 +32,11 @@ tasks:
       BAR: overriden
     cmds:
       - echo "FOO='$FOO' BAR='$BAR' BAZ='$BAZ'" > global.txt
+
+  multiple_type:
+    env:
+      FOO: 1
+      BAR: true
+      BAZ: 1.1
+    cmds:
+      - echo "FOO='$FOO' BAR='$BAR' BAZ='$BAZ'" > multiple_type.txt


### PR DESCRIPTION
Hey @pd93,

I've tried a solution to fix : 
- https://github.com/go-task/task/issues/1640

It's because since the any vars, some vars are detected as int or float and do not get added to the env map.
So we can let them passthrough and convert them with `%v`

I've also added a test to convert this case