### PR TITLE
fix: bug where non-nil, empty dynamic variables are returned as an empty interface

### DIFF
--- a/taskfile/ast/var.go
+++ b/taskfile/ast/var.go
@@ -20,7 +20,7 @@ type Vars struct {
 func (vs *Vars) ToCacheMap() (m map[string]any) {
 	m = make(map[string]any, vs.Len())
 	_ = vs.Range(func(k string, v Var) error {
-		if v.Sh != "" {
+		if v.Sh != nil && *v.Sh != "" {
 			// Dynamic variable is not yet resolved; trigger
 			// <no value> to be used in templates.
 			return nil
@@ -81,7 +81,7 @@ func (vs *Vars) DeepCopy() *Vars {
 type Var struct {
 	Value any
 	Live  any
-	Sh    string
+	Sh    *string
 	Ref   string
 	Dir   string
 }
@@ -98,7 +98,7 @@ func (v *Var) UnmarshalYAML(node *yaml.Node) error {
 			// If the value is a string and it starts with $, then it's a shell command
 			if str, ok := value.(string); ok {
 				if str, ok = strings.CutPrefix(str, "$"); ok {
-					v.Sh = str
+					v.Sh = &str
 					return nil
 				}
 				if str, ok = strings.CutPrefix(str, "#"); ok {
@@ -118,7 +118,7 @@ func (v *Var) UnmarshalYAML(node *yaml.Node) error {
 				switch key {
 				case "sh", "ref", "map":
 					var m struct {
-						Sh  string
+						Sh  *string
 						Ref string
 						Map any
 					}
@@ -150,7 +150,7 @@ func (v *Var) UnmarshalYAML(node *yaml.Node) error {
 		switch key {
 		case "sh", "ref":
 			var m struct {
-				Sh  string
+				Sh  *string
 				Ref string
 			}
 			if err := node.Decode(&m); err != nil {

--- a/variables.go
+++ b/variables.go
@@ -112,7 +112,7 @@ func (e *Executor) compiledTask(call *ast.Call, evaluateShVars bool) (*ast.Task,
 	if evaluateShVars {
 		err = new.Env.Range(func(k string, v ast.Var) error {
 			// If the variable is not dynamic, we can set it and return
-			if v.Value != nil || v.Sh == "" {
+			if v.Value != nil || v.Sh == nil {
 				new.Env.Set(k, ast.Var{Value: v.Value})
 				return nil
 			}
@@ -301,7 +301,7 @@ func itemsFromFor(
 			// If the variable is dynamic, then it hasn't been resolved yet
 			// and we can't use it as a list. This happens when fast compiling a task
 			// for use in --list or --list-all etc.
-			if v.Value != nil && v.Sh == "" {
+			if v.Value != nil && v.Sh == nil {
 				switch value := v.Value.(type) {
 				case string:
 					if f.Split != "" {


### PR DESCRIPTION
Fixes #1903

This PR changes the `Sh` property of a `Var` to a pointer so that we are able to distinguish between a value that is not set (`nil`) and a value that is empty (`&""`). We then use this to return early if we detect an empty dynamic variable. This will always resolve to another empty string.

This fixes cases where a dynamic variable contains a template that resolves to an empty string.