### PR TITLE
docs: improve install script

### DIFF
--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -146,6 +146,15 @@ can install Task from [winget-pkgs](https://github.com/microsoft/winget-pkgs).
 winget install Task.Task
 ```
 
+### Pacstall
+If you are using Debian or Ubuntu, and have [Pacstall](https://pacstall.dev/) installed, you can install Task by running:
+
+```shell
+pacstall -I go-task-deb
+```
+
+This installation method is community owned. After a new release of Task, it may take some time until it's available in [Pacstall](https://pacstall.dev/packages/go-task-deb).
+
 ## Get The Binary
 
 ### Binary

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -185,6 +185,14 @@ default.
 
 :::
 
+By default, it installs the latest version available.
+You can also specify a tag (available in [releases](https://github.com/go-task/task/releases))
+to install a specific version:
+
+```shell
+sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d v3.36.0
+```
+
 ### GitHub Actions
 
 If you want to install Task in GitHub Actions you can try using


### PR DESCRIPTION
Improve the installation docs : 
- Example with a specific version for the installation script
- Adding pacstall method (community owned)

I've checked the repo is still maintained : 
![image](https://github.com/go-task/task/assets/9110126/5322c90c-67df-46b7-897e-d0af3ac81640)

Closes #1352 
