### PR TITLE
fix: `HTTPNode.Location` when building graph

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -1239,6 +1239,10 @@ func TestIncludesRemote(t *testing.T) {
 			firstRemote:  srv.URL + "/first/Taskfile.yml",
 			secondRemote: "./second/Taskfile.yml",
 		},
+		{
+			firstRemote:  srv.URL + "/first/",
+			secondRemote: srv.URL + "/first/second/",
+		},
 	}
 
 	tasks := []string{

--- a/taskfile/node_http.go
+++ b/taskfile/node_http.go
@@ -121,6 +121,6 @@ func (node *HTTPNode) ResolveDir(dir string) (string, error) {
 }
 
 func (node *HTTPNode) FilenameAndLastDir() (string, string) {
-	dir, filename := filepath.Split(node.URL.Path)
+	dir, filename := filepath.Split(node.entrypoint)
 	return filepath.Base(dir), filename
 }

--- a/taskfile/node_http.go
+++ b/taskfile/node_http.go
@@ -17,9 +17,10 @@ import (
 // An HTTPNode is a node that reads a Taskfile from a remote location via HTTP.
 type HTTPNode struct {
 	*BaseNode
-	URL     *url.URL
-	logger  *logger.Logger
-	timeout time.Duration
+	URL        *url.URL // stores url pointing actual remote file. (e.g. with Taskfile.yml)
+	entrypoint string   // stores entrypoint url. used for building graph vertices.
+	logger     *logger.Logger
+	timeout    time.Duration
 }
 
 func NewHTTPNode(
@@ -40,15 +41,16 @@ func NewHTTPNode(
 	}
 
 	return &HTTPNode{
-		BaseNode: base,
-		URL:      url,
-		timeout:  timeout,
-		logger:   l,
+		BaseNode:   base,
+		URL:        url,
+		entrypoint: entrypoint,
+		timeout:    timeout,
+		logger:     l,
 	}, nil
 }
 
 func (node *HTTPNode) Location() string {
-	return node.URL.String()
+	return node.entrypoint
 }
 
 func (node *HTTPNode) Remote() bool {


### PR DESCRIPTION
<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->

After this [commit](https://github.com/go-task/task/commit/c77c8a419b0c4b6905882c61bc663df5aaef6289), building internal graph can raise error because HTTPNode's Location value can be changed while building graph. (See line 65 (`node.URL = url`))

So if taskfile imports remote file with multiple depth (e.g. A --> remote B --> remote C) without filename, it raises

```
source vertex https://{PATH_TO_REMOTE}/Taskfile.yaml: vertex not found
```

So fixing `HTTPNode.Location` not to be changed over time.

(I couldn't find any related issues, so please let me know if there's issue or I have to create it)