### PR TITLE
Fix: Cannot use splitArgs and splitLines in for-loops

### DIFF
--- a/variables.go
+++ b/variables.go
@@ -309,10 +309,10 @@ func itemsFromFor(
 					} else {
 						values = asAnySlice(strings.Fields(value))
 					}
-				case []any:
-					values = value
 				case []string:
 					values = asAnySlice(value)
+				case []any:
+					values = value
 				case map[string]any:
 					for k, v := range value {
 						keys = append(keys, k)

--- a/variables.go
+++ b/variables.go
@@ -311,6 +311,8 @@ func itemsFromFor(
 					}
 				case []string:
 					values = asAnySlice(value)
+				case []int:
+					values = asAnySlice(value)
 				case []any:
 					values = value
 				case map[string]any:

--- a/variables.go
+++ b/variables.go
@@ -309,7 +309,7 @@ func itemsFromFor(
 					} else {
 						values = asAnySlice(strings.Fields(value))
 					}
-				case []any:
+				case []any, []string:
 					values = value
 				case map[string]any:
 					for k, v := range value {

--- a/variables.go
+++ b/variables.go
@@ -309,8 +309,10 @@ func itemsFromFor(
 					} else {
 						values = asAnySlice(strings.Fields(value))
 					}
-				case []any, []string:
+				case []any:
 					values = value
+				case []string:
+					values = asAnySlice(value)
 				case map[string]any:
 					for k, v := range value {
 						keys = append(keys, k)


### PR DESCRIPTION
Solves https://github.com/go-task/task/issues/1822

<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->
