### PR TITLE
feat: update homebrew to use generate_completions_from_executable

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,9 +87,7 @@ brews:
       system "#{bin}/task", "--help"
     install: |-
       bin.install "task"
-      bash_completion.install "completion/bash/task.bash" => "task"
-      zsh_completion.install "completion/zsh/_task" => "_task"
-      fish_completion.install "completion/fish/task.fish"
+      generate_completions_from_executable(bin/"task", "--completion")
     commit_author:
       name: task-bot
       email: 106601941+task-bot@users.noreply.github.com


### PR DESCRIPTION
Updates Go Releaser to use `generate_completions_from_executable` when creating our homebrew tap instead of manually copying the completion files.

I have not tested this at all 😆 