### PR TITLE
fix(docs): add references to experiments links

### DIFF
--- a/website/docs/contributing.mdx
+++ b/website/docs/contributing.mdx
@@ -148,6 +148,8 @@ If you have questions, feel free to ask them in the `#help` forum channel on our
 ---
 
 {/* prettier-ignore-start */}
+[experiments]: /experiments
+[experiments-workflow]: /experiments#workflow
 [task]: https://github.com/go-task/task
 [vscode-task]: https://github.com/go-task/vscode-task
 [go]: https://go.dev

--- a/website/versioned_docs/version-latest/contributing.mdx
+++ b/website/versioned_docs/version-latest/contributing.mdx
@@ -148,6 +148,8 @@ If you have questions, feel free to ask them in the `#help` forum channel on our
 ---
 
 {/* prettier-ignore-start */}
+[experiments]: /experiments
+[experiments-workflow]: /experiments#workflow
 [task]: https://github.com/go-task/task
 [vscode-task]: https://github.com/go-task/vscode-task
 [go]: https://go.dev


### PR DESCRIPTION
Add correct references for the links to experiments and experiment workflows in the Contributing page.
[Link to section](https://taskfile.dev/contributing/#before-you-start)

Before:
<img width="975" alt="image" src="https://github.com/go-task/task/assets/32670283/b7313735-5565-4ab7-8ecc-a3a2b6dea27a">


After:
<img width="928" alt="image" src="https://github.com/go-task/task/assets/32670283/35bf888d-3b9f-4422-a109-2cfff197c1ca">

