### PR TITLE
refactor: VeryFastCompile for Task list

### DIFF
--- a/task.go
+++ b/task.go
@@ -527,7 +527,7 @@ func (e *Executor) GetTaskList(filters ...FilterFunc) ([]*ast.Task, error) {
 	// Compile the list of tasks
 	for i := range tasks {
 		g.Go(func() error {
-			compiledTask, err := e.FastCompiledTask(&ast.Call{Task: tasks[i].Task})
+			compiledTask, err := e.CompiledTaskForTaskList(&ast.Call{Task: tasks[i].Task})
 			if err != nil {
 				return err
 			}

--- a/variables.go
+++ b/variables.go
@@ -27,6 +27,51 @@ func (e *Executor) FastCompiledTask(call *ast.Call) (*ast.Task, error) {
 	return e.compiledTask(call, false)
 }
 
+func (e *Executor) CompiledTaskForTaskList(call *ast.Call) (*ast.Task, error) {
+	origTask, err := e.GetTask(call)
+	if err != nil {
+		return nil, err
+	}
+
+	vars, err := e.Compiler.FastGetVariables(origTask, call)
+	if err != nil {
+		return nil, err
+	}
+
+	cache := &templater.Cache{Vars: vars}
+
+	return &ast.Task{
+		Task:                 origTask.Task,
+		Label:                templater.Replace(origTask.Label, cache),
+		Desc:                 templater.Replace(origTask.Desc, cache),
+		Prompt:               templater.Replace(origTask.Prompt, cache),
+		Summary:              templater.Replace(origTask.Summary, cache),
+		Aliases:              origTask.Aliases,
+		Sources:              origTask.Sources,
+		Generates:            origTask.Generates,
+		Dir:                  origTask.Dir,
+		Set:                  origTask.Set,
+		Shopt:                origTask.Shopt,
+		Vars:                 vars,
+		Env:                  nil,
+		Dotenv:               origTask.Dotenv,
+		Silent:               origTask.Silent,
+		Interactive:          origTask.Interactive,
+		Internal:             origTask.Internal,
+		Method:               origTask.Method,
+		Prefix:               origTask.Prefix,
+		IgnoreError:          origTask.IgnoreError,
+		Run:                  origTask.Run,
+		IncludeVars:          origTask.IncludeVars,
+		IncludedTaskfileVars: origTask.IncludedTaskfileVars,
+		Platforms:            origTask.Platforms,
+		Location:             origTask.Location,
+		Requires:             origTask.Requires,
+		Watch:                origTask.Watch,
+		Namespace:            origTask.Namespace,
+	}, nil
+}
+
 func (e *Executor) compiledTask(call *ast.Call, evaluateShVars bool) (*ast.Task, error) {
 	origTask, err := e.GetTask(call)
 	if err != nil {


### PR DESCRIPTION
I  was looking at #1322 when I realized that we compile every task (even with Fast Variable) just for `--list` or `--list-all`.
`--list-all` is used for autocomplete, so it should be as fast as possible.

I created a new method to compile specifically for this listing. This way, we do not add complexity to the current one.
I’m aware that it could also be used for the `Editor`, but it seems fine.