### PR TITLE
Set desc to cmd on short form tasks

### DIFF
--- a/taskfile/ast/task.go
+++ b/taskfile/ast/task.go
@@ -95,6 +95,7 @@ func (t *Task) UnmarshalYAML(node *yaml.Node) error {
 		if err := node.Decode(&cmd); err != nil {
 			return errors.NewTaskfileDecodeError(err, node)
 		}
+		t.Desc = cmd.Cmd
 		t.Cmds = append(t.Cmds, &cmd)
 		return nil
 


### PR DESCRIPTION
For a taskfile with short form tasks like this one:

```
---
version: "3"

tasks:
  build: docker compose build
  up: docker compose up -d --wait
  logs: docker compose logs etl -f
  down: docker compose down
  mysql: docker compose exec -it etl-db mysql -u etl -petl etl
```

No tasks with descriptions are available. This change automatically sets the description to the aliased command.

```
# task -t Taskfile.services.yml 
task: Available tasks for this project:
* build:       docker compose build
* down:        docker compose down
* logs:        docker compose logs etl -f
* mysql:       docker compose exec -it etl-db mysql -u etl -petl etl
* up:          docker compose up -d --wait
task: Task "default" does not exist
```

A particular case for this is also that i want `services:*` targets be automatically listed in main taskfile. If a one liner becomes reasonably complex, we still have the option to rewrite it to full form.