### PR TITLE
fix: included variable merging

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -1237,6 +1237,34 @@ func TestIncludesInterpolation(t *testing.T) {
 	}
 }
 
+func TestIncludedTaskfileVarMerging(t *testing.T) {
+	const dir = "testdata/included_taskfile_var_merging"
+	tests := []struct {
+		name           string
+		task           string
+		expectedOutput string
+	}{
+		{"foo", "foo:pwd", "included_taskfile_var_merging/foo\n"},
+		{"bar", "bar:pwd", "included_taskfile_var_merging/bar\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var buff bytes.Buffer
+			e := task.Executor{
+				Dir:    dir,
+				Stdout: &buff,
+				Stderr: &buff,
+				Silent: true,
+			}
+			require.NoError(t, e.Setup())
+
+			err := e.Run(context.Background(), &ast.Call{Task: test.task})
+			require.NoError(t, err)
+			assert.Contains(t, buff.String(), test.expectedOutput)
+		})
+	}
+}
+
 func TestInternalTask(t *testing.T) {
 	const dir = "testdata/internal_task"
 	tests := []struct {

--- a/taskfile/ast/tasks.go
+++ b/taskfile/ast/tasks.go
@@ -90,7 +90,7 @@ func (t1 *Tasks) Merge(t2 Tasks, include *Include, includedTaskfileVars *Vars) {
 				task.IncludeVars = &Vars{}
 			}
 			task.IncludeVars.Merge(include.Vars, nil)
-			task.IncludedTaskfileVars = includedTaskfileVars
+			task.IncludedTaskfileVars = includedTaskfileVars.DeepCopy()
 		}
 
 		// Add the task to the merged taskfile

--- a/testdata/included_taskfile_var_merging/Taskfile.yaml
+++ b/testdata/included_taskfile_var_merging/Taskfile.yaml
@@ -1,0 +1,12 @@
+version: "3"
+
+includes:
+  foo:
+    taskfile: ./foo/Taskfile.yaml
+  bar:
+    taskfile: ./bar/Taskfile.yaml
+
+tasks:
+  stub:
+    cmds:
+      - echo 0

--- a/testdata/included_taskfile_var_merging/bar/Taskfile.yaml
+++ b/testdata/included_taskfile_var_merging/bar/Taskfile.yaml
@@ -1,0 +1,11 @@
+version: "3"
+
+vars:
+  DIR: bar
+
+tasks:
+  pwd:
+    dir: ./{{ .DIR }}
+    cmds:
+      - echo "{{ .DIR }}"
+      - pwd

--- a/testdata/included_taskfile_var_merging/foo/Taskfile.yaml
+++ b/testdata/included_taskfile_var_merging/foo/Taskfile.yaml
@@ -1,0 +1,11 @@
+version: "3"
+
+vars:
+  DIR: foo
+
+tasks:
+  pwd:
+    dir: ./{{ .DIR }}
+    cmds:
+      - echo "{{ .DIR }}"
+      - pwd


### PR DESCRIPTION
Fixes #1643 

Small bug with included variable merging when multiple included files use the same variable. This is fixed temporarily by deep copying the variable values. Long term fix for this will be removing merging all together (I'm actively working on this).