### PR TITLE
fix: --version when a version is provided with -ldflags

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,9 @@ func init() {
 	if !ok || info.Main.Version == "" {
 		version = "unknown"
 	} else {
-		version = info.Main.Version
+		if version == "" {
+			version = info.Main.Version
+		}
 		sum = info.Main.Sum
 	}
 }


### PR DESCRIPTION
We went a bit too far when refactoring this. Some people build Task theirself and provide the version with ldflags. But in our implementation we override the version.
fixes #1709 
I used this command to check : 
`go build -o "task" -ldflags "-s -w -X github.com/go-task/task/v3/internal/version.version=3.38.0"  ./cmd/task ` like they do in Homebrew (https://github.com/Homebrew/homebrew-core/blob/e71417b07f53e9ea7c79974dd6f6c2297d9a9a1c/Formula/g/go-task.rb#L23-L32)