### PR TITLE
feat: add ALIAS special var

### DIFF
--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -46,7 +46,7 @@ func (c *Compiler) FastGetVariables(t *ast.Task, call *ast.Call) (*ast.Vars, err
 func (c *Compiler) getVariables(t *ast.Task, call *ast.Call, evaluateShVars bool) (*ast.Vars, error) {
 	result := GetEnviron()
 	if t != nil {
-		specialVars, err := c.getSpecialVars(t)
+		specialVars, err := c.getSpecialVars(t, call)
 		if err != nil {
 			return nil, err
 		}
@@ -179,9 +179,10 @@ func (c *Compiler) ResetCache() {
 	c.dynamicCache = nil
 }
 
-func (c *Compiler) getSpecialVars(t *ast.Task) (map[string]string, error) {
+func (c *Compiler) getSpecialVars(t *ast.Task, call *ast.Call) (map[string]string, error) {
 	return map[string]string{
 		"TASK":             t.Task,
+		"ALIAS":            call.Task,
 		"TASK_EXE":         filepath.ToSlash(os.Args[0]),
 		"ROOT_TASKFILE":    filepathext.SmartJoin(c.Dir, c.Entrypoint),
 		"ROOT_DIR":         c.Dir,

--- a/testdata/special_vars/Taskfile.yml
+++ b/testdata/special_vars/Taskfile.yml
@@ -6,8 +6,16 @@ includes:
     dir: ./included
 
 tasks:
-  print-task: echo {{.TASK}}
+  print-task:
+    aliases: [echo-task]
+    cmds:
+      - echo {{.TASK}}
   print-root-dir: echo {{.ROOT_DIR}}
   print-taskfile: echo {{.TASKFILE}}
   print-taskfile-dir: echo {{.TASKFILE_DIR}}
   print-task-version: echo {{.TASK_VERSION}}
+  print-task-alias:
+    aliases: [echo-task-alias]
+    cmds:
+      - echo "{{.ALIAS}}"
+  print-task-alias-default: echo "{{.ALIAS}}"

--- a/testdata/special_vars/included/Taskfile.yml
+++ b/testdata/special_vars/included/Taskfile.yml
@@ -1,8 +1,16 @@
 version: '3'
 
 tasks:
-  print-task: echo {{.TASK}}
+  print-task:
+    aliases: [echo-task]
+    cmds:
+      - echo {{.TASK}}
   print-root-dir: echo {{.ROOT_DIR}}
   print-taskfile: echo {{.TASKFILE}}
   print-taskfile-dir: echo {{.TASKFILE_DIR}}
   print-task-version: echo {{.TASK_VERSION}}
+  print-task-alias:
+    aliases: [echo-task-alias]
+    cmds:
+      - echo "{{.ALIAS}}"
+  print-task-alias-default: echo "{{.ALIAS}}"

--- a/website/docs/reference/templating.mdx
+++ b/website/docs/reference/templating.mdx
@@ -107,6 +107,7 @@ special variable will be overridden.
 | `CLI_SILENT`       | A boolean containing whether the `--silent`  flag was set.                                                                                               |
 | `CLI_VERBOSE`      | A boolean containing whether the `--verbose`  flag was set.                                                                                              |
 | `TASK`             | The name of the current task.                                                                                                                            |
+| `ALIAS`            | The alias used for the current task, otherwise matches `TASK`                                                                                            |
 | `TASK_EXE`         | The Task executable name or path.                                                                                                                        |
 | `ROOT_TASKFILE`    | The absolute path of the root Taskfile.                                                                                                                  |
 | `ROOT_DIR`         | The absolute path of the root Taskfile directory.                                                                                                        |


### PR DESCRIPTION
Adds `ALIAS` to special vars that represents the alias that was used when invoking the task, otherwise will be the task name.

```bash
> go run ./cmd/task --dir testdata/special_vars echo-task-alias
task: [print-task-alias] echo "echo-task-alias"
echo-task-alias

> go run ./cmd/task --dir testdata/special_vars print-task-alias
task: [print-task-alias] echo "print-task-alias"
print-task-alias
```