### PR TITLE
feat: trigger watched task on new file

### DIFF
--- a/watch_test.go
+++ b/watch_test.go
@@ -28,6 +28,8 @@ task: [default] echo "Hello, World!"
 Hello, World!
 task: [default] echo "Hello, World!"
 Hello, World!
+task: [default] echo "Hello, World!"
+Hello, World!
 	`)
 
 	var buff bytes.Buffer
@@ -68,6 +70,11 @@ Hello, World!
 
 	time.Sleep(10 * time.Millisecond)
 	err = os.WriteFile(filepathext.SmartJoin(dir, "src/a"), []byte("test updated"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(700 * time.Millisecond)
+	err = os.WriteFile(filepathext.SmartJoin(dir, "src/b"), []byte("test"), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Currently, if a task is being watched and a file matching the source glob gets added, the task is NOT run; the file needs to be *subsequently* modified to trigger an actual task run. This PR changes this behavior so that the simple act of adding a file will trigger a task run.

This is based on the discussion and the preliminary code in https://github.com/go-task/task/issues/1179.

