### PR TITLE
docs: update Arch installation instructions

### DIFF
--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -82,23 +82,13 @@ scoop install task
 This installation method is community owned. After a new release of Task, it may
 take some time until it's available on Scoop.
 
-### AUR
+### Arch
 
-If you're on Arch Linux you can install Task from
-[AUR](https://aur.archlinux.org/packages/go-task-bin) using your favorite
-package manager such as `yay`, `pacaur` or `yaourt`:
-
-```shell
-yay -S go-task-bin
-```
-
-Alternatively, there's
-[this package](https://aur.archlinux.org/packages/go-task) which installs from
-the source code instead of downloading the binary from the
-[releases page](https://github.com/go-task/task/releases):
+If you're on Arch Linux you can install Task from the official
+[Arch](https://archlinux.org/packages/extra/x86_64/go-task/) repository using `pacman`:
 
 ```shell
-yay -S go-task
+pacman -S go-task
 ```
 
 This installation method is community owned.


### PR DESCRIPTION
Installing on Arch Linux can now be done using the [official repository](https://archlinux.org/packages/extra/x86_64/go-task/) instead of the AUR. This PR updates the installation docs to reflect this.
