### PR TITLE
feat: allow variable references in a matrix

### DIFF
--- a/testdata/for/cmds/Taskfile.yml
+++ b/testdata/for/cmds/Taskfile.yml
@@ -1,5 +1,10 @@
 version: "3"
 
+vars:
+  OS_VAR: ["windows", "linux", "darwin"]
+  ARCH_VAR: ["amd64", "arm64"]
+  NOT_A_LIST: "not a list"
+
 tasks:
   # Loop over a list of values
   loop-explicit:
@@ -13,6 +18,26 @@ tasks:
           matrix:
             OS: ["windows", "linux", "darwin"]
             ARCH: ["amd64", "arm64"]
+        cmd: echo "{{.ITEM.OS}}/{{.ITEM.ARCH}}"
+
+  loop-matrix-ref:
+    cmds:
+      - for:
+          matrix:
+            OS:
+              ref: .OS_VAR
+            ARCH:
+              ref: .ARCH_VAR
+        cmd: echo "{{.ITEM.OS}}/{{.ITEM.ARCH}}"
+
+  loop-matrix-ref-error:
+    cmds:
+      - for:
+          matrix:
+            OS:
+              ref: .OS_VAR
+            ARCH:
+              ref: .NOT_A_LIST
         cmd: echo "{{.ITEM.OS}}/{{.ITEM.ARCH}}"
 
   # Loop over the task's sources

--- a/testdata/for/deps/Taskfile.yml
+++ b/testdata/for/deps/Taskfile.yml
@@ -1,5 +1,10 @@
 version: "3"
 
+vars:
+  OS_VAR: ["windows", "linux", "darwin"]
+  ARCH_VAR: ["amd64", "arm64"]
+  NOT_A_LIST: "not a list"
+
 tasks:
   # Loop over a list of values
   loop-explicit:
@@ -15,6 +20,30 @@ tasks:
           matrix:
             OS: ["windows", "linux", "darwin"]
             ARCH: ["amd64", "arm64"]
+        task: echo
+        vars:
+          TEXT: "{{.ITEM.OS}}/{{.ITEM.ARCH}}"
+
+  loop-matrix-ref:
+    deps:
+      - for:
+          matrix:
+            OS:
+              ref: .OS_VAR
+            ARCH:
+              ref: .ARCH_VAR
+        task: echo
+        vars:
+          TEXT: "{{.ITEM.OS}}/{{.ITEM.ARCH}}"
+
+  loop-matrix-ref-error:
+    deps:
+      - for:
+          matrix:
+            OS:
+              ref: .OS_VAR
+            ARCH:
+              ref: .NOT_A_LIST
         task: echo
         vars:
           TEXT: "{{.ITEM.OS}}/{{.ITEM.ARCH}}"


### PR DESCRIPTION
Fixes #2065

Based on-top of #2068, this allows `ref` to be used in a `MatrixRow`. For example:

```yml
version: '3'

vars:
  OS_VAR: ["windows", "linux", "darwin"]
  ARCH_VAR: ["amd64", "arm64"]

tasks:
  default:
    silent: true
    cmds:
      - for:
          matrix:
            OS:
              ref: OS_VAR
            ARCH:
              ref: ARCH_VAR
        cmd: echo "{{.ITEM.OS}}/{{.ITEM.ARCH}}"
```

```
windows/amd64
windows/arm64
linux/amd64
linux/arm64
darwin/amd64
darwin/arm64
```