### PR TITLE
feat: improved prompt and release task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -123,10 +123,53 @@ tasks:
     cmds:
       - go install github.com/goreleaser/goreleaser@latest
 
-  release:
+  release:*:
     desc: Prepare the project for a new release
+    summary: |
+      This task will do the following:
+
+      - Update the version and date in the CHANGELOG.md file
+      - Update the version in the package.json and package-lock.json files
+      - Copy the latest docs to the "current" version on the website
+      - Commit the changes
+      - Create a new tag
+      - Push the commit/tag to the repository
+      - Create a GitHub release
+
+      To use the task, simply run "task release:<version>" where "<version>" is is one of:
+
+      - "major" - Bumps the major number
+      - "minor" - Bumps the minor number
+      - "patch" - Bumps the patch number
+      - A semver compatible version number (e.g. "1.2.3")
+    vars:
+      VERSION:
+        sh: "go run ./cmd/release --version {{index .MATCH 0}}"
+      COMPLETE_MESSAGE: |
+        Creating release with GoReleaser: https://github.com/go-task/task/actions/workflows/release.yml
+
+        Please wait for the CI to finish and then do the following:
+
+        - Copy the changelog for v{{.VERSION}} to the GitHub release
+        - Publish the package to NPM with `task npm:publish`
+        - Update and push the snapcraft manifest in https://github.com/go-task/snap/blob/main/snap/snapcraft.yaml
+    preconditions:
+      - sh: test $(git rev-parse --abbrev-ref HEAD) = "main"
+        msg: "You must be on the main branch to release"
+      - sh: "[[ -z $(git diff --shortstat main) ]]"
+        msg: "You must have a clean working tree to release"
+    prompt: "Are you sure you want to release version {{.VERSION}}?"
     cmds:
-      - go run ./cmd/release {{.CLI_ARGS}}
+      - cmd: echo "Releasing v{{.VERSION}}"
+        silent: true
+      - "go run ./cmd/release {{.VERSION}}"
+      - "git add --all"
+      - "git commit -m v{{.VERSION}}"
+      - "git push"
+      - "git tag v{{.VERSION}}"
+      - "git push origin tag v{{.VERSION}}"
+      - cmd: printf "%s" '{{.COMPLETE_MESSAGE}}'
+        silent: true
 
   npm:publish:
     desc: Publish release to npm

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/otiai10/copy"
+	"github.com/spf13/pflag"
 )
 
 const (
@@ -25,6 +26,16 @@ var (
 	versionRegex          = regexp.MustCompile(`(?m)^  "version": "\d+\.\d+\.\d+",$`)
 )
 
+// Flags
+var (
+	versionFlag bool
+)
+
+func init() {
+	pflag.BoolVarP(&versionFlag, "version", "v", false, "resolved version number")
+	pflag.Parse()
+}
+
 func main() {
 	if err := release(); err != nil {
 		fmt.Println(err)
@@ -33,7 +44,7 @@ func main() {
 }
 
 func release() error {
-	if len(os.Args) != 2 {
+	if len(pflag.Args()) != 1 {
 		return errors.New("error: expected version number")
 	}
 
@@ -42,11 +53,14 @@ func release() error {
 		return err
 	}
 
-	if err := bumpVersion(version, os.Args[1]); err != nil {
+	if err := bumpVersion(version, pflag.Arg(0)); err != nil {
 		return err
 	}
 
-	fmt.Println(version)
+	if versionFlag {
+		fmt.Println(version)
+		return nil
+	}
 
 	if err := changelog(version); err != nil {
 		return err

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -156,7 +156,7 @@ func (l *Logger) Prompt(color Color, prompt string, defaultValue string, continu
 		return errors.New("no continue values provided")
 	}
 
-	l.Outf(color, "%s [%s/%s]\n", prompt, strings.ToLower(continueValues[0]), strings.ToUpper(defaultValue))
+	l.Outf(color, "%s [%s/%s]: ", prompt, strings.ToLower(continueValues[0]), strings.ToUpper(defaultValue))
 
 	reader := bufio.NewReader(l.Stdin)
 	input, err := reader.ReadString('\n')

--- a/task.go
+++ b/task.go
@@ -228,7 +228,7 @@ func (e *Executor) RunTask(ctx context.Context, call *ast.Call) error {
 			}
 		}
 
-		if t.Prompt != "" {
+		if t.Prompt != "" && !e.Dry {
 			if err := e.Logger.Prompt(logger.Yellow, t.Prompt, "n", "y", "yes"); errors.Is(err, logger.ErrNoTerminal) {
 				return &errors.TaskCancelledNoTerminalError{TaskName: call.Task}
 			} else if errors.Is(err, logger.ErrPromptCancelled) {

--- a/task.go
+++ b/task.go
@@ -183,16 +183,6 @@ func (e *Executor) RunTask(ctx context.Context, call *ast.Call) error {
 	release := e.acquireConcurrencyLimit()
 	defer release()
 
-	if t.Prompt != "" {
-		if err := e.Logger.Prompt(logger.Yellow, t.Prompt, "n", "y", "yes"); errors.Is(err, logger.ErrNoTerminal) {
-			return &errors.TaskCancelledNoTerminalError{TaskName: call.Task}
-		} else if errors.Is(err, logger.ErrPromptCancelled) {
-			return &errors.TaskCancelledByUserError{TaskName: call.Task}
-		} else if err != nil {
-			return err
-		}
-	}
-
 	return e.startExecution(ctx, t, func(ctx context.Context) error {
 		e.Logger.VerboseErrf(logger.Magenta, "task: %q started\n", call.Task)
 		if err := e.runDeps(ctx, t); err != nil {
@@ -235,6 +225,16 @@ func (e *Executor) RunTask(ctx context.Context, call *ast.Call) error {
 					e.Logger.Errf(logger.Magenta, "task: Task %q is up to date\n", t.Name())
 				}
 				return nil
+			}
+		}
+
+		if t.Prompt != "" {
+			if err := e.Logger.Prompt(logger.Yellow, t.Prompt, "n", "y", "yes"); errors.Is(err, logger.ErrNoTerminal) {
+				return &errors.TaskCancelledNoTerminalError{TaskName: call.Task}
+			} else if errors.Is(err, logger.ErrPromptCancelled) {
+				return &errors.TaskCancelledByUserError{TaskName: call.Task}
+			} else if err != nil {
+				return err
 			}
 		}
 

--- a/website/static/schema.json
+++ b/website/static/schema.json
@@ -496,7 +496,8 @@
           "description": "Failure message to display when the condition fails",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "glob": {
       "anyOf": [
@@ -515,7 +516,8 @@
           "description": "File or glob pattern to exclude from the list",
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "run": {
       "type": "string",
@@ -545,7 +547,8 @@
             }
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "requires_obj": {
       "type": "object",
@@ -557,7 +560,8 @@
             "type": "string"
           }
         }
-      }
+      },
+      "additionalProperties": false
     }
   },
   "allOf": [


### PR DESCRIPTION
This PR does a few things - mostly as I found a few issues while creating an improved release task:

- Added missing `additionalProperties: false` keys in `schema.json`
- Moved prompt check after preconditions and fingerprinting
  - Annoying to be prompted if the task will be stopped anyway
- Stop prompt from showing if `--dry` flag is enabled
  - Again, no value to having a prompt if the task won't execute anyway
- Removed `\n` from prompt message so that the response is on the same line instead of by itself
  - Just a visual thing really. Looks a bit nicer
- **A significantly improved release tool**
  - Uses wildcards (e.g. `task release:patch` instead of `task release -- patch`)
  - Lots of docs to help in the `--summary` and printed after the task completes
  - Prompt and preconditions to make sure it's not run accidentally.
