### PR TITLE
feat: stop task test installing task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -98,21 +98,17 @@ tasks:
   test:
     desc: Runs test suite
     aliases: [t]
-    deps: [install]
+    sources:
+      - "**/*.go"
+      - "testdata/**/*"
     cmds:
-      - go test {{catLines .GO_PACKAGES}}
-    vars:
-      GO_PACKAGES:
-        sh: go list ./...
+      - go test ./...
 
   test:all:
     desc: Runs test suite with signals and watch tests included
-    deps: [install, sleepit:build]
+    deps: [sleepit:build]
     cmds:
-      - go test {{catLines .GO_PACKAGES}} -tags 'signals watch'
-    vars:
-      GO_PACKAGES:
-        sh: go list ./...
+      - go test -tags 'signals watch' ./...
 
   goreleaser:test:
     desc: Tests release process without publishing
@@ -176,11 +172,3 @@ tasks:
     desc: Publish release to npm
     cmds:
       - npm publish --access=public
-
-  packages:
-    cmds:
-      - echo '{{.GO_PACKAGES}}'
-    vars:
-      GO_PACKAGES:
-        sh: go list ./...
-    silent: true


### PR DESCRIPTION
@andreynering Maybe I'm missing something. This has been here since long before I came across Task. Is there a reason that `task test` works the way it does? In most of my projects, I just have `task test` setup to run `go test ./...`, but in our own Taskfile it will install the binary first. This isn't usually what I want to do during development.

Just opening this as a suggestion. Thanks :)