### PR TITLE
Create directory before evaluating dynamic arguments

### DIFF
--- a/task.go
+++ b/task.go
@@ -168,6 +168,11 @@ func (e *Executor) splitRegularAndWatchCalls(calls ...*ast.Call) (regularCalls [
 // RunTask runs a task by its name
 func (e *Executor) RunTask(ctx context.Context, call *ast.Call) error {
 	t, err := e.FastCompiledTask(call)
+
+	if err := e.mkdir(t); err != nil {
+		e.Logger.Errf(logger.Red, "task: cannot make directory %q: %v\n", t.Dir, err)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/task.go
+++ b/task.go
@@ -250,10 +250,6 @@ func (e *Executor) RunTask(ctx context.Context, call *ast.Call) error {
 			}
 		}
 
-		if err := e.mkdir(t); err != nil {
-			e.Logger.Errf(logger.Red, "task: cannot make directory %q: %v\n", t.Dir, err)
-		}
-
 		var deferredExitCode uint8
 
 		for i := range t.Cmds {

--- a/task_test.go
+++ b/task_test.go
@@ -1528,6 +1528,34 @@ func TestDynamicVariablesRunOnTheNewCreatedDir(t *testing.T) {
 	_ = os.RemoveAll(toBeCreated)
 }
 
+func TestExplicitDynamicVariablesRunOnTheNewCreatedDir(t *testing.T) {
+	const expected = "created"
+	const dir = "testdata/dir/explicit_dynamic_var_on_created_dir/"
+	const toBeCreated = dir + expected
+	const target = "default"
+	var out bytes.Buffer
+	e := &task.Executor{
+		Dir:    dir,
+		Stdout: &out,
+		Stderr: &out,
+	}
+
+	// Ensure that the directory to be created doesn't actually exist.
+	_ = os.RemoveAll(toBeCreated)
+	if _, err := os.Stat(toBeCreated); err == nil {
+		t.Errorf("Directory should not exist: %v", err)
+	}
+
+	require.NoError(t, e.Setup())
+	require.NoError(t, e.Run(context.Background(), &ast.Call{Task: target}))
+
+	got := strings.TrimSuffix(filepath.Base(out.String()), "\n")
+	assert.Equal(t, expected, got, "Mismatch in the working directory")
+
+	// Clean-up after ourselves only if no error.
+	_ = os.RemoveAll(toBeCreated)
+}
+
 func TestDynamicVariablesShouldRunOnTheTaskDir(t *testing.T) {
 	tt := fileContentTest{
 		Dir:       "testdata/dir/dynamic_var",

--- a/testdata/dir/explicit_dynamic_var_on_created_dir/Taskfile.yml
+++ b/testdata/dir/explicit_dynamic_var_on_created_dir/Taskfile.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+tasks:
+  default:
+    dir: created
+    vars:
+      TEST_VAR:
+        sh: echo test > created && echo created
+    cmds:
+      - |
+        echo "/{{.TEST_VAR}}"


### PR DESCRIPTION
Create the task's directory before evaluating dynamic arguments, so that they can use the directory if they need to.

I'm new here and to this repo, so hopefully I conformed to the guidelines, but if not let me know!

Fix for https://github.com/go-task/task/issues/1841