### PR TITLE
fix: double help is printed when `--help` is provided

### DIFF
--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -72,6 +72,7 @@ func getEnvFilePath() string {
 	fs := pflag.NewFlagSet("experiments", pflag.ContinueOnError)
 	fs.StringVarP(&dir, "dir", "d", "", "Sets directory of execution.")
 	fs.StringVarP(&taskfile, "taskfile", "t", "", `Choose which Taskfile to run. Defaults to "Taskfile.yml".`)
+	fs.Usage = func() {}
 	_ = fs.Parse(os.Args[1:])
 	// If the directory is set, find a .env file in that directory.
 	if dir != "" {


### PR DESCRIPTION
Initially reported in 
- https://github.com/go-task/task/issues/1805

I took a look and discover when we call `task --help` double usage is printed

![image](https://github.com/user-attachments/assets/9f35268f-0cce-48e3-919f-49d58156fad5)

I've tracked it down to https://github.com/go-task/task/pull/1478
Flagset parse automatically --help to display usage.
A simple fix is to override `usage` func

Now : 

![image](https://github.com/user-attachments/assets/0360257e-407a-49c9-952c-0c0eb1e61283)



