### PR TITLE
fix: evaluate requires before compiled task

### DIFF
--- a/task.go
+++ b/task.go
@@ -176,6 +176,10 @@ func (e *Executor) RunTask(ctx context.Context, call *ast.Call) error {
 		return nil
 	}
 
+	if err := e.areTaskRequiredVarsSet(t, call); err != nil {
+		return err
+	}
+
 	t, err = e.CompiledTask(call)
 	if err != nil {
 		return err
@@ -199,10 +203,6 @@ func (e *Executor) RunTask(ctx context.Context, call *ast.Call) error {
 		skipFingerprinting := e.ForceAll || (!call.Indirect && e.Force)
 		if !skipFingerprinting {
 			if err := ctx.Err(); err != nil {
-				return err
-			}
-
-			if err := e.areTaskRequiredVarsSet(t, call); err != nil {
 				return err
 			}
 

--- a/task_test.go
+++ b/task_test.go
@@ -199,6 +199,10 @@ func TestRequires(t *testing.T) {
 	vars.Set("foo", ast.Var{Value: "one"})
 	require.NoError(t, e.Run(context.Background(), &ast.Call{Task: "validation-var", Vars: vars}))
 	buff.Reset()
+
+	require.NoError(t, e.Setup())
+	require.ErrorContains(t, e.Run(context.Background(), &ast.Call{Task: "require-before-compile"}), "task: Task \"require-before-compile\" cancelled because it is missing required variables: MY_VAR")
+	buff.Reset()
 }
 
 func TestSpecialVars(t *testing.T) {

--- a/testdata/requires/Taskfile.yml
+++ b/testdata/requires/Taskfile.yml
@@ -16,3 +16,12 @@ tasks:
       vars:
         - name: foo
           enum: ['one', 'two']
+
+
+  require-before-compile:
+    requires:
+      vars: [ MY_VAR ]
+    cmd: |
+      {{range .MY_VAR | splitList " " }}
+        echo {{.}}
+      {{end}}


### PR DESCRIPTION
Fixes : 
- https://github.com/go-task/task/issues/1950

Two thing here : 
- The template should be evaluated (in `CompiledTask`) only after verifying the required variables.
- `skipFingerprint` should not bypass the required variable checks.
