### PR TITLE
ci: add new job to check if versioned_docs has been modified

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,3 +41,18 @@ jobs:
 
       - name: check-jsonschema (metaschema)
         run: check-jsonschema --check-metaschema website/static/schema.json
+  check_doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get changed files in the docs folder
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v44
+        with:
+          files: website/versioned_docs/**
+
+      - uses: actions/github-script@v7
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        with:
+          script: |
+            core.setFailed('website/versioned_docs has changed. Instead you need to update the docs in the website/docs folder.')


### PR DESCRIPTION
A small proposal: check in the CI if files under versioned_docs has been modified.

We had the issue twice (https://github.com/go-task/task/pull/1669 && https://github.com/go-task/task/pull/1673) so I think doing this check in the CI can be useful
EDIT : this one too : https://github.com/go-task/task/pull/1702
Here is what it looks like : 

![image](https://github.com/go-task/task/assets/9110126/b8b2b668-9649-4bf7-8ba8-da701f8e992f)

I've put it under `lint` because I did not want to create another workflow file