### PR TITLE
chore: release riscv64 binary on Linux

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,11 +11,16 @@ builds:
       - amd64
       - arm
       - arm64
+      - riscv64
     goarm:
       - '6'
     ignore:
       - goos: darwin
         goarch: '386'
+      - goos: darwin
+        goarch: riscv64
+      - goos: windows
+        goarch: riscv64
     env:
       - CGO_ENABLED=0
     mod_timestamp: '{{ .CommitTimestamp }}'


### PR DESCRIPTION
Tested result:
```
root@visionfive2-1:~/task# uname -a
Linux visionfive2-1 5.15.0-starfive #1 SMP Sun Jun 11 07:48:39 UTC 2023 riscv64 GNU/Linux

root@visionfive2-1:~/task# go test
PASS
ok      github.com/go-task/task/v3      25.144s

root@visionfive2-1:~/task# env GOBIN=/bin go install ./cmd/task
/bin/task --version
Task version: (devel) ()

root@visionfive2-1:~/task# task
task: [lint] golangci-lint run
task: [install] go install -v ./cmd/task
task: [test] go test github.com/go-task/task/v3 github.com/go-task/task/v3/args github.com/go-task/task/v3/cmd/release github.com/go-task/task/v3/cmd/sleepit github.com/go-task/task/v3/cmd/task github.com/go-task/task/v3/errors github.com/go-task/task/v3/internal/compiler github.com/go-task/task/v3/internal/deepcopy github.com/go-task/task/v3/internal/editors github.com/go-task/task/v3/internal/env github.com/go-task/task/v3/internal/execext github.com/go-task/task/v3/internal/exp github.com/go-task/task/v3/internal/experiments github.com/go-task/task/v3/internal/filepathext github.com/go-task/task/v3/internal/fingerprint github.com/go-task/task/v3/internal/flags github.com/go-task/task/v3/internal/goext github.com/go-task/task/v3/internal/hash github.com/go-task/task/v3/internal/logger github.com/go-task/task/v3/internal/mocks github.com/go-task/task/v3/internal/omap github.com/go-task/task/v3/internal/output github.com/go-task/task/v3/internal/slicesext github.com/go-task/task/v3/internal/sort github.com/go-task/task/v3/internal/summary github.com/go-task/task/v3/internal/sysinfo github.com/go-task/task/v3/internal/templater github.com/go-task/task/v3/internal/term github.com/go-task/task/v3/internal/version github.com/go-task/task/v3/taskfile github.com/go-task/task/v3/taskfile/ast
?       github.com/go-task/task/v3/cmd/release  [no test files]
?       github.com/go-task/task/v3/cmd/sleepit  [no test files]
?       github.com/go-task/task/v3/cmd/task     [no test files]
?       github.com/go-task/task/v3/errors       [no test files]
?       github.com/go-task/task/v3/internal/compiler    [no test files]
?       github.com/go-task/task/v3/internal/deepcopy    [no test files]
?       github.com/go-task/task/v3/internal/env [no test files]
?       github.com/go-task/task/v3/internal/exp [no test files]
?       github.com/go-task/task/v3/internal/experiments [no test files]
?       github.com/go-task/task/v3/internal/filepathext [no test files]
?       github.com/go-task/task/v3/internal/execext     [no test files]
?       github.com/go-task/task/v3/internal/editors     [no test files]
?       github.com/go-task/task/v3/internal/flags       [no test files]
?       github.com/go-task/task/v3/internal/goext       [no test files]
?       github.com/go-task/task/v3/internal/hash        [no test files]
?       github.com/go-task/task/v3/internal/logger      [no test files]
?       github.com/go-task/task/v3/internal/mocks       [no test files]
?       github.com/go-task/task/v3/internal/slicesext   [no test files]
?       github.com/go-task/task/v3/internal/sysinfo     [no test files]
?       github.com/go-task/task/v3/internal/templater   [no test files]
?       github.com/go-task/task/v3/internal/term        [no test files]
?       github.com/go-task/task/v3/internal/version     [no test files]
?       github.com/go-task/task/v3/taskfile     [no test files]
ok      github.com/go-task/task/v3      29.250s
ok      github.com/go-task/task/v3/args 0.123s
ok      github.com/go-task/task/v3/internal/fingerprint 0.135s
ok      github.com/go-task/task/v3/internal/omap        0.010s
ok      github.com/go-task/task/v3/internal/output      0.222s
ok      github.com/go-task/task/v3/internal/sort        0.202s
ok      github.com/go-task/task/v3/internal/summary     0.185s
ok      github.com/go-task/task/v3/taskfile/ast 0.126s
```
