### PR TITLE
docs: update setup-task version

### DIFF
--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -209,7 +209,7 @@ If you want to install Task in GitHub Actions you can try using
 
 ```yaml
 - name: Install Task
-  uses: arduino/setup-task@v1
+  uses: arduino/setup-task@v2
   with:
     version: 3.x
     repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/website/versioned_docs/version-latest/installation.mdx
+++ b/website/versioned_docs/version-latest/installation.mdx
@@ -209,7 +209,7 @@ If you want to install Task in GitHub Actions you can try using
 
 ```yaml
 - name: Install Task
-  uses: arduino/setup-task@v1
+  uses: arduino/setup-task@v2
   with:
     version: 3.x
     repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
:wave: Not so long ago we updated the `arduino/setup-task` action from v1 to v2, I've noticed that the doc refers to the old version.
With this PR I'm updating to the latest one (v2).