### PR TITLE
Fix and modify requires behavior.

### DIFF
--- a/requires.go
+++ b/requires.go
@@ -19,9 +19,22 @@ func (e *Executor) areTaskRequiredVarsSet(ctx context.Context, t *ast.Task, call
 
 	var missingVars []string
 	for _, requiredVar := range t.Requires.Vars {
-		if !vars.Exists(requiredVar) {
-			missingVars = append(missingVars, requiredVar)
+		v := vars.Get(requiredVar)
+
+		// Check and continue on positive conditions.
+		if v.Value != nil {
+			switch val := v.Value.(type) {
+			case string:
+				if len(val) > 0 {
+					continue
+				}
+			default:
+				continue
+			}
 		}
+
+		// The required variable is not available.
+		missingVars = append(missingVars, requiredVar)
 	}
 
 	if len(missingVars) > 0 {

--- a/website/docs/usage.mdx
+++ b/website/docs/usage.mdx
@@ -911,13 +911,14 @@ tasks:
 ### Ensuring required variables are set
 
 If you want to check that certain variables are set before running a task then
-you can use `requires`. This is useful when might not be clear to users which
+you can use `requires`. This is useful when it might not be clear to users which
 variables are needed, or if you want clear message about what is required. Also
 some tasks could have dangerous side effects if run with un-set variables.
 
 Using `requires` you specify an array of strings in the `vars` sub-section under
 `requires`, these strings are variable names which are checked prior to running
-the task. If any variables are un-set the the task will error and not run.
+the task. If any of the listed variables are either un-set or zero length strings
+then the task will error and not run.
 
 Environmental variables are also checked.
 
@@ -930,7 +931,8 @@ requires:
 
 :::note
 
-Variables set to empty zero length strings, will pass the `requires` check.
+Variables set to zero length (empty) strings will not pass the `requires` check. 
+Circumvent this by setting the variable to a string with a single space character (i.e. `' '`).
 
 :::
 


### PR DESCRIPTION
Fix and modify the behavior of `requires`.

Fixes #1676 (discussion #1620)
Modifies/updates #1204


Requires was not working in the case that a variable was set to nil (see discussion/issue).


Additional, the behavior of requires is modified so that an zero length (empty) string value fails the required check. In more complex use cases, with sub-tasks and variable templates, the expectation is that requires will ensure that a variable is set to _something_. In such cases, an empty string is not considered as _something_ and so the feature is not useful.

An alternative would be to have a way to set a variable value to `nil` via the template mechanism.


The change is tested with the following taskfile (modified from the original discussion).

```
version: "3"

silent: true

vars:
  IMAGE_NAME: my-web-app
  CONTAINER_REGISTRY: 
  # CONTAINER_REGISTRY: # comment
  # CONTAINER_REGISTRY: ''
  # CONTAINER_REGISTRY: ' '

tasks:
  check-missing:
    desc: Test the task variables
    requires:
      vars: [CONTAINER_REGISTRY]
    cmds:
      - echo "CONTAINER_REGISTRY is {{spew .CONTAINER_REGISTRY}}"
```