### PR TITLE
feat: Add template variable for `watch` trigger

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -70,6 +70,8 @@ func (e *Executor) watchTasks(calls ...*ast.Call) error {
 
 				for _, c := range calls {
 					c := c
+					c.Vars.Set("CHANGED_ABS", ast.Var{Value: event.Path})
+					c.Vars.Set("CHANGED_FILE", ast.Var{Value: event.FileInfo.Name()})
 					go func() {
 						if err := e.RunTask(ctx, c); err != nil && !isContextError(err) {
 							e.Logger.Errf(logger.Red, "%v\n", err)

--- a/website/docs/reference/templating.mdx
+++ b/website/docs/reference/templating.mdx
@@ -102,6 +102,8 @@ special variable will be overridden.
 
 | Var                | Description                                                                                                                                              |
 |--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `CHANGED_ABS`      | The absolute path to the file that triggered the task run. Only avaible when using [`watch`](../../usage/#watch-tasks).                                  |
+| `CHANGED_FILE`     | The name of the file that triggered the task run. Only avaible when using [`watch`](../../usage/#watch-tasks).                                           |
 | `CLI_ARGS`         | Contain all extra arguments passed after `--` when calling Task through the CLI.                                                                         |
 | `CLI_FORCE`        | A boolean containing whether the `--force` or `--force-all` flags were set.                                                                              |
 | `CLI_SILENT`       | A boolean containing whether the `--silent`  flag was set.                                                                                               |


### PR DESCRIPTION
When running a task in `watch` mode it can be useful to know which file triggered the task run.

<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->
