### PR TITLE
feat: make Taskfile initialization less verbose by default

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -44,7 +44,7 @@ func main() {
 }
 
 func run() error {
-	logger := &logger.Logger{
+	log := &logger.Logger{
 		Stdout:  os.Stdout,
 		Stderr:  os.Stderr,
 		Verbose: flags.Verbose,
@@ -69,7 +69,7 @@ func run() error {
 	}
 
 	if flags.Experiments {
-		return experiments.List(logger)
+		return experiments.List(log)
 	}
 
 	if flags.Init {
@@ -78,16 +78,17 @@ func run() error {
 			return err
 		}
 
-		verbosity := uint8(1) // Print filename only
-		if flags.Silent {
-			verbosity = 0 // Print nothing
-		} else if flags.Verbose {
-			verbosity = 2 // Print file contents + filename
-		}
-
-		if err := task.InitTaskfile(os.Stdout, wd, verbosity, logger); err != nil {
+		if err := task.InitTaskfile(os.Stdout, wd); err != nil {
 			return err
 		}
+
+		if !flags.Silent {
+			if flags.Verbose {
+				log.Outf(logger.Default, "%s\n", task.DefaultTaskfile)
+			}
+			log.Outf(logger.Green, "%s created in the current directory\n", task.DefaultTaskFilename)
+		}
+
 		return nil
 	}
 
@@ -154,7 +155,7 @@ func run() error {
 		return err
 	}
 	if experiments.AnyVariables.Enabled {
-		logger.Warnf("The 'Any Variables' experiment flag is no longer required to use non-map variable types. If you wish to use map variables, please use 'TASK_X_MAP_VARIABLES' instead. See https://github.com/go-task/task/issues/1585\n")
+		log.Warnf("The 'Any Variables' experiment flag is no longer required to use non-map variable types. If you wish to use map variables, please use 'TASK_X_MAP_VARIABLES' instead. See https://github.com/go-task/task/issues/1585\n")
 	}
 
 	// If the download flag is specified, we should stop execution as soon as

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -85,7 +85,7 @@ func run() error {
 			verbosity = 2 // Print file contents + filename
 		}
 
-		if err := task.InitTaskfile(os.Stdout, wd, verbosity); err != nil {
+		if err := task.InitTaskfile(os.Stdout, wd, verbosity, logger); err != nil {
 			return err
 		}
 		return nil

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -77,7 +77,15 @@ func run() error {
 		if err != nil {
 			return err
 		}
-		if err := task.InitTaskfile(os.Stdout, wd); err != nil {
+
+		verbosity := uint8(1) // Print filename only
+		if flags.Silent {
+			verbosity = 0 // Print nothing
+		} else if flags.Verbose {
+			verbosity = 2 // Print file contents + filename
+		}
+
+		if err := task.InitTaskfile(os.Stdout, wd, verbosity); err != nil {
 			return err
 		}
 		return nil

--- a/init.go
+++ b/init.go
@@ -1,16 +1,14 @@
 package task
 
 import (
-	"fmt"
 	"io"
 	"os"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/filepathext"
-	"github.com/go-task/task/v3/internal/logger"
 )
 
-const defaultTaskfile = `# https://taskfile.dev
+const DefaultTaskfile = `# https://taskfile.dev
 
 version: '3'
 
@@ -24,33 +22,19 @@ tasks:
     silent: true
 `
 
-const defaultTaskfileName = "Taskfile.yml"
+const DefaultTaskFilename = "Taskfile.yml"
 
 // InitTaskfile creates a new Taskfile
-//
-// verbosity specifies how much to print to the terminal:
-//
-// 0 = Don't print anything
-//
-// 1 = Print filename only
-//
-// 2 = Print file contents + filename
-func InitTaskfile(w io.Writer, dir string, verbosity uint8, l *logger.Logger) error {
-	f := filepathext.SmartJoin(dir, defaultTaskfileName)
+func InitTaskfile(w io.Writer, dir string) error {
+	f := filepathext.SmartJoin(dir, DefaultTaskFilename)
 
 	if _, err := os.Stat(f); err == nil {
 		return errors.TaskfileAlreadyExistsError{}
 	}
 
-	if err := os.WriteFile(f, []byte(defaultTaskfile), 0o644); err != nil {
+	if err := os.WriteFile(f, []byte(DefaultTaskfile), 0o644); err != nil {
 		return err
 	}
 
-	if verbosity > 0 {
-		if verbosity > 1 {
-			fmt.Fprintf(w, "%s\n", defaultTaskfile)
-		}
-		l.Outf(logger.Green, "%s created in the current directory\n", defaultTaskfileName)
-	}
 	return nil
 }

--- a/init.go
+++ b/init.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/filepathext"
+	"github.com/go-task/task/v3/internal/logger"
 )
 
 const defaultTaskfile = `# https://taskfile.dev
@@ -34,7 +35,7 @@ const defaultTaskfileName = "Taskfile.yml"
 // 1 = Print filename only
 //
 // 2 = Print file contents + filename
-func InitTaskfile(w io.Writer, dir string, verbosity uint8) error {
+func InitTaskfile(w io.Writer, dir string, verbosity uint8, l *logger.Logger) error {
 	f := filepathext.SmartJoin(dir, defaultTaskfileName)
 
 	if _, err := os.Stat(f); err == nil {
@@ -49,7 +50,7 @@ func InitTaskfile(w io.Writer, dir string, verbosity uint8) error {
 		if verbosity > 1 {
 			fmt.Fprintf(w, "%s\n", defaultTaskfile)
 		}
-		fmt.Fprintf(w, "%s created in the current directory\n", defaultTaskfileName)
+		l.Outf(logger.Green, "%s created in the current directory\n", defaultTaskfileName)
 	}
 	return nil
 }

--- a/init.go
+++ b/init.go
@@ -25,8 +25,16 @@ tasks:
 
 const defaultTaskfileName = "Taskfile.yml"
 
-// InitTaskfile Taskfile creates a new Taskfile
-func InitTaskfile(w io.Writer, dir string) error {
+// InitTaskfile creates a new Taskfile
+//
+// verbosity specifies how much to print to the terminal:
+//
+// 0 = Don't print anything
+//
+// 1 = Print filename only
+//
+// 2 = Print file contents + filename
+func InitTaskfile(w io.Writer, dir string, verbosity uint8) error {
 	f := filepathext.SmartJoin(dir, defaultTaskfileName)
 
 	if _, err := os.Stat(f); err == nil {
@@ -36,6 +44,12 @@ func InitTaskfile(w io.Writer, dir string) error {
 	if err := os.WriteFile(f, []byte(defaultTaskfile), 0o644); err != nil {
 		return err
 	}
-	fmt.Fprintf(w, "%s created in the current directory\n", defaultTaskfile)
+
+	if verbosity > 0 {
+		if verbosity > 1 {
+			fmt.Fprint(w, defaultTaskfile)
+		}
+		fmt.Fprintf(w, "%s created in the current directory\n", defaultTaskfileName)
+	}
 	return nil
 }

--- a/init.go
+++ b/init.go
@@ -47,7 +47,7 @@ func InitTaskfile(w io.Writer, dir string, verbosity uint8) error {
 
 	if verbosity > 0 {
 		if verbosity > 1 {
-			fmt.Fprint(w, defaultTaskfile)
+			fmt.Fprintf(w, "%s\n", defaultTaskfile)
 		}
 		fmt.Fprintf(w, "%s created in the current directory\n", defaultTaskfileName)
 	}

--- a/init_test.go
+++ b/init_test.go
@@ -1,0 +1,31 @@
+package task_test
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/go-task/task/v3"
+	"github.com/go-task/task/v3/internal/filepathext"
+)
+
+func TestInit(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/init"
+	file := filepathext.SmartJoin(dir, "Taskfile.yml")
+
+	_ = os.Remove(file)
+	if _, err := os.Stat(file); err == nil {
+		t.Errorf("Taskfile.yml should not exist")
+	}
+
+	if err := task.InitTaskfile(io.Discard, dir); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := os.Stat(file); err != nil {
+		t.Errorf("Taskfile.yml should exist")
+	}
+	_ = os.Remove(file)
+}

--- a/task_test.go
+++ b/task_test.go
@@ -1022,7 +1022,9 @@ func TestInit(t *testing.T) {
 		t.Errorf("Taskfile.yml should not exist")
 	}
 
-	if err := task.InitTaskfile(io.Discard, dir, 0); err != nil {
+	l := &logger.Logger{Verbose: true}
+
+	if err := task.InitTaskfile(io.Discard, dir, 0, l); err != nil {
 		t.Error(err)
 	}
 

--- a/task_test.go
+++ b/task_test.go
@@ -1022,7 +1022,7 @@ func TestInit(t *testing.T) {
 		t.Errorf("Taskfile.yml should not exist")
 	}
 
-	if err := task.InitTaskfile(io.Discard, dir); err != nil {
+	if err := task.InitTaskfile(io.Discard, dir, 0); err != nil {
 		t.Error(err)
 	}
 

--- a/task_test.go
+++ b/task_test.go
@@ -1011,27 +1011,6 @@ func TestCmdsVariables(t *testing.T) {
 	assert.Contains(t, buff.String(), tf)
 }
 
-func TestInit(t *testing.T) {
-	t.Parallel()
-
-	const dir = "testdata/init"
-	file := filepathext.SmartJoin(dir, "Taskfile.yml")
-
-	_ = os.Remove(file)
-	if _, err := os.Stat(file); err == nil {
-		t.Errorf("Taskfile.yml should not exist")
-	}
-
-	if err := task.InitTaskfile(io.Discard, dir); err != nil {
-		t.Error(err)
-	}
-
-	if _, err := os.Stat(file); err != nil {
-		t.Errorf("Taskfile.yml should exist")
-	}
-	_ = os.Remove(file)
-}
-
 func TestCyclicDep(t *testing.T) {
 	t.Parallel()
 

--- a/task_test.go
+++ b/task_test.go
@@ -1022,9 +1022,7 @@ func TestInit(t *testing.T) {
 		t.Errorf("Taskfile.yml should not exist")
 	}
 
-	l := &logger.Logger{Verbose: true}
-
-	if err := task.InitTaskfile(io.Discard, dir, 0, l); err != nil {
+	if err := task.InitTaskfile(io.Discard, dir); err != nil {
 		t.Error(err)
 	}
 


### PR DESCRIPTION
Fixes #2009.

When using the `--init` flag to create a new Taskfile, it currently prints the whole contents of the file to the terminal, which is unnecessarily verbose (and honestly seems to be unintentional).

This PR fixes it by only printing the filename by default and taking the `--silent` and `--verbose` flags into account to control the behavior:

```
$ task --init
Taskfile.yml created in the current directory
```

```
$ task --init --silent
```

```
$ task --init --verbose
# https://taskfile.dev

version: '3'

vars:
  GREETING: Hello, World!

tasks:
  default:
    cmds:
      - echo "{{.GREETING}}"
    silent: true

Taskfile.yml created in the current directory
```

Please note that I purposefully did not update the description of the `--silent` and `--verbose` flags so please let me know if you want me to and what should I change them to.