### PR TITLE
fix: dynamic variable output in verbose mode

### DIFF
--- a/internal/compiler/compiler.go
+++ b/internal/compiler/compiler.go
@@ -170,7 +170,7 @@ func (c *Compiler) HandleDynamicVar(v ast.Var, dir string) (string, error) {
 	result = strings.TrimSuffix(result, "\n")
 
 	c.dynamicCache[*v.Sh] = result
-	c.Logger.VerboseErrf(logger.Magenta, "task: dynamic variable: %q result: %q\n", v.Sh, result)
+	c.Logger.VerboseErrf(logger.Magenta, "task: dynamic variable: %q result: %q\n", *v.Sh, result)
 
 	return result, nil
 }


### PR DESCRIPTION
This PR fixes #1920  to correctly log dynamic variables by dereferencing `Sh` 