### PR TITLE
feat(remote): global tempDir when the path is absolute

### DIFF
--- a/help.go
+++ b/help.go
@@ -190,7 +190,7 @@ func (e *Executor) ToEditorOutput(tasks []*ast.Task, noStatus bool) (*editors.Ta
 			}
 			upToDate, err := fingerprint.IsTaskUpToDate(context.Background(), task,
 				fingerprint.WithMethod(method),
-				fingerprint.WithTempDir(e.TempDir.Checksum),
+				fingerprint.WithTempDir(e.TempDir.Fingerprint),
 				fingerprint.WithDry(e.Dry),
 				fingerprint.WithLogger(e.Logger),
 			)

--- a/help.go
+++ b/help.go
@@ -190,7 +190,7 @@ func (e *Executor) ToEditorOutput(tasks []*ast.Task, noStatus bool) (*editors.Ta
 			}
 			upToDate, err := fingerprint.IsTaskUpToDate(context.Background(), task,
 				fingerprint.WithMethod(method),
-				fingerprint.WithTempDir(e.TempDir),
+				fingerprint.WithTempDir(e.TempDir.Checksum),
 				fingerprint.WithDry(e.Dry),
 				fingerprint.WithLogger(e.Logger),
 			)

--- a/setup.go
+++ b/setup.go
@@ -133,11 +133,15 @@ func (e *Executor) setupTempDir() error {
 	}
 
 	if os.Getenv("TASK_REMOTE_DIR") != "" {
-		remoteTempDir, err := execext.Expand(os.Getenv("TASK_REMOTE_DIR"))
-		if err != nil {
-			return err
+		if filepath.IsAbs(os.Getenv("TASK_TEMP_DIR")) || strings.HasPrefix(os.Getenv("TASK_TEMP_DIR"), "~") {
+			remoteTempDir, err := execext.Expand(filepathext.SmartJoin(e.Dir, ".task"))
+			if err != nil {
+				return err
+			}
+			e.TempDir.Remote = remoteTempDir
+		} else {
+			e.TempDir.Remote = filepathext.SmartJoin(e.Dir, ".task")
 		}
-		e.TempDir.Remote = remoteTempDir
 	}
 
 	return nil

--- a/setup.go
+++ b/setup.go
@@ -104,7 +104,7 @@ func (e *Executor) setupFuzzyModel() {
 }
 
 func (e *Executor) setupTempDir() error {
-	if &e.TempDir == nil {
+	if e.TempDir != (TempDir{}) {
 		return nil
 	}
 

--- a/setup.go
+++ b/setup.go
@@ -110,8 +110,8 @@ func (e *Executor) setupTempDir() error {
 
 	if os.Getenv("TASK_TEMP_DIR") == "" {
 		e.TempDir = TempDir{
-			Remote:   filepathext.SmartJoin(e.Dir, ".task"),
-			Checksum: filepathext.SmartJoin(e.Dir, ".task"),
+			Remote:      filepathext.SmartJoin(e.Dir, ".task"),
+			Fingerprint: filepathext.SmartJoin(e.Dir, ".task"),
 		}
 	} else if filepath.IsAbs(os.Getenv("TASK_TEMP_DIR")) || strings.HasPrefix(os.Getenv("TASK_TEMP_DIR"), "~") {
 		tempDir, err := execext.Expand(os.Getenv("TASK_TEMP_DIR"))
@@ -121,14 +121,14 @@ func (e *Executor) setupTempDir() error {
 		projectDir, _ := filepath.Abs(e.Dir)
 		projectName := filepath.Base(projectDir)
 		e.TempDir = TempDir{
-			Remote:   tempDir,
-			Checksum: filepathext.SmartJoin(tempDir, projectName),
+			Remote:      tempDir,
+			Fingerprint: filepathext.SmartJoin(tempDir, projectName),
 		}
 
 	} else {
 		e.TempDir = TempDir{
-			Remote:   filepathext.SmartJoin(e.Dir, os.Getenv("TASK_TEMP_DIR")),
-			Checksum: filepathext.SmartJoin(e.Dir, os.Getenv("TASK_TEMP_DIR")),
+			Remote:      filepathext.SmartJoin(e.Dir, os.Getenv("TASK_TEMP_DIR")),
+			Fingerprint: filepathext.SmartJoin(e.Dir, os.Getenv("TASK_TEMP_DIR")),
 		}
 	}
 

--- a/setup.go
+++ b/setup.go
@@ -132,6 +132,14 @@ func (e *Executor) setupTempDir() error {
 		}
 	}
 
+	if os.Getenv("TASK_REMOTE_DIR") != "" {
+		remoteTempDir, err := execext.Expand(os.Getenv("TASK_REMOTE_DIR"))
+		if err != nil {
+			return err
+		}
+		e.TempDir.Remote = remoteTempDir
+	}
+
 	return nil
 }
 

--- a/status.go
+++ b/status.go
@@ -27,7 +27,7 @@ func (e *Executor) Status(ctx context.Context, calls ...*ast.Call) error {
 		// Check if the task is up-to-date
 		isUpToDate, err := fingerprint.IsTaskUpToDate(ctx, t,
 			fingerprint.WithMethod(method),
-			fingerprint.WithTempDir(e.TempDir),
+			fingerprint.WithTempDir(e.TempDir.Checksum),
 			fingerprint.WithDry(e.Dry),
 			fingerprint.WithLogger(e.Logger),
 		)
@@ -46,7 +46,7 @@ func (e *Executor) statusOnError(t *ast.Task) error {
 	if method == "" {
 		method = e.Taskfile.Method
 	}
-	checker, err := fingerprint.NewSourcesChecker(method, e.TempDir, e.Dry)
+	checker, err := fingerprint.NewSourcesChecker(method, e.TempDir.Checksum, e.Dry)
 	if err != nil {
 		return err
 	}

--- a/status.go
+++ b/status.go
@@ -27,7 +27,7 @@ func (e *Executor) Status(ctx context.Context, calls ...*ast.Call) error {
 		// Check if the task is up-to-date
 		isUpToDate, err := fingerprint.IsTaskUpToDate(ctx, t,
 			fingerprint.WithMethod(method),
-			fingerprint.WithTempDir(e.TempDir.Checksum),
+			fingerprint.WithTempDir(e.TempDir.Fingerprint),
 			fingerprint.WithDry(e.Dry),
 			fingerprint.WithLogger(e.Logger),
 		)
@@ -46,7 +46,7 @@ func (e *Executor) statusOnError(t *ast.Task) error {
 	if method == "" {
 		method = e.Taskfile.Method
 	}
-	checker, err := fingerprint.NewSourcesChecker(method, e.TempDir.Checksum, e.Dry)
+	checker, err := fingerprint.NewSourcesChecker(method, e.TempDir.Fingerprint, e.Dry)
 	if err != nil {
 		return err
 	}

--- a/task.go
+++ b/task.go
@@ -34,13 +34,18 @@ const (
 	MaximumTaskCall = 1000
 )
 
+type TempDir struct {
+	Remote   string
+	Checksum string
+}
+
 // Executor executes a Taskfile
 type Executor struct {
 	Taskfile *ast.Taskfile
 
 	Dir         string
 	Entrypoint  string
-	TempDir     string
+	TempDir     TempDir
 	Force       bool
 	ForceAll    bool
 	Insecure    bool
@@ -212,7 +217,7 @@ func (e *Executor) RunTask(ctx context.Context, call *ast.Call) error {
 
 			upToDate, err := fingerprint.IsTaskUpToDate(ctx, t,
 				fingerprint.WithMethod(method),
-				fingerprint.WithTempDir(e.TempDir),
+				fingerprint.WithTempDir(e.TempDir.Checksum),
 				fingerprint.WithDry(e.Dry),
 				fingerprint.WithLogger(e.Logger),
 			)

--- a/task.go
+++ b/task.go
@@ -35,8 +35,8 @@ const (
 )
 
 type TempDir struct {
-	Remote   string
-	Checksum string
+	Remote      string
+	Fingerprint string
 }
 
 // Executor executes a Taskfile
@@ -217,7 +217,7 @@ func (e *Executor) RunTask(ctx context.Context, call *ast.Call) error {
 
 			upToDate, err := fingerprint.IsTaskUpToDate(ctx, t,
 				fingerprint.WithMethod(method),
-				fingerprint.WithTempDir(e.TempDir.Checksum),
+				fingerprint.WithTempDir(e.TempDir.Fingerprint),
 				fingerprint.WithDry(e.Dry),
 				fingerprint.WithLogger(e.Logger),
 			)

--- a/task_test.go
+++ b/task_test.go
@@ -62,8 +62,11 @@ func (fct fileContentTest) Run(t *testing.T) {
 	}
 
 	e := &task.Executor{
-		Dir:        fct.Dir,
-		TempDir:    filepathext.SmartJoin(fct.Dir, ".task"),
+		Dir: fct.Dir,
+		TempDir: task.TempDir{
+			Remote:   filepathext.SmartJoin(fct.Dir, ".task"),
+			Checksum: filepathext.SmartJoin(fct.Dir, ".task"),
+		},
 		Entrypoint: fct.Entrypoint,
 		Stdout:     io.Discard,
 		Stderr:     io.Discard,
@@ -272,11 +275,14 @@ func TestStatus(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := &task.Executor{
-		Dir:     dir,
-		TempDir: filepathext.SmartJoin(dir, ".task"),
-		Stdout:  &buff,
-		Stderr:  &buff,
-		Silent:  true,
+		Dir: dir,
+		TempDir: task.TempDir{
+			Remote:   filepathext.SmartJoin(dir, ".task"),
+			Checksum: filepathext.SmartJoin(dir, ".task"),
+		},
+		Stdout: &buff,
+		Stderr: &buff,
+		Silent: true,
 	}
 	require.NoError(t, e.Setup())
 	// gen-foo creates foo.txt, and will always fail it's status check.
@@ -468,7 +474,10 @@ func TestStatusChecksum(t *testing.T) {
 			}
 
 			var buff bytes.Buffer
-			tempdir := filepathext.SmartJoin(dir, ".task")
+			tempdir := task.TempDir{
+				Remote:   filepathext.SmartJoin(dir, ".task"),
+				Checksum: filepathext.SmartJoin(dir, ".task"),
+			}
 			e := task.Executor{
 				Dir:     dir,
 				TempDir: tempdir,
@@ -485,7 +494,7 @@ func TestStatusChecksum(t *testing.T) {
 
 			// Capture the modification time, so we can ensure the checksum file
 			// is not regenerated when the hash hasn't changed.
-			s, err := os.Stat(filepathext.SmartJoin(tempdir, "checksum/"+test.task))
+			s, err := os.Stat(filepathext.SmartJoin(tempdir.Checksum, "checksum/"+test.task))
 			require.NoError(t, err)
 			time := s.ModTime()
 
@@ -493,7 +502,7 @@ func TestStatusChecksum(t *testing.T) {
 			require.NoError(t, e.Run(context.Background(), &ast.Call{Task: test.task}))
 			assert.Equal(t, `task: Task "`+test.task+`" is up to date`+"\n", buff.String())
 
-			s, err = os.Stat(filepathext.SmartJoin(tempdir, "checksum/"+test.task))
+			s, err = os.Stat(filepathext.SmartJoin(tempdir.Checksum, "checksum/"+test.task))
 			require.NoError(t, err)
 			assert.Equal(t, time, s.ModTime())
 		})
@@ -814,8 +823,11 @@ func TestStatusVariables(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.Executor{
-		Dir:     dir,
-		TempDir: filepathext.SmartJoin(dir, ".task"),
+		Dir: dir,
+		TempDir: task.TempDir{
+			Remote:   filepathext.SmartJoin(dir, ".task"),
+			Checksum: filepathext.SmartJoin(dir, ".task"),
+		},
 		Stdout:  &buff,
 		Stderr:  &buff,
 		Silent:  false,
@@ -963,11 +975,14 @@ func TestDryChecksum(t *testing.T) {
 	_ = os.Remove(checksumFile)
 
 	e := task.Executor{
-		Dir:     dir,
-		TempDir: filepathext.SmartJoin(dir, ".task"),
-		Stdout:  io.Discard,
-		Stderr:  io.Discard,
-		Dry:     true,
+		Dir: dir,
+		TempDir: task.TempDir{
+			Remote:   filepathext.SmartJoin(dir, ".task"),
+			Checksum: filepathext.SmartJoin(dir, ".task"),
+		},
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+		Dry:    true,
 	}
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &ast.Call{Task: "default"}))

--- a/task_test.go
+++ b/task_test.go
@@ -64,8 +64,8 @@ func (fct fileContentTest) Run(t *testing.T) {
 	e := &task.Executor{
 		Dir: fct.Dir,
 		TempDir: task.TempDir{
-			Remote:   filepathext.SmartJoin(fct.Dir, ".task"),
-			Checksum: filepathext.SmartJoin(fct.Dir, ".task"),
+			Remote:      filepathext.SmartJoin(fct.Dir, ".task"),
+			Fingerprint: filepathext.SmartJoin(fct.Dir, ".task"),
 		},
 		Entrypoint: fct.Entrypoint,
 		Stdout:     io.Discard,
@@ -277,8 +277,8 @@ func TestStatus(t *testing.T) {
 	e := &task.Executor{
 		Dir: dir,
 		TempDir: task.TempDir{
-			Remote:   filepathext.SmartJoin(dir, ".task"),
-			Checksum: filepathext.SmartJoin(dir, ".task"),
+			Remote:      filepathext.SmartJoin(dir, ".task"),
+			Fingerprint: filepathext.SmartJoin(dir, ".task"),
 		},
 		Stdout: &buff,
 		Stderr: &buff,
@@ -475,8 +475,8 @@ func TestStatusChecksum(t *testing.T) {
 
 			var buff bytes.Buffer
 			tempdir := task.TempDir{
-				Remote:   filepathext.SmartJoin(dir, ".task"),
-				Checksum: filepathext.SmartJoin(dir, ".task"),
+				Remote:      filepathext.SmartJoin(dir, ".task"),
+				Fingerprint: filepathext.SmartJoin(dir, ".task"),
 			}
 			e := task.Executor{
 				Dir:     dir,
@@ -494,7 +494,7 @@ func TestStatusChecksum(t *testing.T) {
 
 			// Capture the modification time, so we can ensure the checksum file
 			// is not regenerated when the hash hasn't changed.
-			s, err := os.Stat(filepathext.SmartJoin(tempdir.Checksum, "checksum/"+test.task))
+			s, err := os.Stat(filepathext.SmartJoin(tempdir.Fingerprint, "checksum/"+test.task))
 			require.NoError(t, err)
 			time := s.ModTime()
 
@@ -502,7 +502,7 @@ func TestStatusChecksum(t *testing.T) {
 			require.NoError(t, e.Run(context.Background(), &ast.Call{Task: test.task}))
 			assert.Equal(t, `task: Task "`+test.task+`" is up to date`+"\n", buff.String())
 
-			s, err = os.Stat(filepathext.SmartJoin(tempdir.Checksum, "checksum/"+test.task))
+			s, err = os.Stat(filepathext.SmartJoin(tempdir.Fingerprint, "checksum/"+test.task))
 			require.NoError(t, err)
 			assert.Equal(t, time, s.ModTime())
 		})
@@ -825,8 +825,8 @@ func TestStatusVariables(t *testing.T) {
 	e := task.Executor{
 		Dir: dir,
 		TempDir: task.TempDir{
-			Remote:   filepathext.SmartJoin(dir, ".task"),
-			Checksum: filepathext.SmartJoin(dir, ".task"),
+			Remote:      filepathext.SmartJoin(dir, ".task"),
+			Fingerprint: filepathext.SmartJoin(dir, ".task"),
 		},
 		Stdout:  &buff,
 		Stderr:  &buff,
@@ -977,8 +977,8 @@ func TestDryChecksum(t *testing.T) {
 	e := task.Executor{
 		Dir: dir,
 		TempDir: task.TempDir{
-			Remote:   filepathext.SmartJoin(dir, ".task"),
-			Checksum: filepathext.SmartJoin(dir, ".task"),
+			Remote:      filepathext.SmartJoin(dir, ".task"),
+			Fingerprint: filepathext.SmartJoin(dir, ".task"),
 		},
 		Stdout: io.Discard,
 		Stderr: io.Discard,

--- a/variables.go
+++ b/variables.go
@@ -221,8 +221,8 @@ func (e *Executor) compiledTask(call *ast.Call, evaluateShVars bool) (*ast.Task,
 	}
 
 	if len(origTask.Status) > 0 {
-		timestampChecker := fingerprint.NewTimestampChecker(e.TempDir, e.Dry)
-		checksumChecker := fingerprint.NewChecksumChecker(e.TempDir, e.Dry)
+		timestampChecker := fingerprint.NewTimestampChecker(e.TempDir.Checksum, e.Dry)
+		checksumChecker := fingerprint.NewChecksumChecker(e.TempDir.Checksum, e.Dry)
 
 		for _, checker := range []fingerprint.SourcesCheckable{timestampChecker, checksumChecker} {
 			value, err := checker.Value(&new)

--- a/variables.go
+++ b/variables.go
@@ -221,8 +221,8 @@ func (e *Executor) compiledTask(call *ast.Call, evaluateShVars bool) (*ast.Task,
 	}
 
 	if len(origTask.Status) > 0 {
-		timestampChecker := fingerprint.NewTimestampChecker(e.TempDir.Checksum, e.Dry)
-		checksumChecker := fingerprint.NewChecksumChecker(e.TempDir.Checksum, e.Dry)
+		timestampChecker := fingerprint.NewTimestampChecker(e.TempDir.Fingerprint, e.Dry)
+		checksumChecker := fingerprint.NewChecksumChecker(e.TempDir.Fingerprint, e.Dry)
 
 		for _, checker := range []fingerprint.SourcesCheckable{timestampChecker, checksumChecker} {
 			value, err := checker.Value(&new)

--- a/website/docs/experiments/remote_taskfiles.mdx
+++ b/website/docs/experiments/remote_taskfiles.mdx
@@ -112,7 +112,12 @@ and look for a cached copy instead. This timeout can be configured by setting
 the `--timeout` flag and specifying a duration. For example, `--timeout 5s` will
 set the timeout to 5 seconds.
 
+By default, the cache is stored in the Task temp directory, represented by the `TASK_TEMP_DIR` [environment variable](../reference/environment.mdx)
+You can override the location of the cache by setting the `TASK_REMOTE_DIR` environment variable. This way, you can share the cache between different projects.
+
+
 {/* prettier-ignore-start */}
 [enabling-experiments]: ./experiments.mdx#enabling-experiments
 [man-in-the-middle-attacks]: https://en.wikipedia.org/wiki/Man-in-the-middle_attack
 {/* prettier-ignore-end */}
+

--- a/website/docs/experiments/remote_taskfiles.mdx
+++ b/website/docs/experiments/remote_taskfiles.mdx
@@ -115,9 +115,7 @@ set the timeout to 5 seconds.
 By default, the cache is stored in the Task temp directory, represented by the `TASK_TEMP_DIR` [environment variable](../reference/environment.mdx)
 You can override the location of the cache by setting the `TASK_REMOTE_DIR` environment variable. This way, you can share the cache between different projects.
 
-
 {/* prettier-ignore-start */}
 [enabling-experiments]: ./experiments.mdx#enabling-experiments
 [man-in-the-middle-attacks]: https://en.wikipedia.org/wiki/Man-in-the-middle_attack
 {/* prettier-ignore-end */}
-

--- a/website/docs/reference/environment.mdx
+++ b/website/docs/reference/environment.mdx
@@ -8,10 +8,11 @@ sidebar_position: 4
 Task allows you to configure some behavior using environment variables. This
 page lists all the environment variables that Task supports.
 
-| ENV             | Default | Description                                                                                                       |
-| --------------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
-| `TASK_TEMP_DIR` | `.task` | Location of the temp dir. Can relative to the project like `tmp/task` or absolute like `/tmp/.task` or `~/.task`. |
-| `FORCE_COLOR`   |         | Force color output usage.                                                                                         |
+| ENV               | Default | Description                                                                                                                                         |
+| ----------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TASK_TEMP_DIR`   | `.task`         | Location of the temp dir. Can relative to the project like `tmp/task` or absolute like `/tmp/.task` or `~/.task`.                           |
+| `TASK_REMOTE_DIR` | `TASK_TEMP_DIR` | Location of the remote temp dir (used for caching). Can relative to the project like `tmp/task` or absolute like `/tmp/.task` or `~/.task`. |
+| `FORCE_COLOR`     |                 | Force color output usage.                                                                                                                   |
 
 ## Custom Colors
 


### PR DESCRIPTION
This PR allow to have a global temp directory when using remote taskfile.

Considering a setup with multiple different projects, all using the same remote taskfile. if /  when the remote taskfile changes, we need to approve the prompt for all projects.
At the beginning, I thought changing the TASK_X_TEMP_DIR to `~/.task`, but I've seen that it's suffixed with the dir so I won't work.

The fingerprint dir should stay scoped

This PR changes the behavior only for remote. If the path is absolute or start with `~` then we do not suffix it.

For the implementation, I've chosen to create a struct and store the two paths in it. We could also in the future add an env variable like `TASK_X_REMOTE_DIR`. If you think it can be a nice addition, I can implement it in this PR 

Any feedback on this feature are appreciated :)