### PR TITLE
fix(json-schema): add missing `platforms` property to cmds `for`

### DIFF
--- a/website/static/schema.json
+++ b/website/static/schema.json
@@ -396,6 +396,13 @@
         "vars": {
           "description": "Values passed to the task called",
           "$ref": "#/definitions/vars"
+        },
+        "platforms": {
+          "description": "Specifies which platforms the command should be run on.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "oneOf": [

--- a/website/static/schema.json
+++ b/website/static/schema.json
@@ -6,6 +6,12 @@
     "env": {
       "$ref": "#/definitions/vars"
     },
+    "platforms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "tasks": {
       "type": "object",
       "patternProperties": {
@@ -179,10 +185,7 @@
         },
         "platforms": {
           "description": "Specifies which platforms the task should be run on.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "$ref": "#/definitions/platforms"
         },
         "requires": {
           "description": "A list of variables which should be set if this task is to run, if any of these variables are unset the task will error and not run",
@@ -341,10 +344,7 @@
         },
         "platforms": {
           "description": "Specifies which platforms the command should be run on.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "$ref": "#/definitions/platforms"
         }
       },
       "additionalProperties": false,
@@ -399,10 +399,7 @@
         },
         "platforms": {
           "description": "Specifies which platforms the command should be run on.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "$ref": "#/definitions/platforms"
         }
       },
       "oneOf": [


### PR DESCRIPTION
<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->

# Motivation

I've been getting errors from my editor that using `platforms` as a sibling of `for` under `cmds` is not supported, when it is in fact supported and respected by task

I believe this was missed on #980


# Changes

- This change simply adds a small fix to the json schema to denote that
`platforms` is allowed with `for`

# Screenshots / Testing Instructions

🖼️ Before
![CleanShot 2024-11-10 at 19 35 59@2x](https://github.com/user-attachments/assets/0a19c793-0706-48a6-970c-6a529fb29c6c)


🖼️ After
![CleanShot 2024-11-10 at 19 35 34@2x](https://github.com/user-attachments/assets/b14be4cd-5928-4d36-8839-fd4e64d4bcfe)

