### PR TITLE
chore: Add debug task and vscode launch.json sample

### DIFF
--- a/.vscode/launch-sample.json
+++ b/.vscode/launch-sample.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to dlv",
+            "type": "go",
+            "mode": "remote",
+            "port": 5678,
+            "request": "attach",
+        }
+    ]
+}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,6 +18,9 @@ tasks:
       - task: lint
       - task: test
 
+  debug:
+    cmd: dlv debug ./cmd/task --headless --output=out/bin/debug_bin --listen=:5678 --api-version=2 -- {{.CLI_ARGS}}
+
   install:
     desc: Installs Task
     aliases: [i]


### PR DESCRIPTION
Requires [`dlv`](https://github.com/go-delve/delve) which could of course also be installed with some task but I am not proficient enough to set that up.

<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->
