### PR TITLE
docs: add an example of a `default` value usage in vars

### DIFF
--- a/website/docs/usage.mdx
+++ b/website/docs/usage.mdx
@@ -1212,6 +1212,28 @@ tasks:
       - echo "{{.GREETING}}"
 ```
 
+Example of a `default` value to be overriden from CLI:
+
+```yaml
+version: '3'
+
+  greet_user:
+    desc: "Greet the user with a name."
+    vars:
+      USER_NAME: '{{.USER_NAME| default "DefaultUser"}}'
+    cmds:
+      - echo "Hello, {{.USER_NAME}}!"
+```
+
+```shell
+$ task greet_user
+task: [greet_user] echo "Hello, DefaultUser!"
+Hello, DefaultUser!
+$ task greet_user USER_NAME="Bob"
+task: [greet_user] echo "Hello, Bob!"
+Hello, Bob!
+```
+
 ### Dynamic variables
 
 The below syntax (`sh:` prop in a variable) is considered a dynamic variable.


### PR DESCRIPTION
It's rather often than not you need to use a default value for a variable, and then adjust it to your needs. There's no documentation can be found on how to achieve that so this PR should address this issue

<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->
