### PR TITLE
feat(remote): add tests for git remote taskfiles

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -1116,7 +1116,7 @@ func TestIncludesRemote(t *testing.T) {
 			secondRemote: "./second/Taskfile.yml",
 		},
 		{
-			firstRemote:  srv.URL + "/repo.git//" + dir + "/first/Taskfile.yml?ref=main",
+			firstRemote:  srv.URL + "/repo.git//" + dir + "/first/Taskfile.yml?ref=HEAD",
 			secondRemote: "./second/Taskfile.yml",
 			skip:         !gitSupported,
 		},


### PR DESCRIPTION
This uses a similar approach as the HTTP remote taskfile tests,
leveraging the `git` tool's built-in support for hosting a local HTTP
server via CGI.

I was inspired by the HTTP tests and realized the same thing could work for git.