### PR TITLE
fix(checker): use only one checker at the same time to improve perf

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -965,9 +965,12 @@ func TestStatusVariables(t *testing.T) {
 		Verbose: true,
 	}
 	require.NoError(t, e.Setup())
-	require.NoError(t, e.Run(context.Background(), &ast.Call{Task: "build"}))
+	require.NoError(t, e.Run(context.Background(), &ast.Call{Task: "build-checksum"}))
 
 	assert.Contains(t, buff.String(), "3e464c4b03f4b65d740e1e130d4d108a")
+
+	buff.Reset()
+	require.NoError(t, e.Run(context.Background(), &ast.Call{Task: "build-ts"}))
 
 	inf, err := os.Stat(filepathext.SmartJoin(dir, "source.txt"))
 	require.NoError(t, err)
@@ -998,10 +1001,12 @@ func TestCmdsVariables(t *testing.T) {
 		Verbose: true,
 	}
 	require.NoError(t, e.Setup())
-	require.NoError(t, e.Run(context.Background(), &ast.Call{Task: "build"}))
+	require.NoError(t, e.Run(context.Background(), &ast.Call{Task: "build-checksum"}))
 
 	assert.Contains(t, buff.String(), "3e464c4b03f4b65d740e1e130d4d108a")
 
+	buff.Reset()
+	require.NoError(t, e.Run(context.Background(), &ast.Call{Task: "build-ts"}))
 	inf, err := os.Stat(filepathext.SmartJoin(dir, "source.txt"))
 	require.NoError(t, err)
 	ts := fmt.Sprintf("%d", inf.ModTime().Unix())

--- a/testdata/cmds_vars/Taskfile.yml
+++ b/testdata/cmds_vars/Taskfile.yml
@@ -1,10 +1,16 @@
 version: '3'
 
 tasks:
-  build:
+  build-checksum:
     sources:
       - ./source.txt
-    cmds:
+    status:
       - echo "{{.CHECKSUM}}"
-      - echo "{{.TIMESTAMP.Unix}}"
-      - echo "{{.TIMESTAMP}}"
+
+  build-ts:
+    method: timestamp
+    sources:
+      - ./source.txt
+    status:
+      - echo '{{.TIMESTAMP.Unix}}'
+      - echo '{{.TIMESTAMP}}'

--- a/testdata/cmds_vars/Taskfile.yml
+++ b/testdata/cmds_vars/Taskfile.yml
@@ -4,13 +4,13 @@ tasks:
   build-checksum:
     sources:
       - ./source.txt
-    status:
+    cmds:
       - echo "{{.CHECKSUM}}"
 
   build-ts:
     method: timestamp
     sources:
       - ./source.txt
-    status:
+    cmds:
       - echo '{{.TIMESTAMP.Unix}}'
       - echo '{{.TIMESTAMP}}'

--- a/testdata/status_vars/Taskfile.yml
+++ b/testdata/status_vars/Taskfile.yml
@@ -1,10 +1,16 @@
 version: '3'
 
 tasks:
-  build:
+  build-checksum:
     sources:
       - ./source.txt
     status:
       - echo "{{.CHECKSUM}}"
+
+  build-ts:
+    method: timestamp
+    sources:
+      - ./source.txt
+    status:
       - echo '{{.TIMESTAMP.Unix}}'
       - echo '{{.TIMESTAMP}}'

--- a/variables.go
+++ b/variables.go
@@ -129,10 +129,12 @@ func (e *Executor) compiledTask(call *ast.Call, evaluateShVars bool) (*ast.Task,
 	}
 
 	if len(origTask.Sources) > 0 && origTask.Method != "none" {
+		var checker fingerprint.SourcesCheckable
 
-		var checker fingerprint.SourcesCheckable = fingerprint.NewChecksumChecker(e.TempDir.Fingerprint, e.Dry)
 		if origTask.Method == "timestamp" {
 			checker = fingerprint.NewTimestampChecker(e.TempDir.Fingerprint, e.Dry)
+		} else {
+			checker = fingerprint.NewChecksumChecker(e.TempDir.Fingerprint, e.Dry)
 		}
 
 		value, err := checker.Value(&new)

--- a/variables.go
+++ b/variables.go
@@ -128,17 +128,18 @@ func (e *Executor) compiledTask(call *ast.Call, evaluateShVars bool) (*ast.Task,
 		}
 	}
 
-	if len(origTask.Sources) > 0 {
-		timestampChecker := fingerprint.NewTimestampChecker(e.TempDir.Fingerprint, e.Dry)
-		checksumChecker := fingerprint.NewChecksumChecker(e.TempDir.Fingerprint, e.Dry)
+	if len(origTask.Sources) > 0 && origTask.Method != "none" {
 
-		for _, checker := range []fingerprint.SourcesCheckable{timestampChecker, checksumChecker} {
-			value, err := checker.Value(&new)
-			if err != nil {
-				return nil, err
-			}
-			vars.Set(strings.ToUpper(checker.Kind()), ast.Var{Live: value})
+		var checker fingerprint.SourcesCheckable = fingerprint.NewChecksumChecker(e.TempDir.Fingerprint, e.Dry)
+		if origTask.Method == "timestamp" {
+			checker = fingerprint.NewTimestampChecker(e.TempDir.Fingerprint, e.Dry)
 		}
+
+		value, err := checker.Value(&new)
+		if err != nil {
+			return nil, err
+		}
+		vars.Set(strings.ToUpper(checker.Kind()), ast.Var{Live: value})
 
 		// Adding new variables, requires us to refresh the templaters
 		// cache of the the values manually


### PR DESCRIPTION
fixes #2029 

@pd93 Before, both `{{.TIMESTAMP}}` and `{{.CHECKSUM}}` were available in `status`, but according to our documentation, only one should be available depending on the chosen method.

cf : https://taskfile.dev/usage/#using-programmatic-checks-to-indicate-a-task-is-up-to-date
