### PR TITLE
fix: Fix schema typos

### DIFF
--- a/website/static/schema.json
+++ b/website/static/schema.json
@@ -648,7 +648,7 @@
           "$ref": "#/definitions/tasks"
         },
         "silent": {
-          "description": "Default 'silent' options for this Taskfile. If `false`, can be overidden with `true` in a task by task basis.",
+          "description": "Default 'silent' options for this Taskfile. If `false`, can be overridden with `true` in a task by task basis.",
           "type": "boolean"
         },
         "set": {

--- a/website/static/schema.json
+++ b/website/static/schema.json
@@ -512,7 +512,7 @@
       "type": "object",
       "properties": {
         "exclude": {
-          "description": "File or glob patter to exclude from the list",
+          "description": "File or glob pattern to exclude from the list",
           "type": "string"
         }
       }


### PR DESCRIPTION
This fixes some typos in the [schema file](https://taskfile.dev/schema.json) that I found when updating at https://github.com/SchemaStore/schemastore/issues/3328.

