### PR TITLE
chore: allow using only github.com/go-task/task/v3/errors package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,12 +5,23 @@
 
 linters:
   enable:
+    - depguard
     - goimports
     - gofmt
     - gofumpt
     - misspell
 
 linters-settings:
+  depguard:
+    rules:
+      main:
+        files:
+          - "$all"
+          - "!$test"
+          - "!**/errors/*.go"
+        deny:
+          - pkg: "errors"
+            desc: "Use github.com/go-task/task/v3/errors instead"
   goimports:
     local-prefixes: github.com/go-task
   gofmt:

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,6 +11,8 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/otiai10/copy"
 	"github.com/spf13/pflag"
+
+	"github.com/go-task/task/v3/errors"
 )
 
 const (

--- a/internal/execext/exec.go
+++ b/internal/execext/exec.go
@@ -2,7 +2,6 @@ package execext
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,6 +13,8 @@ import (
 	"mvdan.cc/sh/v3/interp"
 	"mvdan.cc/sh/v3/shell"
 	"mvdan.cc/sh/v3/syntax"
+
+	"github.com/go-task/task/v3/errors"
 )
 
 // RunCommandOptions is the options for the RunCommand func

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -2,7 +2,6 @@ package flags
 
 import (
 	"cmp"
-	"errors"
 	"log"
 	"os"
 	"strconv"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/experiments"
 	"github.com/go-task/task/v3/taskfile/ast"
 )

--- a/precondition.go
+++ b/precondition.go
@@ -2,8 +2,8 @@ package task
 
 import (
 	"context"
-	"errors"
 
+	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/env"
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/logger"


### PR DESCRIPTION
This PR enables [`depguard`](https://golangci-lint.run/usage/linters/#depguard) linter to allow using only `github.com/go-task/task/v3/errors` package for consistency across the project. The `errors` package from stdlib is forbidden.