### PR TITLE
fix(remote): wait for prompt in the reader

### DIFF
--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -244,13 +244,15 @@ func (r *Reader) readNode(node Node) (*ast.Taskfile, error) {
 				// If there is a cached hash, but it doesn't match the expected hash, prompt the user to continue
 				prompt = fmt.Sprintf(taskfileChangedPrompt, node.Location())
 			}
-			r.graph.Lock()
+
 			if prompt != "" {
+				r.graph.Lock()
 				if err := r.logger.Prompt(logger.Yellow, prompt, "n", "y", "yes"); err != nil {
+					r.graph.Unlock()
 					return nil, &errors.TaskfileNotTrustedError{URI: node.Location()}
 				}
+				r.graph.Unlock()
 			}
-			r.graph.Unlock()
 
 			// If the hash has changed (or is new)
 			if checksum != cachedChecksum {

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -244,11 +244,13 @@ func (r *Reader) readNode(node Node) (*ast.Taskfile, error) {
 				// If there is a cached hash, but it doesn't match the expected hash, prompt the user to continue
 				prompt = fmt.Sprintf(taskfileChangedPrompt, node.Location())
 			}
+			r.graph.Lock()
 			if prompt != "" {
 				if err := r.logger.Prompt(logger.Yellow, prompt, "n", "y", "yes"); err != nil {
 					return nil, &errors.TaskfileNotTrustedError{URI: node.Location()}
 				}
 			}
+			r.graph.Unlock()
 
 			// If the hash has changed (or is new)
 			if checksum != cachedChecksum {

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -249,14 +249,14 @@ func (r *Reader) readNode(node Node) (*ast.Taskfile, error) {
 			}
 
 			if prompt != "" {
-				r.promptMutex.Lock()
-				if err := r.logger.Prompt(logger.Yellow, prompt, "n", "y", "yes"); err != nil {
-					r.promptMutex.Unlock()
+				if err := func() error {
+					r.promptMutex.Lock()
+					defer r.promptMutex.Unlock()
+					return r.logger.Prompt(logger.Yellow, prompt, "n", "y", "yes")
+				}(); err != nil {
 					return nil, &errors.TaskfileNotTrustedError{URI: node.Location()}
 				}
-				r.promptMutex.Unlock()
 			}
-
 			// If the hash has changed (or is new)
 			if checksum != cachedChecksum {
 				// Store the checksum


### PR DESCRIPTION
Fixes #1832 
I've choose to re-use the mutex on the graph.

Maybe you have a better solution @pd93 

![image](https://github.com/user-attachments/assets/97a16d3b-4b1d-4344-8547-28fd557993b5)

