### PR TITLE
Add TTL to taskfile.Cache

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -108,6 +108,7 @@ func run() error {
 		Download:    flags.Download,
 		Offline:     flags.Offline,
 		Timeout:     flags.Timeout,
+		CacheTTL:    flags.CacheTTL,
 		Watch:       flags.Watch,
 		Verbose:     flags.Verbose,
 		Silent:      flags.Silent,

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/go-task/task/v3/internal/experiments"
+	"github.com/go-task/task/v3/taskfile"
 	"github.com/go-task/task/v3/taskfile/ast"
 )
 
@@ -67,6 +68,7 @@ var (
 	Offline     bool
 	ClearCache  bool
 	Timeout     time.Duration
+	CacheTTL    time.Duration
 )
 
 func init() {
@@ -115,12 +117,14 @@ func init() {
 		pflag.BoolVarP(&ForceAll, "force", "f", false, "Forces execution even when the task is up-to-date.")
 	}
 
-	// Remote Taskfiles experiment will adds the "download" and "offline" flags
+	// Remote Taskfiles experiment will add the following flags.
 	if experiments.RemoteTaskfiles.Enabled {
 		pflag.BoolVar(&Download, "download", false, "Downloads a cached version of a remote Taskfile.")
 		pflag.BoolVar(&Offline, "offline", false, "Forces Task to only use local or cached Taskfiles.")
 		pflag.DurationVar(&Timeout, "timeout", time.Second*10, "Timeout for downloading remote Taskfiles.")
 		pflag.BoolVar(&ClearCache, "clear-cache", false, "Clear the remote cache.")
+		pflag.DurationVar(&CacheTTL, "remote-cache-ttl", taskfile.DefaultCacheTTL,
+			"TTL of remote Taskfiles downloaded into the local cache.")
 	}
 
 	pflag.Parse()

--- a/setup.go
+++ b/setup.go
@@ -69,6 +69,7 @@ func (e *Executor) readTaskfile(node taskfile.Node) error {
 		e.Download,
 		e.Offline,
 		e.Timeout,
+		e.CacheTTL,
 		e.TempDir.Remote,
 		e.Logger,
 	)

--- a/signals_test.go
+++ b/signals_test.go
@@ -20,9 +20,7 @@ import (
 	"time"
 )
 
-var (
-	SLEEPIT, _ = filepath.Abs("./bin/sleepit")
-)
+var SLEEPIT, _ = filepath.Abs("./bin/sleepit")
 
 func TestSignalSentToProcessGroup(t *testing.T) {
 	task, err := getTaskPath()

--- a/task.go
+++ b/task.go
@@ -52,6 +52,7 @@ type Executor struct {
 	Download    bool
 	Offline     bool
 	Timeout     time.Duration
+	CacheTTL    time.Duration
 	Watch       bool
 	Verbose     bool
 	Silent      bool

--- a/taskfile/README.md
+++ b/taskfile/README.md
@@ -1,0 +1,43 @@
+# The `taskfile` package
+
+```mermaid
+---
+title: taskfile.Cache behaviour
+---
+flowchart LR
+  %% Beginning state
+    start([A remote Taskfile
+      is required])
+
+  %% Checks to decide
+    cached{Remote Taskfile
+      already cached?}
+
+    subgraph checkTTL [Is the cached Taskfile still inside TTL?]
+    %% Beginning state
+      lastModified(Stat the cached
+        Taskfile and get last
+        modified timestamp)
+
+    %% Check to decide
+      timestampPlusTTL{Timestamp
+        plus TTL is in
+        the future?}
+
+    %% Flowlines
+      lastModified-->timestampPlusTTL
+    end
+
+  %% End states
+    useCached([Use the
+      cached Taskfile])
+    download(["(Re)download the
+      remote Taskfile"])
+
+  %% Flowlines
+    start-->cached
+    cached-- Yes -->lastModified
+    cached-- No -->download
+    timestampPlusTTL-- Yes -->useCached
+    timestampPlusTTL-- No -->download
+```

--- a/taskfile/cache.go
+++ b/taskfile/cache.go
@@ -60,7 +60,9 @@ func (c *Cache) write(node Node, b []byte) error {
 }
 
 func (c *Cache) read(node Node) ([]byte, error) {
-	fi, err := os.Stat(c.cacheFilePath(node))
+	cfp := c.cacheFilePath(node)
+
+	fi, err := os.Stat(cfp)
 	if err != nil {
 		return nil, fmt.Errorf("could not stat cached file: %w", err)
 	}
@@ -70,7 +72,7 @@ func (c *Cache) read(node Node) ([]byte, error) {
 		return nil, ErrExpired
 	}
 
-	return os.ReadFile(c.cacheFilePath(node))
+	return os.ReadFile(cfp)
 }
 
 func (c *Cache) writeChecksum(node Node, checksum string) error {

--- a/taskfile/cache.go
+++ b/taskfile/cache.go
@@ -10,8 +10,8 @@ import (
 	"time"
 )
 
-// defaultCacheTTL is one day (24 hours).
-const defaultCacheTTL = time.Duration(time.Hour * 24)
+// DefaultCacheTTL is one day (24 hours).
+const DefaultCacheTTL = time.Duration(time.Hour * 24)
 
 type Cache struct {
 	dir string
@@ -31,7 +31,7 @@ func NewCache(dir string, opts ...CacheOption) (*Cache, error) {
 
 	cache := &Cache{
 		dir: dir,
-		ttl: defaultCacheTTL,
+		ttl: DefaultCacheTTL,
 	}
 
 	// Apply options.

--- a/taskfile/cache.go
+++ b/taskfile/cache.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-// DefaultCacheTTL is one day (24 hours).
+// DefaultCacheTTL is used when a value is not explicitly given to a new Cache.
 const DefaultCacheTTL = time.Duration(time.Hour * 24)
 
 type Cache struct {

--- a/taskfile/cache_internal_test.go
+++ b/taskfile/cache_internal_test.go
@@ -81,16 +81,16 @@ func TestCacheInsideTTL(t *testing.T) {
 }
 
 func TestCacheOutsideTTL(t *testing.T) {
-	// Prime a new Cache with a TTL of one second.
-	cache, fileNode := primeNewCache(t, t.TempDir(), WithTTL(time.Second))
+	// Prime a new Cache with an extremely short TTL.
+	cache, fileNode := primeNewCache(t, t.TempDir(), WithTTL(time.Millisecond))
 
 	// Write some bytes for the cached file.
 	writeBytes := []byte("some bytes")
 	err := cache.write(fileNode, writeBytes)
 	require.NoError(t, err, "writing bytes to cache")
 
-	// Sleep for two seconds so that the cached file is outside of TTL.
-	time.Sleep(2 * time.Second)
+	// Sleep for 5ms so that the cached file is outside of TTL.
+	time.Sleep(5 * time.Millisecond)
 
 	// Reading from the cache after sleeping past the end of TTL should get an error.
 	readBytes, err := cache.read(fileNode)

--- a/taskfile/cache_internal_test.go
+++ b/taskfile/cache_internal_test.go
@@ -54,7 +54,7 @@ func TestCache(t *testing.T) {
 
 	// Attempt to read from cache, then write, then read again.
 	_, err := cache.read(fileNode)
-	require.ErrorAs(t, err, &os.ErrNotExist, "reading from cache before writing should match error type")
+	require.ErrorIs(t, err, os.ErrNotExist, "reading from cache before writing should match error type")
 
 	writeBytes := []byte("some bytes")
 	err = cache.write(fileNode, writeBytes)

--- a/taskfile/cache_internal_test.go
+++ b/taskfile/cache_internal_test.go
@@ -1,38 +1,59 @@
 package taskfile
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-task/task/v3/internal/logger"
 )
 
-func TestCache(t *testing.T) {
-	cacheDir := t.TempDir()
-	cache, err := NewCache(cacheDir)
-	require.NoErrorf(t, err, "creating new cache in temporary directory '%s'", cacheDir)
+func ExampleWithTTL() {
+	c, _ := NewCache(os.TempDir(), WithTTL(2*time.Minute+30*time.Second))
+
+	fmt.Println(c.ttl)
+	// Output: 2m30s
+}
+
+var discardLogger = &logger.Logger{
+	Stdout: io.Discard,
+	Stderr: io.Discard,
+}
+
+func primeNewCache(t *testing.T, tempDir string, cacheOpts ...CacheOption) (*Cache, *FileNode) {
+	t.Helper()
+
+	cache, err := NewCache(tempDir, cacheOpts...)
+	require.NoErrorf(t, err, "creating new cache in temporary directory '%s'", tempDir)
 
 	// Prime the temporary cache directory with a basic Taskfile.
 	filename := "Taskfile.yaml"
 	srcTaskfile := filepath.Join("testdata", filename)
 	dstTaskfile := filepath.Join(cache.dir, filename)
-	err = os.Link(srcTaskfile, dstTaskfile)
-	require.NoErrorf(t, err, "creating hardlink from testdata (%s) to temporary cache (%s)", srcTaskfile, dstTaskfile)
 
-	discardLogger := &logger.Logger{
-		Stdout: io.Discard,
-		Stderr: io.Discard,
-	}
+	taskfileBytes, err := os.ReadFile(srcTaskfile)
+	require.NoErrorf(t, err, "reading from testdata Taskfile (%s)", srcTaskfile)
 
-	// Create a new file node in the cache, with the entrypoint hardlinked above.
+	err = os.WriteFile(dstTaskfile, taskfileBytes, 0o640)
+	require.NoErrorf(t, err, "writing to temporary Taskfile (%s)", dstTaskfile)
+
+	// Create a new file node in the cache, with the entrypoint copied above.
 	fileNode, err := NewFileNode(discardLogger, dstTaskfile, cache.dir)
 	require.NoError(t, err, "creating new file node")
 
-	_, err = cache.read(fileNode)
+	return cache, fileNode
+}
+
+func TestCache(t *testing.T) {
+	cache, fileNode := primeNewCache(t, t.TempDir())
+
+	// Attempt to read from cache, then write, then read again.
+	_, err := cache.read(fileNode)
 	require.ErrorAs(t, err, &os.ErrNotExist, "reading from cache before writing should match error type")
 
 	writeBytes := []byte("some bytes")
@@ -42,4 +63,37 @@ func TestCache(t *testing.T) {
 	readBytes, err := cache.read(fileNode)
 	require.NoError(t, err, "reading from cache after write should not error")
 	require.Equal(t, writeBytes, readBytes, "bytes read from cache should match bytes written")
+}
+
+func TestCacheInsideTTL(t *testing.T) {
+	// Prime a new Cache with a TTL of one minute.
+	cache, fileNode := primeNewCache(t, t.TempDir(), WithTTL(time.Minute))
+
+	// Write some bytes for the cached file.
+	writeBytes := []byte("some bytes")
+	err := cache.write(fileNode, writeBytes)
+	require.NoError(t, err, "writing bytes to cache")
+
+	// Reading from the cache while still inside the TTL should get the written bytes back.
+	readBytes, err := cache.read(fileNode)
+	require.NoError(t, err, "reading from cache inside TTL should not error")
+	require.Equal(t, writeBytes, readBytes, "bytes read from cache should match bytes written")
+}
+
+func TestCacheOutsideTTL(t *testing.T) {
+	// Prime a new Cache with a TTL of one second.
+	cache, fileNode := primeNewCache(t, t.TempDir(), WithTTL(time.Second))
+
+	// Write some bytes for the cached file.
+	writeBytes := []byte("some bytes")
+	err := cache.write(fileNode, writeBytes)
+	require.NoError(t, err, "writing bytes to cache")
+
+	// Sleep for two seconds so that the cached file is outside of TTL.
+	time.Sleep(2 * time.Second)
+
+	// Reading from the cache after sleeping past the end of TTL should get an error.
+	readBytes, err := cache.read(fileNode)
+	require.Empty(t, readBytes, "should not have read any bytes from cache")
+	require.ErrorIs(t, err, ErrExpired, "should get 'expired' error when attempting to read from cache outside of TTL")
 }

--- a/taskfile/cache_internal_test.go
+++ b/taskfile/cache_internal_test.go
@@ -25,11 +25,11 @@ var discardLogger = &logger.Logger{
 	Stderr: io.Discard,
 }
 
-func primeNewCache(t *testing.T, tempDir string, cacheOpts ...CacheOption) (*Cache, *FileNode) {
+func primeNewCache(t *testing.T, cacheOpts ...CacheOption) (*Cache, *FileNode) {
 	t.Helper()
 
-	cache, err := NewCache(tempDir, cacheOpts...)
-	require.NoErrorf(t, err, "creating new cache in temporary directory '%s'", tempDir)
+	cache, err := NewCache(t.TempDir(), cacheOpts...)
+	require.NoErrorf(t, err, "creating new cache")
 
 	// Prime the temporary cache directory with a basic Taskfile.
 	filename := "Taskfile.yaml"
@@ -50,7 +50,7 @@ func primeNewCache(t *testing.T, tempDir string, cacheOpts ...CacheOption) (*Cac
 }
 
 func TestCache(t *testing.T) {
-	cache, fileNode := primeNewCache(t, t.TempDir())
+	cache, fileNode := primeNewCache(t)
 
 	// Attempt to read from cache, then write, then read again.
 	_, err := cache.read(fileNode)
@@ -67,7 +67,7 @@ func TestCache(t *testing.T) {
 
 func TestCacheInsideTTL(t *testing.T) {
 	// Prime a new Cache with a TTL of one minute.
-	cache, fileNode := primeNewCache(t, t.TempDir(), WithTTL(time.Minute))
+	cache, fileNode := primeNewCache(t, WithTTL(time.Minute))
 
 	// Write some bytes for the cached file.
 	writeBytes := []byte("some bytes")
@@ -82,7 +82,7 @@ func TestCacheInsideTTL(t *testing.T) {
 
 func TestCacheOutsideTTL(t *testing.T) {
 	// Prime a new Cache with an extremely short TTL.
-	cache, fileNode := primeNewCache(t, t.TempDir(), WithTTL(time.Millisecond))
+	cache, fileNode := primeNewCache(t, WithTTL(time.Millisecond))
 
 	// Write some bytes for the cached file.
 	writeBytes := []byte("some bytes")

--- a/taskfile/cache_internal_test.go
+++ b/taskfile/cache_internal_test.go
@@ -1,0 +1,45 @@
+package taskfile
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-task/task/v3/internal/logger"
+)
+
+func TestCache(t *testing.T) {
+	cacheDir := t.TempDir()
+	cache, err := NewCache(cacheDir)
+	require.NoErrorf(t, err, "creating new cache in temporary directory '%s'", cacheDir)
+
+	// Prime the temporary cache directory with a basic Taskfile.
+	filename := "Taskfile.yaml"
+	srcTaskfile := filepath.Join("testdata", filename)
+	dstTaskfile := filepath.Join(cache.dir, filename)
+	err = os.Link(srcTaskfile, dstTaskfile)
+	require.NoErrorf(t, err, "creating hardlink from testdata (%s) to temporary cache (%s)", srcTaskfile, dstTaskfile)
+
+	discardLogger := &logger.Logger{
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	}
+
+	// Create a new file node in the cache, with the entrypoint hardlinked above.
+	fileNode, err := NewFileNode(discardLogger, dstTaskfile, cache.dir)
+	require.NoError(t, err, "creating new file node")
+
+	_, err = cache.read(fileNode)
+	require.ErrorAs(t, err, &os.ErrNotExist, "reading from cache before writing should match error type")
+
+	writeBytes := []byte("some bytes")
+	err = cache.write(fileNode, writeBytes)
+	require.NoError(t, err, "writing bytes to cache")
+
+	readBytes, err := cache.read(fileNode)
+	require.NoError(t, err, "reading from cache after write should not error")
+	require.Equal(t, writeBytes, readBytes, "bytes read from cache should match bytes written")
+}

--- a/taskfile/cache_test.go
+++ b/taskfile/cache_test.go
@@ -10,13 +10,20 @@ import (
 )
 
 func TestNewCache(t *testing.T) {
-	cacheDir := t.TempDir()
-	_, err := taskfile.NewCache(cacheDir)
-	require.NoErrorf(t, err, "creating new cache in temporary directory '%s'", cacheDir)
-}
+	testCases := map[string]struct {
+		options []taskfile.CacheOption
+	}{
+		"no options set": {},
 
-func TestNewCacheWithTTL(t *testing.T) {
-	cacheDir := t.TempDir()
-	_, err := taskfile.NewCache(cacheDir, taskfile.WithTTL(time.Hour))
-	require.NoErrorf(t, err, "creating new cache in temporary directory '%s'", cacheDir)
+		"TTL option set": {
+			options: []taskfile.CacheOption{taskfile.WithTTL(time.Hour)},
+		},
+	}
+
+	for desc, testCase := range testCases {
+		t.Run(desc, func(t *testing.T) {
+			_, err := taskfile.NewCache(t.TempDir(), testCase.options...)
+			require.NoError(t, err, "creating new cache")
+		})
+	}
 }

--- a/taskfile/cache_test.go
+++ b/taskfile/cache_test.go
@@ -1,0 +1,15 @@
+package taskfile_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-task/task/v3/taskfile"
+)
+
+func TestNewCache(t *testing.T) {
+	cacheDir := t.TempDir()
+	_, err := taskfile.NewCache(cacheDir)
+	require.NoErrorf(t, err, "creating new cache in temporary directory '%s'", cacheDir)
+}

--- a/taskfile/cache_test.go
+++ b/taskfile/cache_test.go
@@ -2,6 +2,7 @@ package taskfile_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -11,5 +12,11 @@ import (
 func TestNewCache(t *testing.T) {
 	cacheDir := t.TempDir()
 	_, err := taskfile.NewCache(cacheDir)
+	require.NoErrorf(t, err, "creating new cache in temporary directory '%s'", cacheDir)
+}
+
+func TestNewCacheWithTTL(t *testing.T) {
+	cacheDir := t.TempDir()
+	_, err := taskfile.NewCache(cacheDir, taskfile.WithTTL(time.Hour))
 	require.NoErrorf(t, err, "creating new cache in temporary directory '%s'", cacheDir)
 }

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -36,6 +36,7 @@ type Reader struct {
 	download bool
 	offline  bool
 	timeout  time.Duration
+	cacheTTL time.Duration
 	tempDir  string
 	logger   *logger.Logger
 }
@@ -46,6 +47,7 @@ func NewReader(
 	download bool,
 	offline bool,
 	timeout time.Duration,
+	cacheTTL time.Duration,
 	tempDir string,
 	logger *logger.Logger,
 ) *Reader {
@@ -56,6 +58,7 @@ func NewReader(
 		download: download,
 		offline:  offline,
 		timeout:  timeout,
+		cacheTTL: cacheTTL,
 		tempDir:  tempDir,
 		logger:   logger,
 	}
@@ -185,7 +188,7 @@ func (r *Reader) readNode(node Node) (*ast.Taskfile, error) {
 	var cache *Cache
 
 	if node.Remote() {
-		cache, err = NewCache(r.tempDir)
+		cache, err = NewCache(r.tempDir, WithTTL(r.cacheTTL))
 		if err != nil {
 			return nil, err
 		}

--- a/taskfile/testdata/Taskfile.yaml
+++ b/taskfile/testdata/Taskfile.yaml
@@ -1,0 +1,3 @@
+version: '3'
+
+tasks: {}

--- a/watch_test.go
+++ b/watch_test.go
@@ -41,10 +41,10 @@ Hello, World!
 	require.NoError(t, e.Setup())
 	buff.Reset()
 
-	err := os.MkdirAll(filepathext.SmartJoin(dir, "src"), 0755)
+	err := os.MkdirAll(filepathext.SmartJoin(dir, "src"), 0o755)
 	require.NoError(t, err)
 
-	err = os.WriteFile(filepathext.SmartJoin(dir, "src/a"), []byte("test"), 0644)
+	err = os.WriteFile(filepathext.SmartJoin(dir, "src/a"), []byte("test"), 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ Hello, World!
 	}(ctx)
 
 	time.Sleep(10 * time.Millisecond)
-	err = os.WriteFile(filepathext.SmartJoin(dir, "src/a"), []byte("test updated"), 0644)
+	err = os.WriteFile(filepathext.SmartJoin(dir, "src/a"), []byte("test updated"), 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/website/docs/experiments/remote_taskfiles.mdx
+++ b/website/docs/experiments/remote_taskfiles.mdx
@@ -104,20 +104,32 @@ Whenever you run a remote Taskfile, the latest copy will be downloaded from the
 internet and cached locally. If for whatever reason, you lose access to the
 internet, you will still be able to run your tasks by specifying the `--offline`
 flag. This will tell Task to use the latest cached version of the file instead
-of trying to download it. You are able to use the `--download` flag to update
-the cached version of the remote files without running any tasks. You are able
-to use the `--clear-cache` flag to clear all cached version of the remote files
-without running any tasks.
+of trying to download it.
 
-By default, Task will timeout requests to download remote files after 10 seconds
-and look for a cached copy instead. This timeout can be configured by setting
-the `--timeout` flag and specifying a duration. For example, `--timeout 5s` will
-set the timeout to 5 seconds.
+The flags to affect the caching behaviour are as follows:
+
+- `--download` (boolean): update the cached version of the remote files without
+  running any tasks.
+- `--clear-cache` (boolean): clear all cached version of the remote files
+  without running any tasks.
+- `--remote-cache-ttl` (duration): override the default time-to-live (TTL) of
+  remote Taskfiles in the cache, when there is a cached Taskfile present and
+  deciding whether to use the cached copy or download a newer version.
+
+By default, Task requests to download remote files will time out after 10
+seconds and look for a cached copy instead. This timeout can be configured by
+setting the `--timeout` flag and specifying a duration. For example,
+`--timeout 5s` will set the timeout to 5 seconds.
 
 By default, the cache is stored in the Task temp directory, represented by the
 `TASK_TEMP_DIR` [environment variable](../reference/environment.mdx) You can
 override the location of the cache by setting the `TASK_REMOTE_DIR` environment
 variable. This way, you can share the cache between different projects.
+
+The default TTL for remote Taskfiles in the cache is 24 hours. This can be
+overridden by the `--remote-cache-ttl` flag outlined above. The value must be
+specified as a duration, e.g. `30s`, `15m`, `4h`. More information on how
+[durations are parsed is available here](https://pkg.go.dev/time#ParseDuration).
 
 {/* prettier-ignore-start */}
 [enabling-experiments]: ./experiments.mdx#enabling-experiments

--- a/website/versioned_docs/version-latest/experiments/remote_taskfiles.mdx
+++ b/website/versioned_docs/version-latest/experiments/remote_taskfiles.mdx
@@ -104,20 +104,32 @@ Whenever you run a remote Taskfile, the latest copy will be downloaded from the
 internet and cached locally. If for whatever reason, you lose access to the
 internet, you will still be able to run your tasks by specifying the `--offline`
 flag. This will tell Task to use the latest cached version of the file instead
-of trying to download it. You are able to use the `--download` flag to update
-the cached version of the remote files without running any tasks. You are able
-to use the `--clear-cache` flag to clear all cached version of the remote files
-without running any tasks.
+of trying to download it.
 
-By default, Task will timeout requests to download remote files after 10 seconds
-and look for a cached copy instead. This timeout can be configured by setting
-the `--timeout` flag and specifying a duration. For example, `--timeout 5s` will
-set the timeout to 5 seconds.
+The flags to affect the caching behaviour are as follows:
+
+- `--download` (boolean): update the cached version of the remote files without
+  running any tasks.
+- `--clear-cache` (boolean): clear all cached version of the remote files
+  without running any tasks.
+- `--remote-cache-ttl` (duration): override the default time-to-live (TTL) of
+  remote Taskfiles in the cache, when there is a cached Taskfile present and
+  deciding whether to use the cached copy or download a newer version.
+
+By default, Task requests to download remote files will time out after 10
+seconds and look for a cached copy instead. This timeout can be configured by
+setting the `--timeout` flag and specifying a duration. For example,
+`--timeout 5s` will set the timeout to 5 seconds.
 
 By default, the cache is stored in the Task temp directory, represented by the
 `TASK_TEMP_DIR` [environment variable](../reference/environment.mdx) You can
 override the location of the cache by setting the `TASK_REMOTE_DIR` environment
 variable. This way, you can share the cache between different projects.
+
+The default TTL for remote Taskfiles in the cache is 24 hours. This can be
+overridden by the `--remote-cache-ttl` flag outlined above. The value must be
+specified as a duration, e.g. `30s`, `15m`, `4h`. More information on how
+[durations are parsed is available here](https://pkg.go.dev/time#ParseDuration).
 
 {/* prettier-ignore-start */}
 [enabling-experiments]: ./experiments.mdx#enabling-experiments

--- a/website/versioned_docs/version-latest/experiments/remote_taskfiles.mdx
+++ b/website/versioned_docs/version-latest/experiments/remote_taskfiles.mdx
@@ -104,32 +104,20 @@ Whenever you run a remote Taskfile, the latest copy will be downloaded from the
 internet and cached locally. If for whatever reason, you lose access to the
 internet, you will still be able to run your tasks by specifying the `--offline`
 flag. This will tell Task to use the latest cached version of the file instead
-of trying to download it.
+of trying to download it. You are able to use the `--download` flag to update
+the cached version of the remote files without running any tasks. You are able
+to use the `--clear-cache` flag to clear all cached version of the remote files
+without running any tasks.
 
-The flags to affect the caching behaviour are as follows:
-
-- `--download` (boolean): update the cached version of the remote files without
-  running any tasks.
-- `--clear-cache` (boolean): clear all cached version of the remote files
-  without running any tasks.
-- `--remote-cache-ttl` (duration): override the default time-to-live (TTL) of
-  remote Taskfiles in the cache, when there is a cached Taskfile present and
-  deciding whether to use the cached copy or download a newer version.
-
-By default, Task requests to download remote files will time out after 10
-seconds and look for a cached copy instead. This timeout can be configured by
-setting the `--timeout` flag and specifying a duration. For example,
-`--timeout 5s` will set the timeout to 5 seconds.
+By default, Task will timeout requests to download remote files after 10 seconds
+and look for a cached copy instead. This timeout can be configured by setting
+the `--timeout` flag and specifying a duration. For example, `--timeout 5s` will
+set the timeout to 5 seconds.
 
 By default, the cache is stored in the Task temp directory, represented by the
 `TASK_TEMP_DIR` [environment variable](../reference/environment.mdx) You can
 override the location of the cache by setting the `TASK_REMOTE_DIR` environment
 variable. This way, you can share the cache between different projects.
-
-The default TTL for remote Taskfiles in the cache is 24 hours. This can be
-overridden by the `--remote-cache-ttl` flag outlined above. The value must be
-specified as a duration, e.g. `30s`, `15m`, `4h`. More information on how
-[durations are parsed is available here](https://pkg.go.dev/time#ParseDuration).
 
 {/* prettier-ignore-start */}
 [enabling-experiments]: ./experiments.mdx#enabling-experiments


### PR DESCRIPTION
<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->

# Description

This PR implements part of the [remote Taskfiles experiment](https://taskfile.dev/experiments/remote-taskfiles/) (#1317) that is currently ongoing.

## Implementation notes

- `taskfile.Cache` has a new private `time.Duration` field for the TTL setting.
  - The [default TTL setting](https://github.com/jlucktay/task/blob/3c9dab3ecf1e9b4bab16a093c870a7ff55341ba2/taskfile/cache.go#L13-L14) for the cache is 24 hours. Should this be shorter/longer? 4 hours? 1 week?

- The `taskfile` package has some new exports:
  - the default TTL value described above, in a `const`.
  - a static `error`: `ErrExpired`.
  - a `CacheOption` type, and a `WithTTL` func returning this type, to help with creation of new `Cache` structs.

- The main `task` executable has a new flag (currently gated by the `TASK_X_REMOTE_TASKFILES` experiment) to override the default cache TTL setting, outlined below.

# Flow diagram

There is [a flowchart sketched out here on this branch](https://github.com/jlucktay/task/blob/issue-1402/add-ttl-to-taskfile-cache/taskfile/README.md) to describe the overall flow.

# New CLI behaviour

```
$ TASK_X_REMOTE_TASKFILES=1 task --help 
…
Options:
…
      --remote-cache-ttl duration   TTL of remote Taskfiles downloaded into the local cache. (default 24h0m0s)
```

Resolves #1402.
