### PR TITLE
docs: fix some examples to use spaces instead of tabs

### DIFF
--- a/website/docs/usage.mdx
+++ b/website/docs/usage.mdx
@@ -341,43 +341,43 @@ It means that the included Taskfile tasks will be available without the namespac
 
 
 <Tabs defaultValue="1"
-			values={[
-				{label: 'Taskfile.yml', value: '1'},
-				{label: 'Included.yml', value: '2'}
-			]}>
+      values={[
+        {label: 'Taskfile.yml', value: '1'},
+        {label: 'Included.yml', value: '2'}
+      ]}>
 
-	<TabItem value="1">
+  <TabItem value="1">
 
-		```yaml
-		version: '3'
+    ```yaml
+    version: '3'
 
-		includes:
-		  lib:
-		    taskfile: ./Included.yml
-		    flatten: true
+    includes:
+      lib:
+        taskfile: ./Included.yml
+        flatten: true
 
-		tasks:
-		  greet:
-		    cmds:
-		      - echo "Greet"
-		      - task: foo
-		```
-
-
-	</TabItem>
-	<TabItem value="2">
-
-		```yaml
-		version: '3'
-
-		tasks:
-		  foo:
-		    cmds:
-		      - echo "Foo"
-		```
+    tasks:
+      greet:
+        cmds:
+          - echo "Greet"
+          - task: foo
+    ```
 
 
-	</TabItem></Tabs>
+  </TabItem>
+  <TabItem value="2">
+
+    ```yaml
+    version: '3'
+
+    tasks:
+      foo:
+        cmds:
+          - echo "Foo"
+    ```
+
+
+  </TabItem></Tabs>
 
 
 If you run `task -a` it will print :
@@ -400,12 +400,12 @@ Foo
 If multiple tasks have the same name, an error will be thrown:
 
 <Tabs defaultValue="1"
-			values={[
-				{label: 'Taskfile.yml', value: '1'},
-				{label: 'Included.yml', value: '2'}
-			]}>
+      values={[
+        {label: 'Taskfile.yml', value: '1'},
+        {label: 'Included.yml', value: '2'}
+      ]}>
 
-	<TabItem value="1">
+  <TabItem value="1">
 
     ```yaml
     version: '3'
@@ -419,23 +419,23 @@ If multiple tasks have the same name, an error will be thrown:
         cmds:
           - echo "Greet"
           - task: foo
-		```
+    ```
 
 
-	</TabItem>
-	<TabItem value="2">
+  </TabItem>
+  <TabItem value="2">
 
-		```yaml
-		version: '3'
+    ```yaml
+    version: '3'
 
-		tasks:
+    tasks:
       greet:
         cmds:
-		      - echo "Foo"
-		```
+          - echo "Foo"
+    ```
 
 
-	</TabItem></Tabs>
+  </TabItem></Tabs>
 
 If you run `task -a` it will print:
 ```text


### PR DESCRIPTION
Because if you don't use spaces, it looks like this:

![image](https://github.com/user-attachments/assets/c6217830-891e-4682-add9-4adc83350f76)
