### PR TITLE
chore: add linter mirror

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - goimports
     - gofmt
     - gofumpt
+    - mirror
     - misspell
     - noctx
     - paralleltest

--- a/task_test.go
+++ b/task_test.go
@@ -772,7 +772,7 @@ func TestPromptInSummary(t *testing.T) {
 			var outBuff bytes.Buffer
 			var errBuff bytes.Buffer
 
-			inBuff.Write([]byte(test.input))
+			inBuff.WriteString(test.input)
 
 			e := task.Executor{
 				Dir:        dir,
@@ -802,7 +802,7 @@ func TestPromptWithIndirectTask(t *testing.T) {
 	var outBuff bytes.Buffer
 	var errBuff bytes.Buffer
 
-	inBuff.Write([]byte("y\n"))
+	inBuff.WriteString("y\n")
 
 	e := task.Executor{
 		Dir:        dir,
@@ -839,7 +839,7 @@ func TestPromptAssumeYes(t *testing.T) {
 			var errBuff bytes.Buffer
 
 			// always cancel the prompt so we can require.Error
-			inBuff.Write([]byte("\n"))
+			inBuff.WriteByte('\n')
 
 			e := task.Executor{
 				Dir:       dir,

--- a/taskfile/snippet.go
+++ b/taskfile/snippet.go
@@ -59,7 +59,7 @@ func NewSnippet(b []byte, opts ...SnippetOption) *Snippet {
 	// Syntax highlight the input and split it into lines
 	buf := &bytes.Buffer{}
 	if err := quick.Highlight(buf, string(b), "yaml", "terminal", "task"); err != nil {
-		buf.WriteString(string(b))
+		buf.Write(b)
 	}
 	linesRaw := strings.Split(string(b), "\n")
 	linesHighlighted := strings.Split(buf.String(), "\n")


### PR DESCRIPTION
The [`mirror`](https://golangci-lint.run/usage/linters/#mirror) linter detects places where allocations can be avoided.