### PR TITLE
chore: update actions version because node 16 is deprecated

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,14 +16,14 @@ jobs:
         go-version: [1.21.x, 1.22.x]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{matrix.go-version}}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: v1.55.2
 
@@ -34,7 +34,7 @@ jobs:
         with:
           python-version: 3.12
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: install check-jsonschema
         run: python -m pip install 'check-jsonschema==0.27.3'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ${{matrix.platform}}
     steps:
       - name: Set up Go ${{matrix.go-version}}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{matrix.go-version}}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download Go modules
         run: go mod download

--- a/.github/workflows/upload-source-documents.yml
+++ b/.github/workflows/upload-source-documents.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'go-task/task'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Verify changed files
         id: changed-files
@@ -25,7 +25,7 @@ jobs:
             website/src/pages
 
       - name: Install Task
-        uses: arduino/setup-task@v1
+        uses: arduino/setup-task@v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Node 16 is deprecated so I've bump checkout / setup-go and setup-arduino to the lastest version