### PR TITLE
fix: interpolate dynamic vars in defer

### DIFF
--- a/task.go
+++ b/task.go
@@ -330,7 +330,7 @@ func (e *Executor) runDeferred(t *ast.Task, call *ast.Call, i int, deferredExitC
 	}
 
 	cmd := t.Cmds[i]
-	vars, _ := e.Compiler.FastGetVariables(origTask, call)
+	vars, _ := e.Compiler.GetVariables(origTask, call)
 	cache := &templater.Cache{Vars: vars}
 	extra := map[string]any{}
 

--- a/task_test.go
+++ b/task_test.go
@@ -1788,7 +1788,7 @@ func TestExitCodeZero(t *testing.T) {
 	require.NoError(t, e.Setup())
 
 	require.NoError(t, e.Run(context.Background(), &ast.Call{Task: "exit-zero"}))
-	assert.Equal(t, "FOO=bar - EXIT_CODE=", strings.TrimSpace(buff.String()))
+	assert.Equal(t, "FOO=bar - DYNAMIC_FOO=bar - EXIT_CODE=", strings.TrimSpace(buff.String()))
 }
 
 func TestExitCodeOne(t *testing.T) {
@@ -1802,7 +1802,7 @@ func TestExitCodeOne(t *testing.T) {
 	require.NoError(t, e.Setup())
 
 	require.Error(t, e.Run(context.Background(), &ast.Call{Task: "exit-one"}))
-	assert.Equal(t, "FOO=bar - EXIT_CODE=1", strings.TrimSpace(buff.String()))
+	assert.Equal(t, "FOO=bar - DYNAMIC_FOO=bar - EXIT_CODE=1", strings.TrimSpace(buff.String()))
 }
 
 func TestIgnoreNilElements(t *testing.T) {

--- a/testdata/exit_code/Taskfile.yml
+++ b/testdata/exit_code/Taskfile.yml
@@ -9,13 +9,17 @@ tasks:
   exit-zero:
     vars:
       FOO: bar
+      DYNAMIC_FOO:
+        sh: echo 'bar'
     cmds:
-      - defer: echo FOO={{.FOO}} - {{.PREFIX}}{{.EXIT_CODE}}
+      - defer: echo FOO={{.FOO}} - DYNAMIC_FOO={{.DYNAMIC_FOO}} - {{.PREFIX}}{{.EXIT_CODE}}
       - exit 0
 
   exit-one:
     vars:
       FOO: bar
+      DYNAMIC_FOO:
+        sh: echo 'bar'
     cmds:
-      - defer: echo FOO={{.FOO}} - {{.PREFIX}}{{.EXIT_CODE}}
+      - defer: echo FOO={{.FOO}} - DYNAMIC_FOO={{.DYNAMIC_FOO}} - {{.PREFIX}}{{.EXIT_CODE}}
       - exit 1


### PR DESCRIPTION
Fixes #1803 

We need to evaluate sh vars in defer cmds