### PR TITLE
Recompile task after runDeps to reload envs set by deps

### DIFF
--- a/task.go
+++ b/task.go
@@ -195,6 +195,13 @@ func (e *Executor) RunTask(ctx context.Context, call *ast.Call) error {
 		if err := e.runDeps(ctx, t); err != nil {
 			return err
 		}
+		if len(t.Deps) > 0 {
+			// Recompile the task after running dependencies to reload environment variables from dotenv files which may have been set up during the dependency execution
+			t, err = e.CompiledTask(call)
+			if err != nil {
+				return err
+			}
+		}
 
 		skipFingerprinting := e.ForceAll || (!call.Indirect && e.Force)
 		if !skipFingerprinting {


### PR DESCRIPTION
fix #1381

I would like to create an environment variable file using deps, read it with dotenv, and use it in cmds.

### tested by followings

1. generate `Taskfile.test.yml` (copy from #1381 )

```yaml
version: 3

tasks:
  make-env:
    cmds:
      - echo "MY_VAR=MY_VALUE" >> ./.env
  my-task:
    deps:
      - make-env
    dotenv:
      - ./.env
    cmds:
      - echo "MY_VAR = $MY_VAR"
```

2. run following

```bash
rm -f .env && go run ./cmd/task -t Taskfile.test.yml my-task
```

result:

(before):

```
task: [make-env] echo "MY_VAR=MY_VALUE" >> ./.env
task: [my-task] echo "MY_VAR = $MY_VAR"
MY_VAR =
```

(after):

```
task: [make-env] echo "MY_VAR=MY_VALUE" >> ./.env
task: [my-task] echo "MY_VAR = $MY_VAR"
MY_VAR = MY_VALUE
```