### PR TITLE
chore: bump minimum version to 1.23

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60.1
+          version: v1.64.2
 
   lint-jsonschema:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     name: Lint
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x]
+        go-version: [1.23.x, 1.24.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.platform}}
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters:
     - misspell
     - noctx
     - paralleltest
-    - tenv
+    - usetesting
     - thelper
     - tparallel
 
@@ -29,6 +29,8 @@ linters-settings:
             desc: "Use github.com/go-task/task/v3/errors instead"
   goimports:
     local-prefixes: github.com/go-task
+  gofumpt:
+    module-path: github.com/go-task/task/v3
   gofmt:
     rewrite-rules:
       - pattern: 'interface{}'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-task/task/v3
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/Ladicle/tabwriter v1.0.0

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -12,7 +12,7 @@ var (
 
 func init() {
 	info, ok := debug.ReadBuildInfo()
-	if !ok || info.Main.Version == "" {
+	if !ok || info.Main.Version == "(devel)" || info.Main.Version == "" {
 		version = "unknown"
 	} else {
 		if version == "" {


### PR DESCRIPTION
Bumps the minimum Go version to v1.23. This allows us to start using 1.23 features in the next version of Task! Tests will now run on 1.23 and 1.24.