### PR TITLE
Better aliasing for includes

### DIFF
--- a/taskfile/ast/tasks.go
+++ b/taskfile/ast/tasks.go
@@ -156,8 +156,8 @@ func (t *Tasks) UnmarshalYAML(node *yaml.Node) error {
 }
 
 func taskNameWithNamespace(taskName string, namespace string) string {
-	if strings.HasPrefix(taskName, NamespaceSeparator) {
+	if namespace == "" || strings.HasPrefix(taskName, NamespaceSeparator) {
 		return strings.TrimPrefix(taskName, NamespaceSeparator)
 	}
-	return fmt.Sprintf("%s%s%s", namespace, NamespaceSeparator, taskName)
+	return namespace + NamespaceSeparator + taskName
 }


### PR DESCRIPTION
I want to import all the targets for an included taskfile into the current namespace.

```
includes:
  services:
    taskfile: Taskfile.services.yml
    aliases: [""]
```

The aliases feature exists, however when setting it to empty it still includes the `:`, making all of the alias still have the delimiter as the prefix. The change checks for an empty namespace, and removes a redundant sprintf call in the same function.

Before the change:

```
* services:build:       docker compose build                                       (aliases: :build)
* services:down:        docker compose down                                        (aliases: :down)
* services:logs:        docker compose logs etl -f                                 (aliases: :logs)
* services:mysql:       docker compose exec -it etl-db mysql -u etl -petl etl      (aliases: :mysql)
* services:up:          docker compose up -d --wait                                (aliases: :up)
```

After the change:

```
* services:build:       docker compose build                                       (aliases: build)
* services:down:        docker compose down                                        (aliases: down)
* services:logs:        docker compose logs etl -f                                 (aliases: logs)
* services:mysql:       docker compose exec -it etl-db mysql -u etl -petl etl      (aliases: mysql)
* services:up:          docker compose up -d --wait                                (aliases: up)
```