### PR TITLE
Fix zsh completion

### DIFF
--- a/completion/zsh/_task
+++ b/completion/zsh/_task
@@ -39,26 +39,36 @@ function __task_list() {
     _describe 'Task to run' scripts
 }
 
-_arguments \
-    '(-C --concurrency)'{-C,--concurrency}'[limit number of concurrent tasks]: ' \
-    '(-p --parallel)'{-p,--parallel}'[run command-line tasks in parallel]' \
-    '(-f --force)'{-f,--force}'[run even if task is up-to-date]' \
-    '(-c --color)'{-c,--color}'[colored output]' \
-    '(-d --dir)'{-d,--dir}'[dir to run in]:execution dir:_dirs' \
-    '(--dry)--dry[dry-run mode, compile and print tasks only]' \
-    '(-o --output)'{-o,--output}'[set output style]:style:(interleaved group prefixed)' \
-    '(--output-group-begin)--output-group-begin[message template before grouped output]:template text: ' \
-    '(--output-group-end)--output-group-end[message template after grouped output]:template text: ' \
-    '(-s --silent)'{-s,--silent}'[disable echoing]' \
-    '(--status)--status[exit non-zero if supplied tasks not up-to-date]' \
-    '(--summary)--summary[show summary\: field from tasks instead of running them]' \
-    '(-t --taskfile)'{-t,--taskfile}'[specify a different taskfile]:taskfile:_files' \
-    '(-v --verbose)'{-v,--verbose}'[verbose mode]' \
-    '(-w --watch)'{-w,--watch}'[watch-mode for given tasks, re-run when inputs change]' \
-    + '(operation)' \
-        {-l,--list}'[list describable tasks]' \
-        {-a,--list-all}'[list all tasks]' \
-        {-i,--init}'[create new Taskfile.yml]' \
-        '(-*)'{-h,--help}'[show help]' \
-        '(-*)--version[show version and exit]' \
-        '*: :__task_list'
+_task() {
+    _arguments \
+        '(-C --concurrency)'{-C,--concurrency}'[limit number of concurrent tasks]: ' \
+        '(-p --parallel)'{-p,--parallel}'[run command-line tasks in parallel]' \
+        '(-f --force)'{-f,--force}'[run even if task is up-to-date]' \
+        '(-c --color)'{-c,--color}'[colored output]' \
+        '(-d --dir)'{-d,--dir}'[dir to run in]:execution dir:_dirs' \
+        '(--dry)--dry[dry-run mode, compile and print tasks only]' \
+        '(-o --output)'{-o,--output}'[set output style]:style:(interleaved group prefixed)' \
+        '(--output-group-begin)--output-group-begin[message template before grouped output]:template text: ' \
+        '(--output-group-end)--output-group-end[message template after grouped output]:template text: ' \
+        '(-s --silent)'{-s,--silent}'[disable echoing]' \
+        '(--status)--status[exit non-zero if supplied tasks not up-to-date]' \
+        '(--summary)--summary[show summary\: field from tasks instead of running them]' \
+        '(-t --taskfile)'{-t,--taskfile}'[specify a different taskfile]:taskfile:_files' \
+        '(-v --verbose)'{-v,--verbose}'[verbose mode]' \
+        '(-w --watch)'{-w,--watch}'[watch-mode for given tasks, re-run when inputs change]' \
+        + '(operation)' \
+            {-l,--list}'[list describable tasks]' \
+            {-a,--list-all}'[list all tasks]' \
+            {-i,--init}'[create new Taskfile.yml]' \
+            '(-*)'{-h,--help}'[show help]' \
+            '(-*)--version[show version and exit]' \
+            '*: :__task_list'
+    return 0
+}
+
+if [ "$funcstack[1]" = "_task" ]; then
+    _task "$@"
+else
+    compdef _task task
+fi
+


### PR DESCRIPTION
The call of `_arguments` causes an error like this and the completion does not work in zsh.

```console
$  zsh --version
zsh 5.9 (x86_64-debian-linux-gnu)

$  eval "$(task --completion zsh)"
_arguments:comparguments:327: can only be called from completion function
```

This PR fixes it.
I refereed to [mise's completion](https://github.com/jdx/mise/blob/c73ecd1aa55f6e2c29da5d7314a207af4bb2010f/completions/_mise) and this fix seems to work fine.