### PR TITLE
fix: disable version check for use as an external library

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -58,6 +58,9 @@ func run() error {
 	dir := flags.Dir
 	entrypoint := flags.Entrypoint
 
+	// Initialise version
+	ver.Init()
+
 	if flags.Version {
 		fmt.Printf("Task version: %s\n", ver.GetVersionWithSum())
 		return nil
@@ -132,8 +135,9 @@ func run() error {
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
 
-		OutputStyle: flags.Output,
-		TaskSorter:  taskSorter,
+		OutputStyle:        flags.Output,
+		TaskSorter:         taskSorter,
+		EnableVersionCheck: true,
 	}
 	listOptions := task.NewListOptions(flags.List, flags.ListAll, flags.ListJson, flags.NoStatus)
 	if err := listOptions.Validate(); err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -10,7 +10,7 @@ var (
 	sum     = ""
 )
 
-func init() {
+func Init() {
 	info, ok := debug.ReadBuildInfo()
 	if !ok || info.Main.Version == "" {
 		version = "unknown"

--- a/setup.go
+++ b/setup.go
@@ -46,9 +46,9 @@ func (e *Executor) Setup() error {
 	if err := e.readDotEnvFiles(); err != nil {
 		return err
 	}
-	if err := e.doVersionChecks(); err != nil {
-		return err
-	}
+	//if err := e.doVersionChecks(); err != nil {
+	//	return err
+	//}
 	e.setupDefaults()
 	e.setupConcurrencyState()
 	return nil

--- a/setup.go
+++ b/setup.go
@@ -46,9 +46,9 @@ func (e *Executor) Setup() error {
 	if err := e.readDotEnvFiles(); err != nil {
 		return err
 	}
-	//if err := e.doVersionChecks(); err != nil {
-	//	return err
-	//}
+	if err := e.doVersionChecks(); err != nil {
+		return err
+	}
 	e.setupDefaults()
 	e.setupConcurrencyState()
 	return nil
@@ -246,6 +246,9 @@ func (e *Executor) setupConcurrencyState() {
 }
 
 func (e *Executor) doVersionChecks() error {
+	if e.DisableVersionCheck {
+		return nil
+	}
 	// Copy the version to avoid modifying the original
 	schemaVersion := &semver.Version{}
 	*schemaVersion = *e.Taskfile.Version

--- a/setup.go
+++ b/setup.go
@@ -246,7 +246,7 @@ func (e *Executor) setupConcurrencyState() {
 }
 
 func (e *Executor) doVersionChecks() error {
-	if e.DisableVersionCheck {
+	if !e.EnableVersionCheck {
 		return nil
 	}
 	// Copy the version to avoid modifying the original

--- a/task.go
+++ b/task.go
@@ -70,13 +70,13 @@ type Executor struct {
 	Stdout io.Writer
 	Stderr io.Writer
 
-	Logger              *logger.Logger
-	Compiler            *compiler.Compiler
-	Output              output.Output
-	OutputStyle         ast.Output
-	TaskSorter          sort.TaskSorter
-	UserWorkingDir      string
-	DisableVersionCheck bool
+	Logger             *logger.Logger
+	Compiler           *compiler.Compiler
+	Output             output.Output
+	OutputStyle        ast.Output
+	TaskSorter         sort.TaskSorter
+	UserWorkingDir     string
+	EnableVersionCheck bool
 
 	fuzzyModel *fuzzy.Model
 

--- a/task_test.go
+++ b/task_test.go
@@ -220,10 +220,11 @@ func TestSpecialVars(t *testing.T) {
 			t.Run(test.target, func(t *testing.T) {
 				var buff bytes.Buffer
 				e := &task.Executor{
-					Dir:    dir,
-					Stdout: &buff,
-					Stderr: &buff,
-					Silent: true,
+					Dir:                dir,
+					Stdout:             &buff,
+					Stderr:             &buff,
+					Silent:             true,
+					EnableVersionCheck: true,
 				}
 				require.NoError(t, e.Setup())
 				require.NoError(t, e.Run(context.Background(), &ast.Call{Task: test.target}))
@@ -945,9 +946,10 @@ func TestTaskVersion(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Dir, func(t *testing.T) {
 			e := task.Executor{
-				Dir:    test.Dir,
-				Stdout: io.Discard,
-				Stderr: io.Discard,
+				Dir:                test.Dir,
+				Stdout:             io.Discard,
+				Stderr:             io.Discard,
+				EnableVersionCheck: true,
 			}
 			err := e.Setup()
 			if test.wantErr {
@@ -1767,9 +1769,10 @@ func TestDynamicVariablesShouldRunOnTheTaskDir(t *testing.T) {
 
 func TestDisplaysErrorOnVersion1Schema(t *testing.T) {
 	e := task.Executor{
-		Dir:    "testdata/version/v1",
-		Stdout: io.Discard,
-		Stderr: io.Discard,
+		Dir:                "testdata/version/v1",
+		Stdout:             io.Discard,
+		Stderr:             io.Discard,
+		EnableVersionCheck: true,
 	}
 	err := e.Setup()
 	require.Error(t, err)
@@ -1779,9 +1782,10 @@ func TestDisplaysErrorOnVersion1Schema(t *testing.T) {
 func TestDisplaysErrorOnVersion2Schema(t *testing.T) {
 	var buff bytes.Buffer
 	e := task.Executor{
-		Dir:    "testdata/version/v2",
-		Stdout: io.Discard,
-		Stderr: &buff,
+		Dir:                "testdata/version/v2",
+		Stdout:             io.Discard,
+		Stderr:             &buff,
+		EnableVersionCheck: true,
 	}
 	err := e.Setup()
 	require.Error(t, err)


### PR DESCRIPTION
This PR adds an internal flag to the executor to disable version checks. This is to ensure that any application that uses Task as a library doesn't error when Task checks the buildinfo. 
This PR also renames `close` to `closer` in `task.go` as it clashes with the keyword `close.
