### PR TITLE
fix: Flaky TestForDeps tests

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -40,6 +40,7 @@ type SyncBuffer struct {
 func (sb *SyncBuffer) Write(p []byte) (n int, err error) {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
+	fmt.Fprintln(os.Stderr, "len:", len(p))
 	return sb.buf.Write(p)
 }
 

--- a/task_test.go
+++ b/task_test.go
@@ -2489,6 +2489,8 @@ func TestForDeps(t *testing.T) {
 				Stderr: &buff,
 				Silent: true,
 				Force:  true,
+				// Force output of each dep to be grouped together to prevent interleaving
+				OutputStyle: ast.Output{Name: "group"},
 			}
 			require.NoError(t, e.Setup())
 			require.NoError(t, e.Run(context.Background(), &ast.Call{Task: test.name}))

--- a/task_test.go
+++ b/task_test.go
@@ -40,7 +40,6 @@ type SyncBuffer struct {
 func (sb *SyncBuffer) Write(p []byte) (n int, err error) {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
-	fmt.Fprintln(os.Stderr, "len:", len(p))
 	return sb.buf.Write(p)
 }
 


### PR DESCRIPTION
The executor output for parallel task (and dep) execution can come out one character at a time, so even though the tests use `SyncWriter`, the writer's lock doesn't prevent interleaving.

Using `group` output forces the task output to be buffered and kept together before being printed.

Fixes https://github.com/go-task/task/issues/1819.