### PR TITLE
fix: requires allowed values works with dynamic var

### DIFF
--- a/task.go
+++ b/task.go
@@ -185,6 +185,11 @@ func (e *Executor) RunTask(ctx context.Context, call *ast.Call) error {
 	if err != nil {
 		return err
 	}
+
+	if err := e.areTaskRequiredVarsAllowedValuesSet(t); err != nil {
+		return err
+	}
+
 	if !e.Watch && atomic.AddInt32(e.taskCallCount[t.Task], 1) >= MaximumTaskCall {
 		return &errors.TaskCalledTooManyTimesError{
 			TaskName:        t.Task,

--- a/task_test.go
+++ b/task_test.go
@@ -180,12 +180,12 @@ func TestRequires(t *testing.T) {
 	}
 
 	require.NoError(t, e.Setup())
-	require.ErrorContains(t, e.Run(context.Background(), &ast.Call{Task: "missing-var"}), "task: Task \"missing-var\" cancelled because it is missing required variables: foo")
+	require.ErrorContains(t, e.Run(context.Background(), &ast.Call{Task: "missing-var"}), "task: Task \"missing-var\" cancelled because it is missing required variables: FOO")
 	buff.Reset()
 	require.NoError(t, e.Setup())
 
 	vars := ast.NewVars()
-	vars.Set("foo", ast.Var{Value: "bar"})
+	vars.Set("FOO", ast.Var{Value: "bar"})
 	require.NoError(t, e.Run(context.Background(), &ast.Call{
 		Task: "missing-var",
 		Vars: vars,
@@ -193,11 +193,15 @@ func TestRequires(t *testing.T) {
 	buff.Reset()
 
 	require.NoError(t, e.Setup())
-	require.ErrorContains(t, e.Run(context.Background(), &ast.Call{Task: "validation-var", Vars: vars}), "task: Task \"validation-var\" cancelled because it is missing required variables:\n  - foo has an invalid value : 'bar' (allowed values : [one two])")
+	require.ErrorContains(t, e.Run(context.Background(), &ast.Call{Task: "validation-var", Vars: vars}), "task: Task \"validation-var\" cancelled because it is missing required variables:\n  - FOO has an invalid value : 'bar' (allowed values : [one two])")
 	buff.Reset()
 
 	require.NoError(t, e.Setup())
-	vars.Set("foo", ast.Var{Value: "one"})
+	require.NoError(t, e.Run(context.Background(), &ast.Call{Task: "validation-var-dynamic", Vars: vars}))
+	buff.Reset()
+
+	require.NoError(t, e.Setup())
+	vars.Set("FOO", ast.Var{Value: "one"})
 	require.NoError(t, e.Run(context.Background(), &ast.Call{Task: "validation-var", Vars: vars}))
 	buff.Reset()
 

--- a/testdata/requires/Taskfile.yml
+++ b/testdata/requires/Taskfile.yml
@@ -7,7 +7,7 @@ tasks:
   missing-var:
     requires:
       vars:
-        - foo
+        - FOO
     cmd: echo "{{.foo}}"
 
   var-defined-in-task:
@@ -19,10 +19,21 @@ tasks:
     cmd: echo "{{.FOO}}"
 
 
+  validation-var-dynamic:
+    vars:
+      FOO:
+        sh: echo "one"
+
+    requires:
+      vars:
+        - name: FOO
+          enum: ['one', 'two']
+
+
   validation-var:
     requires:
       vars:
-        - name: foo
+        - name: FOO
           enum: ['one', 'two']
 
 


### PR DESCRIPTION
- Fixes #2032 

I've split the check into two methods:
- One for the `requires`  which should be evaluated before the task being compilated (this allows for a well-formed message when using this variable in a template, see: #1950 / #1970 )
- One for the allowed values, which works with dynamic variables.