### PR TITLE
chore: add linter misspell

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - goimports
     - gofmt
     - gofumpt
+    - misspell
 
 linters-settings:
   goimports:

--- a/task_test.go
+++ b/task_test.go
@@ -120,10 +120,10 @@ func TestEnv(t *testing.T) {
 		Target:    "default",
 		TrimSpace: false,
 		Files: map[string]string{
-			"local.txt":         "GOOS='linux' GOARCH='amd64' CGO_ENABLED='0'\n",
-			"global.txt":        "FOO='foo' BAR='overriden' BAZ='baz'\n",
-			"multiple_type.txt": "FOO='1' BAR='true' BAZ='1.1'\n",
-			"not-overriden.txt": "QUX='from_os'\n",
+			"local.txt":          "GOOS='linux' GOARCH='amd64' CGO_ENABLED='0'\n",
+			"global.txt":         "FOO='foo' BAR='overridden' BAZ='baz'\n",
+			"multiple_type.txt":  "FOO='1' BAR='true' BAZ='1.1'\n",
+			"not-overridden.txt": "QUX='from_os'\n",
 		},
 	}
 	tt.Run(t)
@@ -131,10 +131,10 @@ func TestEnv(t *testing.T) {
 	experiments.EnvPrecedence = experiments.New("ENV_PRECEDENCE")
 	ttt := fileContentTest{
 		Dir:       "testdata/env",
-		Target:    "overriden",
+		Target:    "overridden",
 		TrimSpace: false,
 		Files: map[string]string{
-			"overriden.txt": "QUX='from_taskfile'\n",
+			"overridden.txt": "QUX='from_taskfile'\n",
 		},
 	}
 	ttt.Run(t)

--- a/testdata/env/Taskfile.yml
+++ b/testdata/env/Taskfile.yml
@@ -15,7 +15,7 @@ tasks:
     cmds:
       - task: local
       - task: global
-      - task: not-overriden
+      - task: not-overridden
       - task: multiple_type
 
   local:
@@ -31,7 +31,7 @@ tasks:
 
   global:
     env:
-      BAR: overriden
+      BAR: overridden
     cmds:
       - echo "FOO='$FOO' BAR='$BAR' BAZ='$BAZ'" > global.txt
 
@@ -43,10 +43,10 @@ tasks:
     cmds:
       - echo "FOO='$FOO' BAR='$BAR' BAZ='$BAZ'" > multiple_type.txt
 
-  not-overriden:
+  not-overridden:
     cmds:
-      - echo "QUX='$QUX'" > not-overriden.txt
+      - echo "QUX='$QUX'" > not-overridden.txt
 
-  overriden:
+  overridden:
     cmds:
-      - echo "QUX='$QUX'" > overriden.txt
+      - echo "QUX='$QUX'" > overridden.txt


### PR DESCRIPTION
- find commonly misspelled english words

The past participle for "override" is "overridden", both in American and in British English: 
https://www.oxfordlearnersdictionaries.com/definition/english/override?q=override

<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->
