### PR TITLE
fix(completion): display aliases in fish completion

### DIFF
--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -10,7 +10,7 @@ function __task_get_tasks --description "Prints all available tasks with their d
   end
 
   # Grab names and descriptions (if any) of the tasks
-  set -l output (echo $rawOutput | sed -e '1d; s/\* \(.*\):\s*\(.*\)\s*(aliases.*/\1\t\2/' -e 's/\* \(.*\):\s*\(.*\)/\1\t\2/'| string split0)
+  set -l output (echo $rawOutput | sed -e '1d; s/\* \(.*\):\s*\(.*\)\s*(\(aliases.*\))/\1\t\2\t\3/' -e 's/\* \(.*\):\s*\(.*\)/\1\t\2/'| string split0)
   if test $output
     echo $output
   end


### PR DESCRIPTION
Fixes #1781 

Before : 
![task_fish](https://github.com/user-attachments/assets/b7d055f2-3e8f-4621-8004-3266c7691d46)

After : 
![task_fish_fix](https://github.com/user-attachments/assets/2014cb4b-1bf9-4c5b-a60a-6534c04f5ae5)

@davinkevin It would be amazing if you could test it before we release this. I test it locally with the docker container it sounds fine