### PR TITLE
feat: remove logger from taskfile package

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -65,6 +65,12 @@ func (e *Executor) getRootNode() (taskfile.Node, error) {
 }
 
 func (e *Executor) readTaskfile(node taskfile.Node) error {
+	debugFunc := func(s string) {
+		e.Logger.VerboseOutf(logger.Magenta, s)
+	}
+	promptFunc := func(s string) error {
+		return e.Logger.Prompt(logger.Yellow, s, "n", "y", "yes")
+	}
 	reader := taskfile.NewReader(
 		node,
 		taskfile.WithInsecure(e.Insecure),
@@ -72,7 +78,8 @@ func (e *Executor) readTaskfile(node taskfile.Node) error {
 		taskfile.WithOffline(e.Offline),
 		taskfile.WithTimeout(e.Timeout),
 		taskfile.WithTempDir(e.TempDir.Remote),
-		taskfile.WithLogger(e.Logger),
+		taskfile.WithDebugFunc(debugFunc),
+		taskfile.WithPromptFunc(promptFunc),
 	)
 	graph, err := reader.Read()
 	if err != nil {

--- a/setup.go
+++ b/setup.go
@@ -56,7 +56,7 @@ func (e *Executor) Setup() error {
 }
 
 func (e *Executor) getRootNode() (taskfile.Node, error) {
-	node, err := taskfile.NewRootNode(e.Logger, e.Entrypoint, e.Dir, e.Insecure, e.Timeout)
+	node, err := taskfile.NewRootNode(e.Entrypoint, e.Dir, e.Insecure, e.Timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/setup.go
+++ b/setup.go
@@ -67,12 +67,12 @@ func (e *Executor) getRootNode() (taskfile.Node, error) {
 func (e *Executor) readTaskfile(node taskfile.Node) error {
 	reader := taskfile.NewReader(
 		node,
-		e.Insecure,
-		e.Download,
-		e.Offline,
-		e.Timeout,
-		e.TempDir.Remote,
-		e.Logger,
+		taskfile.WithInsecure(e.Insecure),
+		taskfile.WithDownload(e.Download),
+		taskfile.WithOffline(e.Offline),
+		taskfile.WithTimeout(e.Timeout),
+		taskfile.WithTempDir(e.TempDir.Remote),
+		taskfile.WithLogger(e.Logger),
 	)
 	graph, err := reader.Read()
 	if err != nil {

--- a/taskfile/node.go
+++ b/taskfile/node.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/experiments"
-	"github.com/go-task/task/v3/internal/logger"
 )
 
 type Node interface {
@@ -26,7 +25,6 @@ type Node interface {
 }
 
 func NewRootNode(
-	l *logger.Logger,
 	entrypoint string,
 	dir string,
 	insecure bool,
@@ -37,11 +35,10 @@ func NewRootNode(
 	if entrypoint == "-" {
 		return NewStdinNode(dir)
 	}
-	return NewNode(l, entrypoint, dir, insecure, timeout)
+	return NewNode(entrypoint, dir, insecure, timeout)
 }
 
 func NewNode(
-	l *logger.Logger,
 	entrypoint string,
 	dir string,
 	insecure bool,
@@ -58,9 +55,9 @@ func NewNode(
 	case "git":
 		node, err = NewGitNode(entrypoint, dir, insecure, opts...)
 	case "http", "https":
-		node, err = NewHTTPNode(l, entrypoint, dir, insecure, timeout, opts...)
+		node, err = NewHTTPNode(entrypoint, dir, insecure, timeout, opts...)
 	default:
-		node, err = NewFileNode(l, entrypoint, dir, opts...)
+		node, err = NewFileNode(entrypoint, dir, opts...)
 
 	}
 

--- a/taskfile/node_file.go
+++ b/taskfile/node_file.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
-	"github.com/go-task/task/v3/internal/logger"
 )
 
 // A FileNode is a node that reads a taskfile from the local filesystem.
@@ -18,10 +17,10 @@ type FileNode struct {
 	Entrypoint string
 }
 
-func NewFileNode(l *logger.Logger, entrypoint, dir string, opts ...NodeOption) (*FileNode, error) {
+func NewFileNode(entrypoint, dir string, opts ...NodeOption) (*FileNode, error) {
 	var err error
 	base := NewBaseNode(dir, opts...)
-	entrypoint, base.dir, err = resolveFileNodeEntrypointAndDir(l, entrypoint, base.dir)
+	entrypoint, base.dir, err = resolveFileNodeEntrypointAndDir(entrypoint, base.dir)
 	if err != nil {
 		return nil, err
 	}
@@ -50,10 +49,10 @@ func (node *FileNode) Read(ctx context.Context) ([]byte, error) {
 
 // resolveFileNodeEntrypointAndDir resolves checks the values of entrypoint and dir and
 // populates them with default values if necessary.
-func resolveFileNodeEntrypointAndDir(l *logger.Logger, entrypoint, dir string) (string, string, error) {
+func resolveFileNodeEntrypointAndDir(entrypoint, dir string) (string, string, error) {
 	var err error
 	if entrypoint != "" {
-		entrypoint, err = Exists(l, entrypoint)
+		entrypoint, err = Exists(entrypoint)
 		if err != nil {
 			return "", "", err
 		}
@@ -68,7 +67,7 @@ func resolveFileNodeEntrypointAndDir(l *logger.Logger, entrypoint, dir string) (
 			return "", "", err
 		}
 	}
-	entrypoint, err = ExistsWalk(l, dir)
+	entrypoint, err = ExistsWalk(dir)
 	if err != nil {
 		return "", "", err
 	}

--- a/taskfile/node_http.go
+++ b/taskfile/node_http.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
-	"github.com/go-task/task/v3/internal/logger"
 )
 
 // An HTTPNode is a node that reads a Taskfile from a remote location via HTTP.
@@ -19,12 +18,10 @@ type HTTPNode struct {
 	*BaseNode
 	URL        *url.URL // stores url pointing actual remote file. (e.g. with Taskfile.yml)
 	entrypoint string   // stores entrypoint url. used for building graph vertices.
-	logger     *logger.Logger
 	timeout    time.Duration
 }
 
 func NewHTTPNode(
-	l *logger.Logger,
 	entrypoint string,
 	dir string,
 	insecure bool,
@@ -45,7 +42,6 @@ func NewHTTPNode(
 		URL:        url,
 		entrypoint: entrypoint,
 		timeout:    timeout,
-		logger:     l,
 	}, nil
 }
 
@@ -58,7 +54,7 @@ func (node *HTTPNode) Remote() bool {
 }
 
 func (node *HTTPNode) Read(ctx context.Context) ([]byte, error) {
-	url, err := RemoteExists(ctx, node.logger, node.URL, node.timeout)
+	url, err := RemoteExists(ctx, node.URL, node.timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -27,13 +27,18 @@ Continue?`
 Continue?`
 )
 
-// A Reader will recursively read Taskfiles from a given source using a directed
-// acyclic graph (DAG).
 type (
-	ReaderOption     func(*Reader)
-	ReaderDebugFunc  func(string)
+	// ReaderDebugFunc is a function that is called when the reader wants to
+	// log debug messages
+	ReaderDebugFunc func(string)
+	// ReaderPromptFunc is a function that is called when the reader wants to
+	// prompt the user in some way
 	ReaderPromptFunc func(string) error
-	Reader           struct {
+	// ReaderOption is a function that configures a Reader.
+	ReaderOption func(*Reader)
+	// A Reader will recursively read Taskfiles from a given source using a directed
+	// acyclic graph (DAG).
+	Reader struct {
 		graph       *ast.TaskfileGraph
 		node        Node
 		insecure    bool
@@ -47,6 +52,7 @@ type (
 	}
 )
 
+// NewReader constructs a new Taskfile Reader using the given Node and options.
 func NewReader(
 	node Node,
 	opts ...ReaderOption,
@@ -69,30 +75,40 @@ func NewReader(
 	return reader
 }
 
+// WithInsecure enables insecure connections when reading remote taskfiles. By
+// default, secure connections are rejected.
 func WithInsecure(insecure bool) ReaderOption {
 	return func(r *Reader) {
 		r.insecure = insecure
 	}
 }
 
+// WithDownload forces the reader to download a fresh copy of the taskfile from
+// the remote source.
 func WithDownload(download bool) ReaderOption {
 	return func(r *Reader) {
 		r.download = download
 	}
 }
 
+// WithOffline stops the reader from being able to make network connections.
+// It will still be able to read local files and cached copies of remote files.
 func WithOffline(offline bool) ReaderOption {
 	return func(r *Reader) {
 		r.offline = offline
 	}
 }
 
+// WithTimeout sets the timeout for reading remote taskfiles. By default, the
+// timeout is set to 10 seconds.
 func WithTimeout(timeout time.Duration) ReaderOption {
 	return func(r *Reader) {
 		r.timeout = timeout
 	}
 }
 
+// WithTempDir sets the temporary directory to be used by the reader. By
+// default, the reader uses `os.TempDir()`.
 func WithTempDir(tempDir string) ReaderOption {
 	return func(r *Reader) {
 		r.tempDir = tempDir

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -76,7 +76,7 @@ func NewReader(
 }
 
 // WithInsecure enables insecure connections when reading remote taskfiles. By
-// default, secure connections are rejected.
+// default, insecure connections are rejected.
 func WithInsecure(insecure bool) ReaderOption {
 	return func(r *Reader) {
 		r.insecure = insecure

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -30,37 +30,75 @@ Continue?`
 
 // A Reader will recursively read Taskfiles from a given source using a directed
 // acyclic graph (DAG).
-type Reader struct {
-	graph       *ast.TaskfileGraph
-	node        Node
-	insecure    bool
-	download    bool
-	offline     bool
-	timeout     time.Duration
-	tempDir     string
-	logger      *logger.Logger
-	promptMutex sync.Mutex
-}
+type (
+	Reader struct {
+		graph       *ast.TaskfileGraph
+		node        Node
+		insecure    bool
+		download    bool
+		offline     bool
+		timeout     time.Duration
+		tempDir     string
+		logger      *logger.Logger
+		promptMutex sync.Mutex
+	}
+	ReaderOption func(*Reader)
+)
 
 func NewReader(
 	node Node,
-	insecure bool,
-	download bool,
-	offline bool,
-	timeout time.Duration,
-	tempDir string,
-	logger *logger.Logger,
+	opts ...ReaderOption,
 ) *Reader {
-	return &Reader{
+	reader := &Reader{
 		graph:       ast.NewTaskfileGraph(),
 		node:        node,
-		insecure:    insecure,
-		download:    download,
-		offline:     offline,
-		timeout:     timeout,
-		tempDir:     tempDir,
-		logger:      logger,
+		insecure:    false,
+		download:    false,
+		offline:     false,
+		timeout:     time.Second * 10,
+		tempDir:     os.TempDir(),
+		logger:      nil,
 		promptMutex: sync.Mutex{},
+	}
+	for _, opt := range opts {
+		opt(reader)
+	}
+	return reader
+}
+
+func WithInsecure(insecure bool) ReaderOption {
+	return func(r *Reader) {
+		r.insecure = insecure
+	}
+}
+
+func WithDownload(download bool) ReaderOption {
+	return func(r *Reader) {
+		r.download = download
+	}
+}
+
+func WithOffline(offline bool) ReaderOption {
+	return func(r *Reader) {
+		r.offline = offline
+	}
+}
+
+func WithTimeout(timeout time.Duration) ReaderOption {
+	return func(r *Reader) {
+		r.timeout = timeout
+	}
+}
+
+func WithTempDir(tempDir string) ReaderOption {
+	return func(r *Reader) {
+		r.tempDir = tempDir
+	}
+}
+
+func WithLogger(logger *logger.Logger) ReaderOption {
+	return func(r *Reader) {
+		r.logger = logger
 	}
 }
 

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -132,7 +132,7 @@ func (r *Reader) include(node Node) error {
 				return err
 			}
 
-			includeNode, err := NewNode(r.logger, entrypoint, include.Dir, r.insecure, r.timeout,
+			includeNode, err := NewNode(entrypoint, include.Dir, r.insecure, r.timeout,
 				WithParent(node),
 			)
 			if err != nil {


### PR DESCRIPTION
Our package API should not rely on our internal `logger` package. Logging is a CLI-specific responsibility and users that want to use Task as a package may want to implement their own logging. As such, this PR removes the logger from the `taskfile` package entirely.

Normally this would mean we lose the ability to insert debug logs into our code. However, we can pass a generic function into the `Reader` which will process logs instead. This allows all of Task's current logging to remain in place while a 3rd party user can either omit the logging function when creating their reader (and discard the logs) or implement their own custom logging.

I have also done the same thing for the prompt function so that package API users can implement their own prompt functionality.

Finally, the reader now uses functional options in its constructor. This allows us to set sensible defaults instead of the caller having to specify everything each time (including the new logging functions).