### PR TITLE
fix: typos in docs, changelog, testdata, comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,7 +292,7 @@
 - Added the
   [Remote Taskfiles experiment](https://taskfile.dev/experiments/remote-taskfiles)
   as a draft (#1152, #1317 by @pd93).
-- Improve performance of content checksuming on `sources:` by replacing md5 with
+- Improve performance of content checksumming on `sources:` by replacing md5 with
   [XXH3](https://xxhash.com/) which is much faster. This is a soft breaking
   change because checksums will be invalidated when upgrading to this release
   (#1325 by @ReillyBrogan).
@@ -352,7 +352,7 @@
 - Deprecated `version: 2` schema. This will be removed in the next major release
   (#1197, #1198, #1199 by @pd93).
 - Added a new `prompt:` prop to set a warning prompt to be shown before running
-  a potential dangurous task (#100, #1163 by @MaxCheetham,
+  a potential dangerous task (#100, #1163 by @MaxCheetham,
   [Documentation](https://taskfile.dev/usage/#warning-prompts)).
 - Added support for single command task syntax. With this change, it's now
   possible to declare just `cmd:` in a task, avoiding the more complex
@@ -367,7 +367,7 @@
   percentage (#1173 by @misitebao).
 - Starting on this release, official binaries for FreeBSD will be available to
   download (#1068 by @andreynering).
-- Fix some errors being unintendedly supressed (#1134 by @clintmod).
+- Fix some errors being unintendedly suppressed (#1134 by @clintmod).
 - Fix a nil pointer error when `version` is omitted from a Taskfile (#1148,
   #1149 by @pd93).
 - Fix duplicate error message when a task does not exists (#1141, #1144 by
@@ -441,7 +441,7 @@ it a go and let us know what you think via a
   by @pd93).
 - Update to Go 1.20 (bump minimum version to 1.19) (#1010 by @pd93)
 - Added environment variable `FORCE_COLOR` support to force color output.
-  Usefull for environments without TTY (#1003 by @automation-stack)
+  Useful for environments without TTY (#1003 by @automation-stack)
 
 ## v3.20.0 - 2023-01-14
 
@@ -796,7 +796,7 @@ it a go and let us know what you think via a
 
 - Fix error code for the `--help` flag (#300, #330).
 - Print version to stdout instead of stderr (#299, #329).
-- Supress `context` errors when using the `--watch` flag (#313, #317).
+- Suppress `context` errors when using the `--watch` flag (#313, #317).
 - Support templating on description (#276, #283).
 
 ## v2.8.0 - 2019-12-07
@@ -805,7 +805,7 @@ it a go and let us know what you think via a
   parallel (#266).
 - Fixed bug where calling the `task` CLI only informing global vars would not
   execute the `default` task.
-- Add hability to silent all tasks by adding `silent: true` a the root of the
+- Add ability to silent all tasks by adding `silent: true` a the root of the
   Taskfile.
 
 ## v2.7.1 - 2019-11-10
@@ -947,7 +947,7 @@ document, since it describes in depth what changed for this version.
 ## v1.4.3 - 2017-09-07
 
 - Allow assigning variables to tasks at run time via CLI (#33)
-- Added suport for multiline variables from sh (#64)
+- Added support for multiline variables from sh (#64)
 - Fixes env: remove square braces and evaluate shell (#62)
 - Watch: change watch library and few fixes and improvements
 - When use watching, cancel and restart long running process on file change (#59
@@ -1007,7 +1007,7 @@ document, since it describes in depth what changed for this version.
 - More tests and Travis integration
 - Watch a task (experimental)
 - Possibility to call another task
-- Fix "=" not being reconized in variables/environment variables
+- Fix "=" not being recognized in variables/environment variables
 - Tasks can now have a description, and help will print them (#10)
 - Task dependencies now run concurrently
 - Support for a default task (#16)

--- a/cmd/sleepit/sleepit.go
+++ b/cmd/sleepit/sleepit.go
@@ -159,7 +159,7 @@ func worker(
 	return workerDone
 }
 
-// Do some work and then return, so that the caller can decide wether to continue or not.
+// Do some work and then return, so that the caller can decide whether to continue or not.
 // Return true when all work is done.
 func doSomeWork(deadline time.Time) bool {
 	if time.Now().After(deadline) {

--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -175,7 +175,7 @@ func (c *Compiler) HandleDynamicVar(v ast.Var, dir string) (string, error) {
 	return result, nil
 }
 
-// ResetCache clear the dymanic variables cache
+// ResetCache clear the dynamic variables cache
 func (c *Compiler) ResetCache() {
 	c.muDynamicCache.Lock()
 	defer c.muDynamicCache.Unlock()

--- a/task_test.go
+++ b/task_test.go
@@ -120,10 +120,10 @@ func TestEnv(t *testing.T) {
 		Target:    "default",
 		TrimSpace: false,
 		Files: map[string]string{
-			"local.txt":         "GOOS='linux' GOARCH='amd64' CGO_ENABLED='0'\n",
-			"global.txt":        "FOO='foo' BAR='overriden' BAZ='baz'\n",
-			"multiple_type.txt": "FOO='1' BAR='true' BAZ='1.1'\n",
-			"not-overriden.txt": "QUX='from_os'\n",
+			"local.txt":          "GOOS='linux' GOARCH='amd64' CGO_ENABLED='0'\n",
+			"global.txt":         "FOO='foo' BAR='overridden' BAZ='baz'\n",
+			"multiple_type.txt":  "FOO='1' BAR='true' BAZ='1.1'\n",
+			"not-overridden.txt": "QUX='from_os'\n",
 		},
 	}
 	tt.Run(t)
@@ -131,10 +131,10 @@ func TestEnv(t *testing.T) {
 	experiments.EnvPrecedence = experiments.New("ENV_PRECEDENCE")
 	ttt := fileContentTest{
 		Dir:       "testdata/env",
-		Target:    "overriden",
+		Target:    "overridden",
 		TrimSpace: false,
 		Files: map[string]string{
-			"overriden.txt": "QUX='from_taskfile'\n",
+			"overridden.txt": "QUX='from_taskfile'\n",
 		},
 	}
 	ttt.Run(t)

--- a/testdata/env/Taskfile.yml
+++ b/testdata/env/Taskfile.yml
@@ -15,7 +15,7 @@ tasks:
     cmds:
       - task: local
       - task: global
-      - task: not-overriden
+      - task: not-overridden
       - task: multiple_type
 
   local:
@@ -31,7 +31,7 @@ tasks:
 
   global:
     env:
-      BAR: overriden
+      BAR: overridden
     cmds:
       - echo "FOO='$FOO' BAR='$BAR' BAZ='$BAZ'" > global.txt
 
@@ -43,10 +43,10 @@ tasks:
     cmds:
       - echo "FOO='$FOO' BAR='$BAR' BAZ='$BAZ'" > multiple_type.txt
 
-  not-overriden:
+  not-overridden:
     cmds:
-      - echo "QUX='$QUX'" > not-overriden.txt
+      - echo "QUX='$QUX'" > not-overridden.txt
 
-  overriden:
+  overridden:
     cmds:
-      - echo "QUX='$QUX'" > overriden.txt
+      - echo "QUX='$QUX'" > overridden.txt

--- a/testdata/exit_immediately/Taskfile.yml
+++ b/testdata/exit_immediately/Taskfile.yml
@@ -3,4 +3,4 @@ version: '3'
 tasks:
   default: |
     this_should_fail
-    echo "This shoudn't be print"
+    echo "This shouldn't be print"

--- a/testdata/summary/Taskfile.yml
+++ b/testdata/summary/Taskfile.yml
@@ -2,7 +2,7 @@ version: '3'
 
 tasks:
   task-with-summary:
-    deps: [dependend-task-1, dependend-task-2]
+    deps: [dependent-task-1, dependent-task-2]
     summary: |
       summary of task-with-summary - line 1
       line 2
@@ -17,10 +17,10 @@ tasks:
     cmds:
       - echo 'other-task-with-summary was executed'
 
-  dependend-task-1:
+  dependent-task-1:
     cmds:
-      - echo 'dependend-task-1 was executed'
+      - echo 'dependent-task-1 was executed'
 
-  dependend-task-2:
+  dependent-task-2:
     cmds:
-      - echo 'dependend-task-2 was executed'
+      - echo 'dependent-task-2 was executed'

--- a/testdata/summary/task-with-summary.txt
+++ b/testdata/summary/task-with-summary.txt
@@ -5,8 +5,8 @@ line 2
 line 3
 
 dependencies:
- - dependend-task-1
- - dependend-task-2
+ - dependent-task-1
+ - dependent-task-2
 
 commands:
  - echo 'task-with-summary was executed'

--- a/website/docs/changelog.mdx
+++ b/website/docs/changelog.mdx
@@ -297,7 +297,7 @@ sidebar_position: 14
 - Added the
   [Remote Taskfiles experiment](https://taskfile.dev/experiments/remote-taskfiles)
   as a draft (#1152, #1317 by @pd93).
-- Improve performance of content checksuming on `sources:` by replacing md5 with
+- Improve performance of content checksumming on `sources:` by replacing md5 with
   [XXH3](https://xxhash.com/) which is much faster. This is a soft breaking
   change because checksums will be invalidated when upgrading to this release
   (#1325 by @ReillyBrogan).
@@ -357,7 +357,7 @@ sidebar_position: 14
 - Deprecated `version: 2` schema. This will be removed in the next major release
   (#1197, #1198, #1199 by @pd93).
 - Added a new `prompt:` prop to set a warning prompt to be shown before running
-  a potential dangurous task (#100, #1163 by @MaxCheetham,
+  a potential dangerous task (#100, #1163 by @MaxCheetham,
   [Documentation](https://taskfile.dev/usage/#warning-prompts)).
 - Added support for single command task syntax. With this change, it's now
   possible to declare just `cmd:` in a task, avoiding the more complex
@@ -372,7 +372,7 @@ sidebar_position: 14
   percentage (#1173 by @misitebao).
 - Starting on this release, official binaries for FreeBSD will be available to
   download (#1068 by @andreynering).
-- Fix some errors being unintendedly supressed (#1134 by @clintmod).
+- Fix some errors being unintendedly suppressed (#1134 by @clintmod).
 - Fix a nil pointer error when `version` is omitted from a Taskfile (#1148,
   #1149 by @pd93).
 - Fix duplicate error message when a task does not exists (#1141, #1144 by
@@ -446,7 +446,7 @@ it a go and let us know what you think via a
   by @pd93).
 - Update to Go 1.20 (bump minimum version to 1.19) (#1010 by @pd93)
 - Added environment variable `FORCE_COLOR` support to force color output.
-  Usefull for environments without TTY (#1003 by @automation-stack)
+  Useful for environments without TTY (#1003 by @automation-stack)
 
 ## v3.20.0 - 2023-01-14
 
@@ -801,7 +801,7 @@ it a go and let us know what you think via a
 
 - Fix error code for the `--help` flag (#300, #330).
 - Print version to stdout instead of stderr (#299, #329).
-- Supress `context` errors when using the `--watch` flag (#313, #317).
+- Suppress `context` errors when using the `--watch` flag (#313, #317).
 - Support templating on description (#276, #283).
 
 ## v2.8.0 - 2019-12-07
@@ -810,7 +810,7 @@ it a go and let us know what you think via a
   parallel (#266).
 - Fixed bug where calling the `task` CLI only informing global vars would not
   execute the `default` task.
-- Add hability to silent all tasks by adding `silent: true` a the root of the
+- Add ability to silent all tasks by adding `silent: true` a the root of the
   Taskfile.
 
 ## v2.7.1 - 2019-11-10
@@ -952,7 +952,7 @@ document, since it describes in depth what changed for this version.
 ## v1.4.3 - 2017-09-07
 
 - Allow assigning variables to tasks at run time via CLI (#33)
-- Added suport for multiline variables from sh (#64)
+- Added support for multiline variables from sh (#64)
 - Fixes env: remove square braces and evaluate shell (#62)
 - Watch: change watch library and few fixes and improvements
 - When use watching, cancel and restart long running process on file change (#59
@@ -1012,7 +1012,7 @@ document, since it describes in depth what changed for this version.
 - More tests and Travis integration
 - Watch a task (experimental)
 - Possibility to call another task
-- Fix "=" not being reconized in variables/environment variables
+- Fix "=" not being recognized in variables/environment variables
 - Tasks can now have a description, and help will print them (#10)
 - Task dependencies now run concurrently
 - Support for a default task (#16)

--- a/website/docs/usage.mdx
+++ b/website/docs/usage.mdx
@@ -1212,7 +1212,7 @@ tasks:
       - echo "{{.GREETING}}"
 ```
 
-Example of a `default` value to be overriden from CLI:
+Example of a `default` value to be overridden from CLI:
 
 ```yaml
 version: '3'

--- a/website/versioned_docs/version-latest/changelog.mdx
+++ b/website/versioned_docs/version-latest/changelog.mdx
@@ -297,7 +297,7 @@ sidebar_position: 14
 - Added the
   [Remote Taskfiles experiment](https://taskfile.dev/experiments/remote-taskfiles)
   as a draft (#1152, #1317 by @pd93).
-- Improve performance of content checksuming on `sources:` by replacing md5 with
+- Improve performance of content checksumming on `sources:` by replacing md5 with
   [XXH3](https://xxhash.com/) which is much faster. This is a soft breaking
   change because checksums will be invalidated when upgrading to this release
   (#1325 by @ReillyBrogan).
@@ -357,7 +357,7 @@ sidebar_position: 14
 - Deprecated `version: 2` schema. This will be removed in the next major release
   (#1197, #1198, #1199 by @pd93).
 - Added a new `prompt:` prop to set a warning prompt to be shown before running
-  a potential dangurous task (#100, #1163 by @MaxCheetham,
+  a potential dangerous task (#100, #1163 by @MaxCheetham,
   [Documentation](https://taskfile.dev/usage/#warning-prompts)).
 - Added support for single command task syntax. With this change, it's now
   possible to declare just `cmd:` in a task, avoiding the more complex
@@ -372,7 +372,7 @@ sidebar_position: 14
   percentage (#1173 by @misitebao).
 - Starting on this release, official binaries for FreeBSD will be available to
   download (#1068 by @andreynering).
-- Fix some errors being unintendedly supressed (#1134 by @clintmod).
+- Fix some errors being unintendedly suppressed (#1134 by @clintmod).
 - Fix a nil pointer error when `version` is omitted from a Taskfile (#1148,
   #1149 by @pd93).
 - Fix duplicate error message when a task does not exists (#1141, #1144 by
@@ -446,7 +446,7 @@ it a go and let us know what you think via a
   by @pd93).
 - Update to Go 1.20 (bump minimum version to 1.19) (#1010 by @pd93)
 - Added environment variable `FORCE_COLOR` support to force color output.
-  Usefull for environments without TTY (#1003 by @automation-stack)
+  Useful for environments without TTY (#1003 by @automation-stack)
 
 ## v3.20.0 - 2023-01-14
 
@@ -801,7 +801,7 @@ it a go and let us know what you think via a
 
 - Fix error code for the `--help` flag (#300, #330).
 - Print version to stdout instead of stderr (#299, #329).
-- Supress `context` errors when using the `--watch` flag (#313, #317).
+- Suppress `context` errors when using the `--watch` flag (#313, #317).
 - Support templating on description (#276, #283).
 
 ## v2.8.0 - 2019-12-07
@@ -810,7 +810,7 @@ it a go and let us know what you think via a
   parallel (#266).
 - Fixed bug where calling the `task` CLI only informing global vars would not
   execute the `default` task.
-- Add hability to silent all tasks by adding `silent: true` a the root of the
+- Add ability to silent all tasks by adding `silent: true` a the root of the
   Taskfile.
 
 ## v2.7.1 - 2019-11-10
@@ -952,7 +952,7 @@ document, since it describes in depth what changed for this version.
 ## v1.4.3 - 2017-09-07
 
 - Allow assigning variables to tasks at run time via CLI (#33)
-- Added suport for multiline variables from sh (#64)
+- Added support for multiline variables from sh (#64)
 - Fixes env: remove square braces and evaluate shell (#62)
 - Watch: change watch library and few fixes and improvements
 - When use watching, cancel and restart long running process on file change (#59
@@ -1012,7 +1012,7 @@ document, since it describes in depth what changed for this version.
 - More tests and Travis integration
 - Watch a task (experimental)
 - Possibility to call another task
-- Fix "=" not being reconized in variables/environment variables
+- Fix "=" not being recognized in variables/environment variables
 - Tasks can now have a description, and help will print them (#10)
 - Task dependencies now run concurrently
 - Support for a default task (#16)

--- a/website/versioned_docs/version-latest/usage.mdx
+++ b/website/versioned_docs/version-latest/usage.mdx
@@ -1212,7 +1212,7 @@ tasks:
       - echo "{{.GREETING}}"
 ```
 
-Example of a `default` value to be overriden from CLI:
+Example of a `default` value to be overridden from CLI:
 
 ```yaml
 version: '3'


### PR DESCRIPTION
This PR corrects spelling mistakes in the CHANGELOG, Go comments, and testdata filenames.

See https://www.noslangues-ourlanguages.gc.ca/en/writing-tips-plus/dependant-dependent