### PR TITLE
fix: add defer's `silent` property to schema

### DIFF
--- a/website/static/schema.json
+++ b/website/static/schema.json
@@ -363,6 +363,10 @@
               "$ref": "#/definitions/task_call"
             }
           ]
+        },
+        "silent": {
+          "description": "Hides task name and command from output. The command's output will still be redirected to `STDOUT` and `STDERR`.",
+          "type": "boolean"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
This smol fix brings the YAML schema in line with the feature implemented in #1879

Fixes #2061 