### PR TITLE
fix: Print dotenv file path when there is an error reading file

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -1657,6 +1657,18 @@ func TestDotenvHasEnvVarInPath(t *testing.T) {
 	tt.Run(t)
 }
 
+func TestTaskDotenvParseErrorMessage(t *testing.T) {
+	e := task.Executor{
+		Dir: "testdata/dotenv/parse_error",
+	}
+
+	path, _ := filepath.Abs(filepath.Join(e.Dir, ".env-with-error"))
+	expected := fmt.Sprintf("error reading env file %s:", path)
+
+	err := e.Setup()
+	require.ErrorContains(t, err, expected)
+}
+
 func TestTaskDotenv(t *testing.T) {
 	tt := fileContentTest{
 		Dir:       "testdata/dotenv_task/default",

--- a/taskfile/dotenv.go
+++ b/taskfile/dotenv.go
@@ -1,6 +1,7 @@
 package taskfile
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/joho/godotenv"
@@ -37,7 +38,7 @@ func Dotenv(c *compiler.Compiler, tf *ast.Taskfile, dir string) (*ast.Vars, erro
 
 		envs, err := godotenv.Read(dotEnvPath)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error reading env file %s: %w", dotEnvPath, err)
 		}
 		for key, value := range envs {
 			if ok := env.Exists(key); !ok {

--- a/testdata/dotenv/parse_error/.env-with-error
+++ b/testdata/dotenv/parse_error/.env-with-error
@@ -1,0 +1,2 @@
+#intentional parse error
+SOME_VAR

--- a/testdata/dotenv/parse_error/Taskfile.yml
+++ b/testdata/dotenv/parse_error/Taskfile.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+dotenv: ['.env-with-error']
+
+tasks:
+  default:
+    cmd: "true"
+


### PR DESCRIPTION
Fixes #1261.
