### PR TITLE
fix: run once in shared dependencies

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -4,15 +4,12 @@ import (
 	"fmt"
 
 	"github.com/go-task/task/v3/internal/hash"
+	"github.com/go-task/task/v3/internal/slicesext"
 	"github.com/go-task/task/v3/taskfile/ast"
 )
 
 func (e *Executor) GetHash(t *ast.Task) (string, error) {
-	r := t.Run
-	if r == "" {
-		r = e.Taskfile.Run
-	}
-
+	r := slicesext.FirstNonZero(t.Run, e.Taskfile.Run)
 	var h hash.HashFunc
 	switch r {
 	case "always":

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -15,7 +15,7 @@ func Empty(*ast.Task) (string, error) {
 }
 
 func Name(t *ast.Task) (string, error) {
-	return t.Task, nil
+	return fmt.Sprintf("%s:%s", t.Location.Taskfile, t.LocalName()), nil
 }
 
 func Hash(t *ast.Task) (string, error) {

--- a/internal/slicesext/slicesext.go
+++ b/internal/slicesext/slicesext.go
@@ -18,3 +18,13 @@ func UniqueJoin[T cmp.Ordered](ss ...[]T) []T {
 	slices.Sort(r)
 	return slices.Compact(r)
 }
+
+func FirstNonZero[T comparable](values ...T) T {
+	var zero T
+	for _, v := range values {
+		if v != zero {
+			return v
+		}
+	}
+	return zero
+}

--- a/task_test.go
+++ b/task_test.go
@@ -1664,6 +1664,26 @@ func TestRunOnlyRunsJobsHashOnce(t *testing.T) {
 	tt.Run(t)
 }
 
+func TestRunOnceSharedDeps(t *testing.T) {
+	const dir = "testdata/run_once_shared_deps"
+
+	var buff bytes.Buffer
+	e := task.Executor{
+		Dir:      dir,
+		Stdout:   &buff,
+		Stderr:   &buff,
+		ForceAll: true,
+	}
+	require.NoError(t, e.Setup())
+	require.NoError(t, e.Run(context.Background(), &ast.Call{Task: "build"}))
+
+	rx := regexp.MustCompile(`task: \[service-[a,b]:library:build\] echo "build library"`)
+	matches := rx.FindAllStringSubmatch(buff.String(), -1)
+	assert.Len(t, matches, 1)
+	assert.Contains(t, buff.String(), `task: [service-a:build] echo "build a"`)
+	assert.Contains(t, buff.String(), `task: [service-b:build] echo "build b"`)
+}
+
 func TestDeferredCmds(t *testing.T) {
 	const dir = "testdata/deferred"
 	var buff bytes.Buffer

--- a/taskfile/ast/task.go
+++ b/taskfile/ast/task.go
@@ -13,37 +13,39 @@ import (
 
 // Task represents a task
 type Task struct {
-	Task                 string
-	Cmds                 []*Cmd
-	Deps                 []*Dep
-	Label                string
-	Desc                 string
-	Prompt               string
-	Summary              string
-	Requires             *Requires
-	Aliases              []string
-	Sources              []*Glob
-	Generates            []*Glob
-	Status               []string
-	Preconditions        []*Precondition
-	Dir                  string
-	Set                  []string
-	Shopt                []string
-	Vars                 *Vars
-	Env                  *Vars
-	Dotenv               []string
-	Silent               bool
-	Interactive          bool
-	Internal             bool
-	Method               string
-	Prefix               string
-	IgnoreError          bool
-	Run                  string
+	Task          string
+	Cmds          []*Cmd
+	Deps          []*Dep
+	Label         string
+	Desc          string
+	Prompt        string
+	Summary       string
+	Requires      *Requires
+	Aliases       []string
+	Sources       []*Glob
+	Generates     []*Glob
+	Status        []string
+	Preconditions []*Precondition
+	Dir           string
+	Set           []string
+	Shopt         []string
+	Vars          *Vars
+	Env           *Vars
+	Dotenv        []string
+	Silent        bool
+	Interactive   bool
+	Internal      bool
+	Method        string
+	Prefix        string
+	IgnoreError   bool
+	Run           string
+	Platforms     []*Platform
+	Watch         bool
+	Location      *Location
+	// Populated during merging
+	Namespace            string
 	IncludeVars          *Vars
 	IncludedTaskfileVars *Vars
-	Platforms            []*Platform
-	Location             *Location
-	Watch                bool
 }
 
 func (t *Task) Name() string {
@@ -51,6 +53,13 @@ func (t *Task) Name() string {
 		return t.Label
 	}
 	return t.Task
+}
+
+func (t *Task) LocalName() string {
+	name := t.Task
+	name = strings.TrimPrefix(name, t.Namespace)
+	name = strings.TrimPrefix(name, ":")
+	return name
 }
 
 // WildcardMatch will check if the given string matches the name of the Task and returns any wildcard values.
@@ -210,6 +219,7 @@ func (t *Task) DeepCopy() *Task {
 		Platforms:            deepcopy.Slice(t.Platforms),
 		Location:             t.Location.DeepCopy(),
 		Requires:             t.Requires.DeepCopy(),
+		Namespace:            t.Namespace,
 	}
 	return c
 }

--- a/taskfile/ast/tasks.go
+++ b/taskfile/ast/tasks.go
@@ -47,7 +47,7 @@ func (t *Tasks) FindMatchingTasks(call *Call) []*MatchingTask {
 }
 
 func (t1 *Tasks) Merge(t2 Tasks, include *Include, includedTaskfileVars *Vars) {
-	_ = t2.Range(func(k string, v *Task) error {
+	_ = t2.Range(func(name string, v *Task) error {
 		// We do a deep copy of the task struct here to ensure that no data can
 		// be changed elsewhere once the taskfile is merged.
 		task := v.DeepCopy()
@@ -95,7 +95,8 @@ func (t1 *Tasks) Merge(t2 Tasks, include *Include, includedTaskfileVars *Vars) {
 		}
 
 		// Add the task to the merged taskfile
-		taskNameWithNamespace := taskNameWithNamespace(k, include.Namespace)
+		taskNameWithNamespace := taskNameWithNamespace(name, include.Namespace)
+		task.Namespace = include.Namespace
 		task.Task = taskNameWithNamespace
 		t1.Set(taskNameWithNamespace, task)
 

--- a/testdata/run_once_shared_deps/Taskfile.yml
+++ b/testdata/run_once_shared_deps/Taskfile.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+includes:
+  service-a: ./service-a
+  service-b: ./service-b
+
+tasks:
+  build:
+    deps:
+      - service-a:build
+      - service-b:build

--- a/testdata/run_once_shared_deps/library/Taskfile.yml
+++ b/testdata/run_once_shared_deps/library/Taskfile.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+tasks:
+  build:
+    run: once
+    cmds:
+      - echo "build library"
+    sources:
+      - src/**/*

--- a/testdata/run_once_shared_deps/service-a/Taskfile.yml
+++ b/testdata/run_once_shared_deps/service-a/Taskfile.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+includes:
+  library:
+    taskfile: ../library/Taskfile.yml
+    dir: ../library
+
+tasks:
+  build:
+    run: once
+    deps: [library:build]
+    cmds:
+      - echo "build a"
+    sources:
+      - src/**/*

--- a/testdata/run_once_shared_deps/service-a/src/imasource.go
+++ b/testdata/run_once_shared_deps/service-a/src/imasource.go
@@ -1,0 +1,1 @@
+package main

--- a/testdata/run_once_shared_deps/service-b/Taskfile.yml
+++ b/testdata/run_once_shared_deps/service-b/Taskfile.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+includes:
+  library:
+    taskfile: ../library/Taskfile.yml
+    dir: ../library
+
+tasks:
+  build:
+    run: once
+    deps: [library:build]
+    cmds:
+      - echo "build b"
+    sources:
+      - src/**/*

--- a/testdata/run_once_shared_deps/service-b/src/imasource.go
+++ b/testdata/run_once_shared_deps/service-b/src/imasource.go
@@ -1,0 +1,1 @@
+package main

--- a/variables.go
+++ b/variables.go
@@ -72,6 +72,7 @@ func (e *Executor) compiledTask(call *ast.Call, evaluateShVars bool) (*ast.Task,
 		Location:             origTask.Location,
 		Requires:             origTask.Requires,
 		Watch:                origTask.Watch,
+		Namespace:            origTask.Namespace,
 	}
 	new.Dir, err = execext.Expand(new.Dir)
 	if err != nil {


### PR DESCRIPTION
Fixes #852

This PR changes the hash we use when a task is marked as `run:once`. Previously we used the full name of the task. This is fine most of the time, but when a task in an included Taskfile is included multiple times, the name will contain a namespace that is different for each task. Using the example given in #852, the hashes produced are:

```
service-a:build
service-b:build
service-b:library:build #  <-- this...
service-a:library:build #  <-- is different to this
```

As a result `library:build` is run twice, even though it is marked as `run: once`.

In this PR, we are creating a hash that is a combination of the file location and the name of the task _without a namespace_. This means that the hash is unique for each task, but will be the same when a task is included in different namespaces.

```
/path/to/project/service-a/Taskfile.yml:build
/path/to/project/service-b/Taskfile.yml:build
/path/to/project/library/Taskfile.yml:library:build  <-- this...
/path/to/project/library/Taskfile.yml:library:build  <-- is the same as this
```

---

> [!NOTE]  
> As discussed below, we're no longer focussing on the second problem in this PR. We're open to further discussion in another issue for anyone coming across this in the future.

#852 mentions a secondary problem:

> We also noticed that if we run a "task build" in service-a and then service-b that the `.task/` checksum cache is not shared and so the library is built twice.

You can see this illustrated below:

```sh
❯ task build   
task: [service-a:library:build] echo "build library" # <-- first run - library builds
build library
task: [service-b:build] echo "build b" # <-- library is run:once so service-b doesn't build it again
task: [service-a:build] echo "build a"
build a
build b
```

```sh
❯ task build
task: Task "service-a:library:build" is up to date # <-- second run - library is up to date so doesn't build
task: Task "service-a:build" is up to date
task: Task "service-b:build" is up to date
```

```sh
❯ task build
task: [service-b:library:build] echo "build library" 
# ^ service-b goes first this time (because the order of deps is non-deterministic)
# but it doesn't share a hash with service-a so it builds the library again
build library
task: Task "service-b:build" is up to date
task: Task "service-a:build" is up to date
```

We need to determine the correct behaviour:

1. Working as intended - Tasks should always have independent caches as even shared tasks can have different outputs depending on the context. The fact that the library is built again sometimes is a side effect of the non-deterministic order of the tasks.
1. Always share a cache between shared tasks - This seems dangerous as variables that are passed into a task can change its output. This might lead to a task not running when it should.
1. Share a cache when `run: once` is specified - This still has the same problem as above. However, you could argue that the user has made a mistake by adding `run: once` when the result of a task could be different depending on the context.

If we choose 2 or 3, then what should the task hash be?

- `<location>:service-a:build` (probably not)
- `<location>:service-b:build` (also probably not)
- Some combination of the two
- Something else entirely?

I would appreciate any thoughts/feedback on these options - or other options entirely.