### PR TITLE
fix: checksum override when passed via ldflags

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,7 +18,9 @@ func init() {
 		if version == "" {
 			version = info.Main.Version
 		}
-		sum = info.Main.Sum
+		if sum == "" {
+			sum = info.Main.Sum
+		}
 	}
 }
 


### PR DESCRIPTION
PR #1711 fixed variable `version` being overridden, this PR ensures that the same does not happen to `sum`.

EDIT: This patch is being shipped in the `go-task` package for Arch Linux.