### PR TITLE
fix: snapshot builds and wrong winget version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,7 +49,7 @@ release:
   draft: true
 
 snapshot:
-  version_template: "{{.Tag}}"
+  version_template: "{{.Version}}"
 
 checksum:
   name_template: "task_checksums.txt"


### PR DESCRIPTION
refs https://github.com/goreleaser/goreleaser/issues/5142

docs should be better, but its not a good idea to use `tag` in the snapshot version template

this should fix the issue you're having