### PR TITLE
fix: schema does not allow ignore_error in a for loop

### DIFF
--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -442,6 +442,10 @@
           "description": "Silent mode disables echoing of command before Task runs it",
           "type": "boolean"
         },
+        "ignore_error": {
+          "description": "Prevent command from aborting the execution of task even after receiving a status code of 1",
+          "type": "boolean"
+        },
         "platforms": {
           "description": "Specifies which platforms the command should be run on.",
           "$ref": "#/definitions/platforms"
@@ -466,6 +470,10 @@
         },
         "silent": {
           "description": "Silent mode disables echoing of command before Task runs it",
+          "type": "boolean"
+        },
+        "ignore_error": {
+          "description": "Prevent command from aborting the execution of task even after receiving a status code of 1",
           "type": "boolean"
         },
         "platforms": {

--- a/website/static/schema.json
+++ b/website/static/schema.json
@@ -390,6 +390,10 @@
           "description": "Values passed to the task called",
           "$ref": "#/definitions/vars"
         },
+        "ignore_error": {
+          "description": "Prevent command from aborting the execution of task even after receiving a status code of 1",
+          "type": "boolean"
+        },
         "platforms": {
           "description": "Specifies which platforms the command should be run on.",
           "$ref": "#/definitions/platforms"


### PR DESCRIPTION
Visual Studio Code shows a problem when adding `ignore_error` to a `for` loop (`for_cmds_call`), however in practice it appears to work perfectly fine and I can't find anything in the task code that would indicate it shouldn't be allowed.

This change simply adds `ignore_error` as an allowed property of a `for` loop.

## Before

![001731 Taskfile yml - projects-ai (Workspace)  SSH_ lxms-d-intops01 atb com  - Visual S](https://github.com/user-attachments/assets/fb670cd4-a9d2-4f99-a4c9-603f4213feb2)

![001732 Taskfile yml - projects-ai (Workspace)  SSH_ lxms-d-intops01 atb com  - Visual S](https://github.com/user-attachments/assets/a90b9c57-00a3-4036-b209-c36660f99b9b)

## After

![001733 Taskfile yml - projects-ai (Workspace)  SSH_ lxms-d-intops01 atb com  - Visual S](https://github.com/user-attachments/assets/e0d4076b-71b3-4ff0-9628-b1c3003331a8)
