### PR TITLE
fix: sources brace expansion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0
 	github.com/go-task/template v0.1.0
 	github.com/joho/godotenv v1.5.1
-	github.com/mattn/go-zglob v0.0.6
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/otiai10/copy v1.14.1
 	github.com/puzpuzpuz/xsync/v3 v3.5.1

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,6 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-zglob v0.0.6 h1:mP8RnmCgho4oaUYDIDn6GNxYk+qJGUs8fJLn+twYj2A=
-github.com/mattn/go-zglob v0.0.6/go.mod h1:MxxjyoXXnMxfIpxTK2GAkw1w8glPsQILx3N5wrKakiY=
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=

--- a/internal/fingerprint/glob.go
+++ b/internal/fingerprint/glob.go
@@ -4,8 +4,6 @@ import (
 	"os"
 	"sort"
 
-	"github.com/mattn/go-zglob"
-
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
 	"github.com/go-task/task/v3/taskfile/ast"
@@ -28,12 +26,7 @@ func Globs(dir string, globs []*ast.Glob) ([]string, error) {
 func glob(dir string, g string) ([]string, error) {
 	g = filepathext.SmartJoin(dir, g)
 
-	g, err := execext.Expand(g)
-	if err != nil {
-		return nil, err
-	}
-
-	fs, err := zglob.GlobFollowSymlinks(g)
+	fs, err := execext.ExpandFields(g)
 	if err != nil {
 		return nil, err
 	}

--- a/setup.go
+++ b/setup.go
@@ -120,7 +120,7 @@ func (e *Executor) setupTempDir() error {
 			Fingerprint: filepathext.SmartJoin(e.Dir, ".task"),
 		}
 	} else if filepath.IsAbs(tempDir) || strings.HasPrefix(tempDir, "~") {
-		tempDir, err := execext.Expand(tempDir)
+		tempDir, err := execext.ExpandLiteral(tempDir)
 		if err != nil {
 			return err
 		}
@@ -141,7 +141,7 @@ func (e *Executor) setupTempDir() error {
 	remoteDir := env.GetTaskEnv("REMOTE_DIR")
 	if remoteDir != "" {
 		if filepath.IsAbs(remoteDir) || strings.HasPrefix(remoteDir, "~") {
-			remoteTempDir, err := execext.Expand(remoteDir)
+			remoteTempDir, err := execext.ExpandLiteral(remoteDir)
 			if err != nil {
 				return err
 			}

--- a/taskfile/node_file.go
+++ b/taskfile/node_file.go
@@ -84,7 +84,7 @@ func (node *FileNode) ResolveEntrypoint(entrypoint string) (string, error) {
 		return entrypoint, nil
 	}
 
-	path, err := execext.Expand(entrypoint)
+	path, err := execext.ExpandLiteral(entrypoint)
 	if err != nil {
 		return "", err
 	}
@@ -100,7 +100,7 @@ func (node *FileNode) ResolveEntrypoint(entrypoint string) (string, error) {
 }
 
 func (node *FileNode) ResolveDir(dir string) (string, error) {
-	path, err := execext.Expand(dir)
+	path, err := execext.ExpandLiteral(dir)
 	if err != nil {
 		return "", err
 	}

--- a/taskfile/node_git.go
+++ b/taskfile/node_git.go
@@ -106,7 +106,7 @@ func (node *GitNode) ResolveEntrypoint(entrypoint string) (string, error) {
 }
 
 func (node *GitNode) ResolveDir(dir string) (string, error) {
-	path, err := execext.Expand(dir)
+	path, err := execext.ExpandLiteral(dir)
 	if err != nil {
 		return "", err
 	}

--- a/taskfile/node_http.go
+++ b/taskfile/node_http.go
@@ -97,7 +97,7 @@ func (node *HTTPNode) ResolveEntrypoint(entrypoint string) (string, error) {
 }
 
 func (node *HTTPNode) ResolveDir(dir string) (string, error) {
-	path, err := execext.Expand(dir)
+	path, err := execext.ExpandLiteral(dir)
 	if err != nil {
 		return "", err
 	}

--- a/taskfile/node_stdin.go
+++ b/taskfile/node_stdin.go
@@ -48,7 +48,7 @@ func (node *StdinNode) ResolveEntrypoint(entrypoint string) (string, error) {
 		return entrypoint, nil
 	}
 
-	path, err := execext.Expand(entrypoint)
+	path, err := execext.ExpandLiteral(entrypoint)
 	if err != nil {
 		return "", err
 	}
@@ -61,7 +61,7 @@ func (node *StdinNode) ResolveEntrypoint(entrypoint string) (string, error) {
 }
 
 func (node *StdinNode) ResolveDir(dir string) (string, error) {
-	path, err := execext.Expand(dir)
+	path, err := execext.ExpandLiteral(dir)
 	if err != nil {
 		return "", err
 	}

--- a/variables.go
+++ b/variables.go
@@ -77,7 +77,7 @@ func (e *Executor) compiledTask(call *Call, evaluateShVars bool) (*ast.Task, err
 		Watch:                origTask.Watch,
 		Namespace:            origTask.Namespace,
 	}
-	new.Dir, err = execext.Expand(new.Dir)
+	new.Dir, err = execext.ExpandLiteral(new.Dir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #2073 

Removes `zglob` as a dependency and instead relies on mvdan's `expand.Fields` with globbing turned on for `sources` globs.

We also use `expand.Fields` in multiple other places to resolve things like `~` and environment variables. However, most of the time, we don't also want brace expansion or globbing, so I have separated this into two functions. One wraps `expand.Literal` which returns a single string with just the variables resolved, and the other wraps `expand.Fields` with braces and globbing enabled.