### PR TITLE
Fix bug for running tasks twice

### DIFF
--- a/taskfile/ast/task.go
+++ b/taskfile/ast/task.go
@@ -43,7 +43,7 @@ type Task struct {
 	Watch         bool
 	Location      *Location
 	// Populated during merging
-	Namespace            string
+	Namespace            []string
 	IncludeVars          *Vars
 	IncludedTaskfileVars *Vars
 }
@@ -57,8 +57,10 @@ func (t *Task) Name() string {
 
 func (t *Task) LocalName() string {
 	name := t.Task
-	name = strings.TrimPrefix(name, t.Namespace)
-	name = strings.TrimPrefix(name, ":")
+	for _, namespace := range t.Namespace {
+		name = strings.TrimPrefix(name, namespace)
+		name = strings.TrimPrefix(name, ":")
+	}
 	return name
 }
 
@@ -219,7 +221,7 @@ func (t *Task) DeepCopy() *Task {
 		Platforms:            deepcopy.Slice(t.Platforms),
 		Location:             t.Location.DeepCopy(),
 		Requires:             t.Requires.DeepCopy(),
-		Namespace:            t.Namespace,
+		Namespace:            append([]string{}, t.Namespace...),
 	}
 	return c
 }

--- a/taskfile/ast/tasks.go
+++ b/taskfile/ast/tasks.go
@@ -87,7 +87,7 @@ func (t1 *Tasks) Merge(t2 Tasks, include *Include, includedTaskfileVars *Vars) e
 			}
 
 			taskName = taskNameWithNamespace(name, include.Namespace)
-			task.Namespace = include.Namespace
+			task.Namespace = append([]string{include.Namespace}, task.Namespace...)
 			task.Task = taskName
 		}
 


### PR DESCRIPTION
This fixes #1498 by keeping track of the namespaces of a task in an array, instead of just the last one.