### PR TITLE
refactor: executor functional options

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -113,7 +113,10 @@ func run() error {
 		log.Warnf("%s\n", err.Error())
 	}
 
-	e := task.NewExecutor(flags.WithFlags())
+	e := task.NewExecutor(
+		flags.WithFlags(),
+		task.WithVersionCheck(true),
+	)
 	if err := e.Setup(); err != nil {
 		return err
 	}

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -112,10 +112,6 @@ func run() error {
 	if err := experiments.Validate(); err != nil {
 		log.Warnf("%s\n", err.Error())
 	}
-	listOptions := task.NewListOptions(flags.List, flags.ListAll, flags.ListJson, flags.NoStatus)
-	if err := listOptions.Validate(); err != nil {
-		return err
-	}
 
 	e := task.NewExecutor(flags.WithFlags())
 	if err := e.Setup(); err != nil {
@@ -136,11 +132,16 @@ func run() error {
 		return cache.Clear()
 	}
 
-	if (listOptions.ShouldListTasks()) && flags.Silent {
-		return e.ListTaskNames(flags.ListAll)
-	}
-
+	listOptions := task.NewListOptions(
+		flags.List,
+		flags.ListAll,
+		flags.ListJson,
+		flags.NoStatus,
+	)
 	if listOptions.ShouldListTasks() {
+		if flags.Silent {
+			return e.ListTaskNames(flags.ListAll)
+		}
 		foundTasks, err := e.ListTasks(listOptions)
 		if err != nil {
 			return err

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -114,8 +114,8 @@ func run() error {
 	}
 
 	e := task.NewExecutor(
-		flags.WithFlags(),
-		task.WithVersionCheck(true),
+		flags.WithExecutorOptions(),
+		task.ExecutorWithVersionCheck(true),
 	)
 	if err := e.Setup(); err != nil {
 		return err

--- a/executor.go
+++ b/executor.go
@@ -16,9 +16,10 @@ import (
 )
 
 type (
-	// An ExecutorOption is a functional option for an Executor
+	// An ExecutorOption is a functional option for an [Executor].
 	ExecutorOption func(*Executor)
-	// An Executor is a type that is used for processing and executing Taskfiles
+	// An Executor is used for processing Taskfile(s) and executing the task(s)
+	// within them.
 	Executor struct {
 		// Flags
 		Dir         string
@@ -71,6 +72,8 @@ type (
 	}
 )
 
+// NewExecutor creates a new [Executor] and applies the given functional options
+// to it.
 func NewExecutor(opts ...ExecutorOption) *Executor {
 	e := &Executor{
 		Timeout:              time.Second * 10,
@@ -95,156 +98,216 @@ func NewExecutor(opts ...ExecutorOption) *Executor {
 	return e
 }
 
+// Options loops through the given [ExecutorOption] functions and applies them
+// to the [Executor].
 func (e *Executor) Options(opts ...ExecutorOption) {
 	for _, opt := range opts {
 		opt(e)
 	}
 }
 
+// WithDir sets the working directory of the [Executor]. By default, the
+// directory is set to the user's current working directory.
 func WithDir(dir string) ExecutorOption {
 	return func(e *Executor) {
 		e.Dir = dir
 	}
 }
 
+// WithEntrypoint sets the entrypoint (main Taskfile) of the [Executor]. By
+// default, Task will search for one of the default Taskfiles in the given
+// directory.
 func WithEntrypoint(entrypoint string) ExecutorOption {
 	return func(e *Executor) {
 		e.Entrypoint = entrypoint
 	}
 }
 
+// WithTempDir sets the temporary directory that will be used by [Executor] for
+// storing temporary files like checksums and cached remote files. By default,
+// the temporary directory is set to the user's temporary directory.
 func WithTempDir(tempDir TempDir) ExecutorOption {
 	return func(e *Executor) {
 		e.TempDir = tempDir
 	}
 }
 
+// WithForce ensures that the [Executor] always runs a task, even when
+// fingerprinting or prompts would normally stop it.
 func WithForce(force bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Force = force
 	}
 }
 
+// WithForceAll ensures that the [Executor] always runs all tasks (including
+// subtasks), even when fingerprinting or prompts would normally stop them.
 func WithForceAll(forceAll bool) ExecutorOption {
 	return func(e *Executor) {
 		e.ForceAll = forceAll
 	}
 }
 
+// WithInsecure allows the [Executor] to make insecure connections when reading
+// remote taskfiles. By default, insecure connections are rejected.
 func WithInsecure(insecure bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Insecure = insecure
 	}
 }
 
+// WithDownload forces the [Executor] to download a fresh copy of the taskfile
+// from the remote source.
 func WithDownload(download bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Download = download
 	}
 }
 
+// WithOffline stops the [Executor] from being able to make network connections.
+// It will still be able to read local files and cached copies of remote files.
 func WithOffline(offline bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Offline = offline
 	}
 }
 
+// WithTimeout sets the [Executor]'s timeout for fetching remote taskfiles. By
+// default, the timeout is set to 10 seconds.
 func WithTimeout(timeout time.Duration) ExecutorOption {
 	return func(e *Executor) {
 		e.Timeout = timeout
 	}
 }
 
+// WithWatch tells the [Executor] to keep running in the background and watch
+// for changes to the fingerprint of the tasks that are run. When changes are
+// detected, a new task run is triggered.
 func WithWatch(watch bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Watch = watch
 	}
 }
 
+// WithVerbose tells the [Executor] to output more information about the tasks
+// that are run.
 func WithVerbose(verbose bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Verbose = verbose
 	}
 }
 
+// WithSilent tells the [Executor] to suppress all output except for the output
+// of the tasks that are run.
 func WithSilent(silent bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Silent = silent
 	}
 }
 
+// WithAssumeYes tells the [Executor] to assume "yes" for all prompts.
 func WithAssumeYes(assumeYes bool) ExecutorOption {
 	return func(e *Executor) {
 		e.AssumeYes = assumeYes
 	}
 }
 
+// WithAssumeTerm is used for testing purposes to simulate a terminal.
 func WithDry(dry bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Dry = dry
 	}
 }
 
+// WithSummary tells the [Executor] to output a summary of the given tasks
+// instead of running them.
 func WithSummary(summary bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Summary = summary
 	}
 }
 
+// WithParallel tells the [Executor] to run tasks given in the same call
+// in parallel.
 func WithParallel(parallel bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Parallel = parallel
 	}
 }
 
+// WithColor tells the [Executor] whether or not to output using colorized
+// strings.
 func WithColor(color bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Color = color
 	}
 }
 
+// WithConcurrency sets the maximum number of tasks that the [Executor] can run
+// in parallel.
 func WithConcurrency(concurrency int) ExecutorOption {
 	return func(e *Executor) {
 		e.Concurrency = concurrency
 	}
 }
 
+// WithInterval sets the interval at which the [Executor] will check for changes
+// when watching tasks.
 func WithInterval(interval time.Duration) ExecutorOption {
 	return func(e *Executor) {
 		e.Interval = interval
 	}
 }
 
+// WithOutputStyle sets the output style of the [Executor]. By default, the
+// output style is set to the style defined in the Taskfile.
 func WithOutputStyle(outputStyle ast.Output) ExecutorOption {
 	return func(e *Executor) {
 		e.OutputStyle = outputStyle
 	}
 }
 
+// WithTaskSorter sets the sorter that the [Executor] will use to sort tasks.
+// By default, the sorter is set to sort tasks alphabetically, but with tasks
+// with no namespace (in the root Taskfile) first.
 func WithTaskSorter(sorter sort.Sorter) ExecutorOption {
 	return func(e *Executor) {
 		e.TaskSorter = sorter
 	}
 }
 
+// WithStdin sets the [Executor]'s standard input [io.Reader].
 func WithStdin(stdin io.Reader) ExecutorOption {
 	return func(e *Executor) {
 		e.Stdin = stdin
 	}
 }
 
+// WithStdout sets the [Executor]'s standard output [io.Writer].
 func WithStdout(stdout io.Writer) ExecutorOption {
 	return func(e *Executor) {
 		e.Stdout = stdout
 	}
 }
 
+// WithStderr sets the [Executor]'s standard error [io.Writer].
 func WithStderr(stderr io.Writer) ExecutorOption {
 	return func(e *Executor) {
 		e.Stderr = stderr
 	}
 }
 
+// WithIO sets the [Executor]'s standard input, output, and error to the same
+// [io.ReadWriter].
+func WithIO(rw io.ReadWriter) ExecutorOption {
+	return func(e *Executor) {
+		e.Stdin = rw
+		e.Stdout = rw
+		e.Stderr = rw
+	}
+}
+
+// WithVersionCheck tells the [Executor] whether or not to check the version of
 func WithVersionCheck(enableVersionCheck bool) ExecutorOption {
 	return func(e *Executor) {
 		e.EnableVersionCheck = enableVersionCheck

--- a/executor.go
+++ b/executor.go
@@ -106,200 +106,203 @@ func (e *Executor) Options(opts ...ExecutorOption) {
 	}
 }
 
-// WithDir sets the working directory of the [Executor]. By default, the
+// ExecutorWithDir sets the working directory of the [Executor]. By default, the
 // directory is set to the user's current working directory.
-func WithDir(dir string) ExecutorOption {
+func ExecutorWithDir(dir string) ExecutorOption {
 	return func(e *Executor) {
 		e.Dir = dir
 	}
 }
 
-// WithEntrypoint sets the entrypoint (main Taskfile) of the [Executor]. By
-// default, Task will search for one of the default Taskfiles in the given
+// ExecutorWithEntrypoint sets the entrypoint (main Taskfile) of the [Executor].
+// By default, Task will search for one of the default Taskfiles in the given
 // directory.
-func WithEntrypoint(entrypoint string) ExecutorOption {
+func ExecutorWithEntrypoint(entrypoint string) ExecutorOption {
 	return func(e *Executor) {
 		e.Entrypoint = entrypoint
 	}
 }
 
-// WithTempDir sets the temporary directory that will be used by [Executor] for
-// storing temporary files like checksums and cached remote files. By default,
-// the temporary directory is set to the user's temporary directory.
-func WithTempDir(tempDir TempDir) ExecutorOption {
+// ExecutorWithTempDir sets the temporary directory that will be used by
+// [Executor] for storing temporary files like checksums and cached remote
+// files. By default, the temporary directory is set to the user's temporary
+// directory.
+func ExecutorWithTempDir(tempDir TempDir) ExecutorOption {
 	return func(e *Executor) {
 		e.TempDir = tempDir
 	}
 }
 
-// WithForce ensures that the [Executor] always runs a task, even when
+// ExecutorWithForce ensures that the [Executor] always runs a task, even when
 // fingerprinting or prompts would normally stop it.
-func WithForce(force bool) ExecutorOption {
+func ExecutorWithForce(force bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Force = force
 	}
 }
 
-// WithForceAll ensures that the [Executor] always runs all tasks (including
-// subtasks), even when fingerprinting or prompts would normally stop them.
-func WithForceAll(forceAll bool) ExecutorOption {
+// ExecutorWithForceAll ensures that the [Executor] always runs all tasks
+// (including subtasks), even when fingerprinting or prompts would normally stop
+// them.
+func ExecutorWithForceAll(forceAll bool) ExecutorOption {
 	return func(e *Executor) {
 		e.ForceAll = forceAll
 	}
 }
 
-// WithInsecure allows the [Executor] to make insecure connections when reading
-// remote taskfiles. By default, insecure connections are rejected.
-func WithInsecure(insecure bool) ExecutorOption {
+// ExecutorWithInsecure allows the [Executor] to make insecure connections when
+// reading remote taskfiles. By default, insecure connections are rejected.
+func ExecutorWithInsecure(insecure bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Insecure = insecure
 	}
 }
 
-// WithDownload forces the [Executor] to download a fresh copy of the taskfile
-// from the remote source.
-func WithDownload(download bool) ExecutorOption {
+// ExecutorWithDownload forces the [Executor] to download a fresh copy of the
+// taskfile from the remote source.
+func ExecutorWithDownload(download bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Download = download
 	}
 }
 
-// WithOffline stops the [Executor] from being able to make network connections.
-// It will still be able to read local files and cached copies of remote files.
-func WithOffline(offline bool) ExecutorOption {
+// ExecutorWithOffline stops the [Executor] from being able to make network
+// connections. It will still be able to read local files and cached copies of
+// remote files.
+func ExecutorWithOffline(offline bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Offline = offline
 	}
 }
 
-// WithTimeout sets the [Executor]'s timeout for fetching remote taskfiles. By
-// default, the timeout is set to 10 seconds.
-func WithTimeout(timeout time.Duration) ExecutorOption {
+// ExecutorWithTimeout sets the [Executor]'s timeout for fetching remote
+// taskfiles. By default, the timeout is set to 10 seconds.
+func ExecutorWithTimeout(timeout time.Duration) ExecutorOption {
 	return func(e *Executor) {
 		e.Timeout = timeout
 	}
 }
 
-// WithWatch tells the [Executor] to keep running in the background and watch
-// for changes to the fingerprint of the tasks that are run. When changes are
-// detected, a new task run is triggered.
-func WithWatch(watch bool) ExecutorOption {
+// ExecutorWithWatch tells the [Executor] to keep running in the background and
+// watch for changes to the fingerprint of the tasks that are run. When changes
+// are detected, a new task run is triggered.
+func ExecutorWithWatch(watch bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Watch = watch
 	}
 }
 
-// WithVerbose tells the [Executor] to output more information about the tasks
-// that are run.
-func WithVerbose(verbose bool) ExecutorOption {
+// ExecutorWithVerbose tells the [Executor] to output more information about the
+// tasks that are run.
+func ExecutorWithVerbose(verbose bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Verbose = verbose
 	}
 }
 
-// WithSilent tells the [Executor] to suppress all output except for the output
-// of the tasks that are run.
-func WithSilent(silent bool) ExecutorOption {
+// ExecutorWithSilent tells the [Executor] to suppress all output except for the
+// output of the tasks that are run.
+func ExecutorWithSilent(silent bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Silent = silent
 	}
 }
 
-// WithAssumeYes tells the [Executor] to assume "yes" for all prompts.
-func WithAssumeYes(assumeYes bool) ExecutorOption {
+// ExecutorWithAssumeYes tells the [Executor] to assume "yes" for all prompts.
+func ExecutorWithAssumeYes(assumeYes bool) ExecutorOption {
 	return func(e *Executor) {
 		e.AssumeYes = assumeYes
 	}
 }
 
 // WithAssumeTerm is used for testing purposes to simulate a terminal.
-func WithDry(dry bool) ExecutorOption {
+func ExecutorWithDry(dry bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Dry = dry
 	}
 }
 
-// WithSummary tells the [Executor] to output a summary of the given tasks
-// instead of running them.
-func WithSummary(summary bool) ExecutorOption {
+// ExecutorWithSummary tells the [Executor] to output a summary of the given
+// tasks instead of running them.
+func ExecutorWithSummary(summary bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Summary = summary
 	}
 }
 
-// WithParallel tells the [Executor] to run tasks given in the same call
+// ExecutorWithParallel tells the [Executor] to run tasks given in the same call
 // in parallel.
-func WithParallel(parallel bool) ExecutorOption {
+func ExecutorWithParallel(parallel bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Parallel = parallel
 	}
 }
 
-// WithColor tells the [Executor] whether or not to output using colorized
-// strings.
-func WithColor(color bool) ExecutorOption {
+// ExecutorWithColor tells the [Executor] whether or not to output using
+// colorized strings.
+func ExecutorWithColor(color bool) ExecutorOption {
 	return func(e *Executor) {
 		e.Color = color
 	}
 }
 
-// WithConcurrency sets the maximum number of tasks that the [Executor] can run
-// in parallel.
-func WithConcurrency(concurrency int) ExecutorOption {
+// ExecutorWithConcurrency sets the maximum number of tasks that the [Executor]
+// can run in parallel.
+func ExecutorWithConcurrency(concurrency int) ExecutorOption {
 	return func(e *Executor) {
 		e.Concurrency = concurrency
 	}
 }
 
-// WithInterval sets the interval at which the [Executor] will check for changes
-// when watching tasks.
-func WithInterval(interval time.Duration) ExecutorOption {
+// ExecutorWithInterval sets the interval at which the [Executor] will check for
+// changes when watching tasks.
+func ExecutorWithInterval(interval time.Duration) ExecutorOption {
 	return func(e *Executor) {
 		e.Interval = interval
 	}
 }
 
-// WithOutputStyle sets the output style of the [Executor]. By default, the
-// output style is set to the style defined in the Taskfile.
-func WithOutputStyle(outputStyle ast.Output) ExecutorOption {
+// ExecutorWithOutputStyle sets the output style of the [Executor]. By default,
+// the output style is set to the style defined in the Taskfile.
+func ExecutorWithOutputStyle(outputStyle ast.Output) ExecutorOption {
 	return func(e *Executor) {
 		e.OutputStyle = outputStyle
 	}
 }
 
-// WithTaskSorter sets the sorter that the [Executor] will use to sort tasks.
-// By default, the sorter is set to sort tasks alphabetically, but with tasks
-// with no namespace (in the root Taskfile) first.
-func WithTaskSorter(sorter sort.Sorter) ExecutorOption {
+// ExecutorWithTaskSorter sets the sorter that the [Executor] will use to sort
+// tasks. By default, the sorter is set to sort tasks alphabetically, but with
+// tasks with no namespace (in the root Taskfile) first.
+func ExecutorWithTaskSorter(sorter sort.Sorter) ExecutorOption {
 	return func(e *Executor) {
 		e.TaskSorter = sorter
 	}
 }
 
-// WithStdin sets the [Executor]'s standard input [io.Reader].
-func WithStdin(stdin io.Reader) ExecutorOption {
+// ExecutorWithStdin sets the [Executor]'s standard input [io.Reader].
+func ExecutorWithStdin(stdin io.Reader) ExecutorOption {
 	return func(e *Executor) {
 		e.Stdin = stdin
 	}
 }
 
-// WithStdout sets the [Executor]'s standard output [io.Writer].
-func WithStdout(stdout io.Writer) ExecutorOption {
+// ExecutorWithStdout sets the [Executor]'s standard output [io.Writer].
+func ExecutorWithStdout(stdout io.Writer) ExecutorOption {
 	return func(e *Executor) {
 		e.Stdout = stdout
 	}
 }
 
-// WithStderr sets the [Executor]'s standard error [io.Writer].
-func WithStderr(stderr io.Writer) ExecutorOption {
+// ExecutorWithStderr sets the [Executor]'s standard error [io.Writer].
+func ExecutorWithStderr(stderr io.Writer) ExecutorOption {
 	return func(e *Executor) {
 		e.Stderr = stderr
 	}
 }
 
-// WithIO sets the [Executor]'s standard input, output, and error to the same
-// [io.ReadWriter].
-func WithIO(rw io.ReadWriter) ExecutorOption {
+// ExecutorWithIO sets the [Executor]'s standard input, output, and error to the
+// same [io.ReadWriter].
+func ExecutorWithIO(rw io.ReadWriter) ExecutorOption {
 	return func(e *Executor) {
 		e.Stdin = rw
 		e.Stdout = rw
@@ -307,8 +310,9 @@ func WithIO(rw io.ReadWriter) ExecutorOption {
 	}
 }
 
-// WithVersionCheck tells the [Executor] whether or not to check the version of
-func WithVersionCheck(enableVersionCheck bool) ExecutorOption {
+// ExecutorWithVersionCheck tells the [Executor] whether or not to check the
+// version of
+func ExecutorWithVersionCheck(enableVersionCheck bool) ExecutorOption {
 	return func(e *Executor) {
 		e.EnableVersionCheck = enableVersionCheck
 	}

--- a/executor.go
+++ b/executor.go
@@ -1,0 +1,252 @@
+package task
+
+import (
+	"context"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/sajari/fuzzy"
+
+	"github.com/go-task/task/v3/internal/logger"
+	"github.com/go-task/task/v3/internal/output"
+	"github.com/go-task/task/v3/internal/sort"
+	"github.com/go-task/task/v3/taskfile/ast"
+)
+
+type (
+	// An ExecutorOption is a functional option for an Executor
+	ExecutorOption func(*Executor)
+	// An Executor is a type that is used for processing and executing Taskfiles
+	Executor struct {
+		// Flags
+		Dir         string
+		Entrypoint  string
+		TempDir     TempDir
+		Force       bool
+		ForceAll    bool
+		Insecure    bool
+		Download    bool
+		Offline     bool
+		Timeout     time.Duration
+		Watch       bool
+		Verbose     bool
+		Silent      bool
+		AssumeYes   bool
+		AssumeTerm  bool // Used for testing
+		Dry         bool
+		Summary     bool
+		Parallel    bool
+		Color       bool
+		Concurrency int
+		Interval    time.Duration
+
+		// I/O
+		Stdin  io.Reader
+		Stdout io.Writer
+		Stderr io.Writer
+
+		// Internal
+		Taskfile           *ast.Taskfile
+		Logger             *logger.Logger
+		Compiler           *Compiler
+		Output             output.Output
+		OutputStyle        ast.Output
+		TaskSorter         sort.Sorter
+		UserWorkingDir     string
+		EnableVersionCheck bool
+
+		fuzzyModel *fuzzy.Model
+
+		concurrencySemaphore chan struct{}
+		taskCallCount        map[string]*int32
+		mkdirMutexMap        map[string]*sync.Mutex
+		executionHashes      map[string]context.Context
+		executionHashesMutex sync.Mutex
+	}
+	TempDir struct {
+		Remote      string
+		Fingerprint string
+	}
+)
+
+func NewExecutor(opts ...ExecutorOption) *Executor {
+	e := &Executor{
+		Timeout:              time.Second * 10,
+		Interval:             time.Second * 5,
+		Stdin:                os.Stdin,
+		Stdout:               os.Stdout,
+		Stderr:               os.Stderr,
+		Logger:               nil,
+		Compiler:             nil,
+		Output:               nil,
+		OutputStyle:          ast.Output{},
+		TaskSorter:           sort.AlphaNumericWithRootTasksFirst,
+		UserWorkingDir:       "",
+		fuzzyModel:           nil,
+		concurrencySemaphore: nil,
+		taskCallCount:        map[string]*int32{},
+		mkdirMutexMap:        map[string]*sync.Mutex{},
+		executionHashes:      map[string]context.Context{},
+		executionHashesMutex: sync.Mutex{},
+	}
+	e.Options(opts...)
+	return e
+}
+
+func (e *Executor) Options(opts ...ExecutorOption) {
+	for _, opt := range opts {
+		opt(e)
+	}
+}
+
+func WithDir(dir string) ExecutorOption {
+	return func(e *Executor) {
+		e.Dir = dir
+	}
+}
+
+func WithEntrypoint(entrypoint string) ExecutorOption {
+	return func(e *Executor) {
+		e.Entrypoint = entrypoint
+	}
+}
+
+func WithTempDir(tempDir TempDir) ExecutorOption {
+	return func(e *Executor) {
+		e.TempDir = tempDir
+	}
+}
+
+func WithForce(force bool) ExecutorOption {
+	return func(e *Executor) {
+		e.Force = force
+	}
+}
+
+func WithForceAll(forceAll bool) ExecutorOption {
+	return func(e *Executor) {
+		e.ForceAll = forceAll
+	}
+}
+
+func WithInsecure(insecure bool) ExecutorOption {
+	return func(e *Executor) {
+		e.Insecure = insecure
+	}
+}
+
+func WithDownload(download bool) ExecutorOption {
+	return func(e *Executor) {
+		e.Download = download
+	}
+}
+
+func WithOffline(offline bool) ExecutorOption {
+	return func(e *Executor) {
+		e.Offline = offline
+	}
+}
+
+func WithTimeout(timeout time.Duration) ExecutorOption {
+	return func(e *Executor) {
+		e.Timeout = timeout
+	}
+}
+
+func WithWatch(watch bool) ExecutorOption {
+	return func(e *Executor) {
+		e.Watch = watch
+	}
+}
+
+func WithVerbose(verbose bool) ExecutorOption {
+	return func(e *Executor) {
+		e.Verbose = verbose
+	}
+}
+
+func WithSilent(silent bool) ExecutorOption {
+	return func(e *Executor) {
+		e.Silent = silent
+	}
+}
+
+func WithAssumeYes(assumeYes bool) ExecutorOption {
+	return func(e *Executor) {
+		e.AssumeYes = assumeYes
+	}
+}
+
+func WithDry(dry bool) ExecutorOption {
+	return func(e *Executor) {
+		e.Dry = dry
+	}
+}
+
+func WithSummary(summary bool) ExecutorOption {
+	return func(e *Executor) {
+		e.Summary = summary
+	}
+}
+
+func WithParallel(parallel bool) ExecutorOption {
+	return func(e *Executor) {
+		e.Parallel = parallel
+	}
+}
+
+func WithColor(color bool) ExecutorOption {
+	return func(e *Executor) {
+		e.Color = color
+	}
+}
+
+func WithConcurrency(concurrency int) ExecutorOption {
+	return func(e *Executor) {
+		e.Concurrency = concurrency
+	}
+}
+
+func WithInterval(interval time.Duration) ExecutorOption {
+	return func(e *Executor) {
+		e.Interval = interval
+	}
+}
+
+func WithOutputStyle(outputStyle ast.Output) ExecutorOption {
+	return func(e *Executor) {
+		e.OutputStyle = outputStyle
+	}
+}
+
+func WithTaskSorter(sorter sort.Sorter) ExecutorOption {
+	return func(e *Executor) {
+		e.TaskSorter = sorter
+	}
+}
+
+func WithStdin(stdin io.Reader) ExecutorOption {
+	return func(e *Executor) {
+		e.Stdin = stdin
+	}
+}
+
+func WithStdout(stdout io.Writer) ExecutorOption {
+	return func(e *Executor) {
+		e.Stdout = stdout
+	}
+}
+
+func WithStderr(stderr io.Writer) ExecutorOption {
+	return func(e *Executor) {
+		e.Stderr = stderr
+	}
+}
+
+func WithVersionCheck(enableVersionCheck bool) ExecutorOption {
+	return func(e *Executor) {
+		e.EnableVersionCheck = enableVersionCheck
+	}
+}

--- a/help.go
+++ b/help.go
@@ -41,20 +41,6 @@ func (o ListOptions) ShouldListTasks() bool {
 	return o.ListOnlyTasksWithDescriptions || o.ListAllTasks
 }
 
-// Validate validates that the collection of list-related options are in a valid configuration
-func (o ListOptions) Validate() error {
-	if o.ListOnlyTasksWithDescriptions && o.ListAllTasks {
-		return fmt.Errorf("task: cannot use --list and --list-all at the same time")
-	}
-	if o.FormatTaskListAsJSON && !o.ShouldListTasks() {
-		return fmt.Errorf("task: --json only applies to --list or --list-all")
-	}
-	if o.NoStatus && !o.FormatTaskListAsJSON {
-		return fmt.Errorf("task: --no-status only applies to --json with --list or --list-all")
-	}
-	return nil
-}
-
 // Filters returns the slice of FilterFunc which filters a list
 // of ast.Task according to the given ListOptions
 func (o ListOptions) Filters() []FilterFunc {

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -176,9 +176,9 @@ func Validate() error {
 	return nil
 }
 
-// WithFlags is a special internal functional option that is used to pass flags
+// WithExecutorOptions is a special internal functional option that is used to pass flags
 // from the CLI directly to the executor.
-func WithFlags() task.ExecutorOption {
+func WithExecutorOptions() task.ExecutorOption {
 	return func(e *task.Executor) {
 		// Set the sorter
 		var sorter sort.Sorter
@@ -199,27 +199,27 @@ func WithFlags() task.ExecutorOption {
 		}
 
 		e.Options(
-			task.WithDir(dir),
-			task.WithEntrypoint(Entrypoint),
-			task.WithForce(Force),
-			task.WithForceAll(ForceAll),
-			task.WithInsecure(Insecure),
-			task.WithDownload(Download),
-			task.WithOffline(Offline),
-			task.WithTimeout(Timeout),
-			task.WithWatch(Watch),
-			task.WithVerbose(Verbose),
-			task.WithSilent(Silent),
-			task.WithAssumeYes(AssumeYes),
-			task.WithDry(Dry || Status),
-			task.WithSummary(Summary),
-			task.WithParallel(Parallel),
-			task.WithColor(Color),
-			task.WithConcurrency(Concurrency),
-			task.WithInterval(Interval),
-			task.WithOutputStyle(Output),
-			task.WithTaskSorter(sorter),
-			task.WithVersionCheck(true),
+			task.ExecutorWithDir(dir),
+			task.ExecutorWithEntrypoint(Entrypoint),
+			task.ExecutorWithForce(Force),
+			task.ExecutorWithForceAll(ForceAll),
+			task.ExecutorWithInsecure(Insecure),
+			task.ExecutorWithDownload(Download),
+			task.ExecutorWithOffline(Offline),
+			task.ExecutorWithTimeout(Timeout),
+			task.ExecutorWithWatch(Watch),
+			task.ExecutorWithVerbose(Verbose),
+			task.ExecutorWithSilent(Silent),
+			task.ExecutorWithAssumeYes(AssumeYes),
+			task.ExecutorWithDry(Dry || Status),
+			task.ExecutorWithSummary(Summary),
+			task.ExecutorWithParallel(Parallel),
+			task.ExecutorWithColor(Color),
+			task.ExecutorWithConcurrency(Concurrency),
+			task.ExecutorWithInterval(Interval),
+			task.ExecutorWithOutputStyle(Output),
+			task.ExecutorWithTaskSorter(sorter),
+			task.ExecutorWithVersionCheck(true),
 		)
 	}
 }

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -146,8 +146,7 @@ func Validate() error {
 	}
 
 	if Global && Dir != "" {
-		log.Fatal("task: You can't set both --global and --dir")
-		return nil
+		return errors.New("task: You can't set both --global and --dir")
 	}
 
 	if Output.Name != "group" {
@@ -160,6 +159,18 @@ func Validate() error {
 		if Output.Group.ErrorOnly {
 			return errors.New("task: You can't set --output-group-error-only without --output=group")
 		}
+	}
+
+	if List && ListAll {
+		return errors.New("task: cannot use --list and --list-all at the same time")
+	}
+
+	if ListJson && !List && !ListAll {
+		return errors.New("task: --json only applies to --list or --list-all")
+	}
+
+	if NoStatus && !ListJson {
+		return errors.New("task: --no-status only applies to --json with --list or --list-all")
 	}
 
 	return nil

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"github.com/go-task/task/v3"
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/env"
 	"github.com/go-task/task/v3/internal/experiments"
+	"github.com/go-task/task/v3/internal/sort"
 	"github.com/go-task/task/v3/taskfile/ast"
 )
 
@@ -161,4 +163,52 @@ func Validate() error {
 	}
 
 	return nil
+}
+
+// WithFlags is a special internal functional option that is used to pass flags
+// from the CLI directly to the executor.
+func WithFlags() task.ExecutorOption {
+	return func(e *task.Executor) {
+		// Set the sorter
+		var sorter sort.Sorter
+		switch TaskSort {
+		case "none":
+			sorter = nil
+		case "alphanumeric":
+			sorter = sort.AlphaNumeric
+		}
+
+		// Change the directory to the user's home directory if the global flag is set
+		dir := Dir
+		if Global {
+			home, err := os.UserHomeDir()
+			if err == nil {
+				dir = home
+			}
+		}
+
+		e.Options(
+			task.WithDir(dir),
+			task.WithEntrypoint(Entrypoint),
+			task.WithForce(Force),
+			task.WithForceAll(ForceAll),
+			task.WithInsecure(Insecure),
+			task.WithDownload(Download),
+			task.WithOffline(Offline),
+			task.WithTimeout(Timeout),
+			task.WithWatch(Watch),
+			task.WithVerbose(Verbose),
+			task.WithSilent(Silent),
+			task.WithAssumeYes(AssumeYes),
+			task.WithDry(Dry || Status),
+			task.WithSummary(Summary),
+			task.WithParallel(Parallel),
+			task.WithColor(Color),
+			task.WithConcurrency(Concurrency),
+			task.WithInterval(Interval),
+			task.WithOutputStyle(Output),
+			task.WithTaskSorter(sorter),
+			task.WithVersionCheck(true),
+		)
+	}
 }

--- a/setup.go
+++ b/setup.go
@@ -72,13 +72,13 @@ func (e *Executor) readTaskfile(node taskfile.Node) error {
 	}
 	reader := taskfile.NewReader(
 		node,
-		taskfile.WithInsecure(e.Insecure),
-		taskfile.WithDownload(e.Download),
-		taskfile.WithOffline(e.Offline),
-		taskfile.WithTimeout(e.Timeout),
-		taskfile.WithTempDir(e.TempDir.Remote),
-		taskfile.WithDebugFunc(debugFunc),
-		taskfile.WithPromptFunc(promptFunc),
+		taskfile.ReaderWithInsecure(e.Insecure),
+		taskfile.ReaderWithDownload(e.Download),
+		taskfile.ReaderWithOffline(e.Offline),
+		taskfile.ReaderWithTimeout(e.Timeout),
+		taskfile.ReaderWithTempDir(e.TempDir.Remote),
+		taskfile.ReaderWithDebugFunc(debugFunc),
+		taskfile.ReaderWithPromptFunc(promptFunc),
 	)
 	graph, err := reader.Read()
 	if err != nil {

--- a/task.go
+++ b/task.go
@@ -3,13 +3,10 @@ package task
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"runtime"
 	"slices"
-	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/env"
@@ -23,7 +20,6 @@ import (
 	"github.com/go-task/task/v3/internal/templater"
 	"github.com/go-task/task/v3/taskfile/ast"
 
-	"github.com/sajari/fuzzy"
 	"golang.org/x/sync/errgroup"
 	"mvdan.cc/sh/v3/interp"
 )
@@ -33,57 +29,6 @@ const (
 	// This exists to prevent infinite loops on cyclic dependencies
 	MaximumTaskCall = 1000
 )
-
-type TempDir struct {
-	Remote      string
-	Fingerprint string
-}
-
-// Executor executes a Taskfile
-type Executor struct {
-	Taskfile *ast.Taskfile
-
-	Dir         string
-	Entrypoint  string
-	TempDir     TempDir
-	Force       bool
-	ForceAll    bool
-	Insecure    bool
-	Download    bool
-	Offline     bool
-	Timeout     time.Duration
-	Watch       bool
-	Verbose     bool
-	Silent      bool
-	AssumeYes   bool
-	AssumeTerm  bool // Used for testing
-	Dry         bool
-	Summary     bool
-	Parallel    bool
-	Color       bool
-	Concurrency int
-	Interval    time.Duration
-
-	Stdin  io.Reader
-	Stdout io.Writer
-	Stderr io.Writer
-
-	Logger             *logger.Logger
-	Compiler           *Compiler
-	Output             output.Output
-	OutputStyle        ast.Output
-	TaskSorter         sort.Sorter
-	UserWorkingDir     string
-	EnableVersionCheck bool
-
-	fuzzyModel *fuzzy.Model
-
-	concurrencySemaphore chan struct{}
-	taskCallCount        map[string]*int32
-	mkdirMutexMap        map[string]*sync.Mutex
-	executionHashes      map[string]context.Context
-	executionHashesMutex sync.Mutex
-}
 
 // MatchingTask represents a task that matches a given call. It includes the
 // task itself and a list of wildcards that were matched.

--- a/task_test.go
+++ b/task_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/experiments"
 	"github.com/go-task/task/v3/internal/filepathext"
-	"github.com/go-task/task/v3/internal/logger"
 	"github.com/go-task/task/v3/taskfile/ast"
 )
 
@@ -70,16 +69,17 @@ func (fct fileContentTest) Run(t *testing.T) {
 	for f := range fct.Files {
 		_ = os.Remove(filepathext.SmartJoin(fct.Dir, f))
 	}
-	e := &task.Executor{
-		Dir: fct.Dir,
-		TempDir: task.TempDir{
+
+	e := task.NewExecutor(
+		task.WithDir(fct.Dir),
+		task.WithTempDir(task.TempDir{
 			Remote:      filepathext.SmartJoin(fct.Dir, ".task"),
 			Fingerprint: filepathext.SmartJoin(fct.Dir, ".task"),
-		},
-		Entrypoint: fct.Entrypoint,
-		Stdout:     io.Discard,
-		Stderr:     io.Discard,
-	}
+		}),
+		task.WithEntrypoint(fct.Entrypoint),
+		task.WithStdout(io.Discard),
+		task.WithStderr(io.Discard),
+	)
 
 	require.NoError(t, e.Setup(), "e.Setup()")
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: fct.Target}), "e.Run(target)")
@@ -100,11 +100,12 @@ func (fct fileContentTest) Run(t *testing.T) {
 func TestEmptyTask(t *testing.T) {
 	t.Parallel()
 
-	e := &task.Executor{
-		Dir:    "testdata/empty_task",
-		Stdout: io.Discard,
-		Stderr: io.Discard,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/empty_task"),
+		task.WithStdout(io.Discard),
+		task.WithStderr(io.Discard),
+	)
+
 	require.NoError(t, e.Setup(), "e.Setup()")
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "default"}))
 }
@@ -112,11 +113,12 @@ func TestEmptyTask(t *testing.T) {
 func TestEmptyTaskfile(t *testing.T) {
 	t.Parallel()
 
-	e := &task.Executor{
-		Dir:    "testdata/empty_taskfile",
-		Stdout: io.Discard,
-		Stderr: io.Discard,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/empty_taskfile"),
+		task.WithStdout(io.Discard),
+		task.WithStderr(io.Discard),
+	)
+
 	require.Error(t, e.Setup(), "e.Setup()")
 }
 
@@ -173,11 +175,11 @@ func TestRequires(t *testing.T) {
 	const dir = "testdata/requires"
 
 	var buff bytes.Buffer
-	e := &task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 
 	require.NoError(t, e.Setup())
 	require.ErrorContains(t, e.Run(context.Background(), &task.Call{Task: "missing-var"}), "task: Task \"missing-var\" cancelled because it is missing required variables: FOO")
@@ -256,13 +258,13 @@ func TestSpecialVars(t *testing.T) {
 				t.Parallel()
 
 				var buff bytes.Buffer
-				e := &task.Executor{
-					Dir:                dir,
-					Stdout:             &buff,
-					Stderr:             &buff,
-					Silent:             true,
-					EnableVersionCheck: true,
-				}
+				e := task.NewExecutor(
+					task.WithDir(dir),
+					task.WithStdout(&buff),
+					task.WithStderr(&buff),
+					task.WithSilent(true),
+					task.WithVersionCheck(true),
+				)
 				require.NoError(t, e.Setup())
 				require.NoError(t, e.Run(context.Background(), &task.Call{Task: test.target}))
 				assert.Equal(t, test.expected+"\n", buff.String())
@@ -278,13 +280,12 @@ func TestConcurrency(t *testing.T) {
 		dir    = "testdata/concurrency"
 		target = "default"
 	)
-
-	e := &task.Executor{
-		Dir:         dir,
-		Stdout:      io.Discard,
-		Stderr:      io.Discard,
-		Concurrency: 1,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(io.Discard),
+		task.WithStderr(io.Discard),
+		task.WithConcurrency(1),
+	)
 	require.NoError(t, e.Setup(), "e.Setup()")
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: target}), "e.Run(target)")
 }
@@ -339,11 +340,11 @@ func TestDeps(t *testing.T) {
 		_ = os.Remove(filepathext.SmartJoin(dir, f))
 	}
 
-	e := &task.Executor{
-		Dir:    dir,
-		Stdout: io.Discard,
-		Stderr: io.Discard,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(io.Discard),
+		task.WithStderr(io.Discard),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "default"}))
 
@@ -375,16 +376,16 @@ func TestStatus(t *testing.T) {
 	}
 
 	var buff bytes.Buffer
-	e := &task.Executor{
-		Dir: dir,
-		TempDir: task.TempDir{
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSilent(true),
+		task.WithTempDir(task.TempDir{
 			Remote:      filepathext.SmartJoin(dir, ".task"),
 			Fingerprint: filepathext.SmartJoin(dir, ".task"),
-		},
-		Stdout: &buff,
-		Stderr: &buff,
-		Silent: true,
-	}
+		}),
+	)
 	require.NoError(t, e.Setup())
 	// gen-foo creates foo.txt, and will always fail it's status check.
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "gen-foo"}))
@@ -462,11 +463,11 @@ func TestPrecondition(t *testing.T) {
 	const dir = "testdata/precondition"
 
 	var buff bytes.Buffer
-	e := &task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 
 	// A precondition that has been met
 	require.NoError(t, e.Setup())
@@ -522,11 +523,11 @@ func TestGenerates(t *testing.T) {
 	}
 
 	buff := bytes.NewBuffer(nil)
-	e := &task.Executor{
-		Dir:    dir,
-		Stdout: buff,
-		Stderr: buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(buff),
+		task.WithStderr(buff),
+	)
 	require.NoError(t, e.Setup())
 
 	for _, theTask := range []string{relTask, absTask, fileWithSpaces} {
@@ -579,16 +580,16 @@ func TestStatusChecksum(t *testing.T) { // nolint:paralleltest // cannot run in 
 			}
 
 			var buff bytes.Buffer
-			tempdir := task.TempDir{
+			tempDir := task.TempDir{
 				Remote:      filepathext.SmartJoin(dir, ".task"),
 				Fingerprint: filepathext.SmartJoin(dir, ".task"),
 			}
-			e := task.Executor{
-				Dir:     dir,
-				TempDir: tempdir,
-				Stdout:  &buff,
-				Stderr:  &buff,
-			}
+			e := task.NewExecutor(
+				task.WithDir(dir),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+				task.WithTempDir(tempDir),
+			)
 			require.NoError(t, e.Setup())
 
 			require.NoError(t, e.Run(context.Background(), &task.Call{Task: test.task}))
@@ -599,7 +600,7 @@ func TestStatusChecksum(t *testing.T) { // nolint:paralleltest // cannot run in 
 
 			// Capture the modification time, so we can ensure the checksum file
 			// is not regenerated when the hash hasn't changed.
-			s, err := os.Stat(filepathext.SmartJoin(tempdir.Fingerprint, "checksum/"+test.task))
+			s, err := os.Stat(filepathext.SmartJoin(tempDir.Fingerprint, "checksum/"+test.task))
 			require.NoError(t, err)
 			time := s.ModTime()
 
@@ -607,7 +608,7 @@ func TestStatusChecksum(t *testing.T) { // nolint:paralleltest // cannot run in 
 			require.NoError(t, e.Run(context.Background(), &task.Call{Task: test.task}))
 			assert.Equal(t, `task: Task "`+test.task+`" is up to date`+"\n", buff.String())
 
-			s, err = os.Stat(filepathext.SmartJoin(tempdir.Fingerprint, "checksum/"+test.task))
+			s, err = os.Stat(filepathext.SmartJoin(tempDir.Fingerprint, "checksum/"+test.task))
 			require.NoError(t, err)
 			assert.Equal(t, time, s.ModTime())
 		})
@@ -623,11 +624,11 @@ func TestAlias(t *testing.T) {
 	require.NoError(t, err)
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "f"}))
 	assert.Equal(t, string(data), buff.String())
@@ -639,11 +640,11 @@ func TestDuplicateAlias(t *testing.T) {
 	const dir = "testdata/alias"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 	require.Error(t, e.Run(context.Background(), &task.Call{Task: "x"}))
 	assert.Equal(t, "", buff.String())
@@ -658,12 +659,12 @@ func TestAliasSummary(t *testing.T) {
 	require.NoError(t, err)
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:     dir,
-		Summary: true,
-		Stdout:  &buff,
-		Stderr:  &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSummary(true),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "f"}))
 	assert.Equal(t, string(data), buff.String())
@@ -675,11 +676,11 @@ func TestLabelUpToDate(t *testing.T) {
 	const dir = "testdata/label_uptodate"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "foo"}))
 	assert.Contains(t, buff.String(), "foobar")
@@ -691,12 +692,12 @@ func TestLabelSummary(t *testing.T) {
 	const dir = "testdata/label_summary"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:     dir,
-		Summary: true,
-		Stdout:  &buff,
-		Stderr:  &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSummary(true),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "foo"}))
 	assert.Contains(t, buff.String(), "foobar")
@@ -707,9 +708,9 @@ func TestLabelInStatus(t *testing.T) {
 
 	const dir = "testdata/label_status"
 
-	e := task.Executor{
-		Dir: dir,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+	)
 	require.NoError(t, e.Setup())
 	err := e.Status(context.Background(), &task.Call{Task: "foo"})
 	assert.ErrorContains(t, err, "foobar")
@@ -721,11 +722,11 @@ func TestLabelWithVariableExpansion(t *testing.T) {
 	const dir = "testdata/label_var"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "foo"}))
 	assert.Contains(t, buff.String(), "foobaz")
@@ -737,11 +738,11 @@ func TestLabelInSummary(t *testing.T) {
 	const dir = "testdata/label_summary"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "foo"}))
 	assert.Contains(t, buff.String(), "foobar")
@@ -774,13 +775,13 @@ func TestPromptInSummary(t *testing.T) {
 
 			inBuff.Write([]byte(test.input))
 
-			e := task.Executor{
-				Dir:        dir,
-				Stdin:      &inBuff,
-				Stdout:     &outBuff,
-				Stderr:     &errBuff,
-				AssumeTerm: true,
-			}
+			e := task.NewExecutor(
+				task.WithDir(dir),
+				task.WithStdin(&inBuff),
+				task.WithStdout(&outBuff),
+				task.WithStderr(&errBuff),
+			)
+			e.AssumeTerm = true
 			require.NoError(t, e.Setup())
 
 			err := e.Run(context.Background(), &task.Call{Task: "foo"})
@@ -804,13 +805,13 @@ func TestPromptWithIndirectTask(t *testing.T) {
 
 	inBuff.Write([]byte("y\n"))
 
-	e := task.Executor{
-		Dir:        dir,
-		Stdin:      &inBuff,
-		Stdout:     &outBuff,
-		Stderr:     &errBuff,
-		AssumeTerm: true,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdin(&inBuff),
+		task.WithStdout(&outBuff),
+		task.WithStderr(&errBuff),
+	)
+	e.AssumeTerm = true
 	require.NoError(t, e.Setup())
 
 	err := e.Run(context.Background(), &task.Call{Task: "bar"})
@@ -841,13 +842,13 @@ func TestPromptAssumeYes(t *testing.T) {
 			// always cancel the prompt so we can require.Error
 			inBuff.Write([]byte("\n"))
 
-			e := task.Executor{
-				Dir:       dir,
-				Stdin:     &inBuff,
-				Stdout:    &outBuff,
-				Stderr:    &errBuff,
-				AssumeYes: test.assumeYes,
-			}
+			e := task.NewExecutor(
+				task.WithDir(dir),
+				task.WithStdin(&inBuff),
+				task.WithStdout(&outBuff),
+				task.WithStderr(&errBuff),
+			)
+			e.AssumeTerm = true
 			require.NoError(t, e.Setup())
 
 			err := e.Run(context.Background(), &task.Call{Task: "foo"})
@@ -866,11 +867,11 @@ func TestNoLabelInList(t *testing.T) {
 	const dir = "testdata/label_list"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 	if _, err := e.ListTasks(task.ListOptions{ListOnlyTasksWithDescriptions: true}); err != nil {
 		t.Error(err)
@@ -885,12 +886,11 @@ func TestListAllShowsNoDesc(t *testing.T) {
 	const dir = "testdata/list_mixed_desc"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
-
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	var title string
@@ -913,12 +913,11 @@ func TestListCanListDescOnly(t *testing.T) {
 	const dir = "testdata/list_mixed_desc"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
-
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 	if _, err := e.ListTasks(task.ListOptions{ListOnlyTasksWithDescriptions: true}); err != nil {
 		t.Error(err)
@@ -940,12 +939,11 @@ func TestListDescInterpolation(t *testing.T) {
 	const dir = "testdata/list_desc_interpolation"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
-
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 	if _, err := e.ListTasks(task.ListOptions{ListOnlyTasksWithDescriptions: true}); err != nil {
 		t.Error(err)
@@ -964,17 +962,17 @@ func TestStatusVariables(t *testing.T) {
 	_ = os.Remove(filepathext.SmartJoin(dir, "generated.txt"))
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir: dir,
-		TempDir: task.TempDir{
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithTempDir(task.TempDir{
 			Remote:      filepathext.SmartJoin(dir, ".task"),
 			Fingerprint: filepathext.SmartJoin(dir, ".task"),
-		},
-		Stdout:  &buff,
-		Stderr:  &buff,
-		Silent:  false,
-		Verbose: true,
-	}
+		}),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSilent(false),
+		task.WithVerbose(true),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "build-checksum"}))
 
@@ -1000,17 +998,17 @@ func TestCmdsVariables(t *testing.T) {
 	_ = os.RemoveAll(filepathext.SmartJoin(dir, ".task"))
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir: dir,
-		TempDir: task.TempDir{
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithTempDir(task.TempDir{
 			Remote:      filepathext.SmartJoin(dir, ".task"),
 			Fingerprint: filepathext.SmartJoin(dir, ".task"),
-		},
-		Stdout:  &buff,
-		Stderr:  &buff,
-		Silent:  false,
-		Verbose: true,
-	}
+		}),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSilent(false),
+		task.WithVerbose(true),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "build-checksum"}))
 
@@ -1032,11 +1030,11 @@ func TestCyclicDep(t *testing.T) {
 
 	const dir = "testdata/cyclic"
 
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: io.Discard,
-		Stderr: io.Discard,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(io.Discard),
+		task.WithStderr(io.Discard),
+	)
 	require.NoError(t, e.Setup())
 	assert.IsType(t, &errors.TaskCalledTooManyTimesError{}, e.Run(context.Background(), &task.Call{Task: "task-1"}))
 }
@@ -1058,12 +1056,12 @@ func TestTaskVersion(t *testing.T) {
 		t.Run(test.Dir, func(t *testing.T) {
 			t.Parallel()
 
-			e := task.Executor{
-				Dir:                test.Dir,
-				Stdout:             io.Discard,
-				Stderr:             io.Discard,
-				EnableVersionCheck: true,
-			}
+			e := task.NewExecutor(
+				task.WithDir(test.Dir),
+				task.WithStdout(io.Discard),
+				task.WithStderr(io.Discard),
+				task.WithVersionCheck(true),
+			)
 			err := e.Setup()
 			if test.wantErr {
 				require.Error(t, err)
@@ -1081,11 +1079,11 @@ func TestTaskIgnoreErrors(t *testing.T) {
 
 	const dir = "testdata/ignore_errors"
 
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: io.Discard,
-		Stderr: io.Discard,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(io.Discard),
+		task.WithStderr(io.Discard),
+	)
 	require.NoError(t, e.Setup())
 
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "task-should-pass"}))
@@ -1105,11 +1103,11 @@ func TestExpand(t *testing.T) {
 	}
 	var buff bytes.Buffer
 
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "pwd"}))
 	assert.Equal(t, home, strings.TrimSpace(buff.String()))
@@ -1125,12 +1123,12 @@ func TestDry(t *testing.T) {
 
 	var buff bytes.Buffer
 
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-		Dry:    true,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithDry(true),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "build"}))
 
@@ -1150,16 +1148,16 @@ func TestDryChecksum(t *testing.T) {
 	checksumFile := filepathext.SmartJoin(dir, ".task/checksum/default")
 	_ = os.Remove(checksumFile)
 
-	e := task.Executor{
-		Dir: dir,
-		TempDir: task.TempDir{
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithTempDir(task.TempDir{
 			Remote:      filepathext.SmartJoin(dir, ".task"),
 			Fingerprint: filepathext.SmartJoin(dir, ".task"),
-		},
-		Stdout: io.Discard,
-		Stderr: io.Discard,
-		Dry:    true,
-	}
+		}),
+		task.WithStdout(io.Discard),
+		task.WithStderr(io.Discard),
+		task.WithDry(true),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "default"}))
 
@@ -1258,34 +1256,38 @@ func TestIncludesRemote(t *testing.T) {
 			}{
 				{
 					name: "online, always download",
-					executor: &task.Executor{
-						Dir:      dir,
-						Stdout:   &buff,
-						Stderr:   &buff,
-						Timeout:  time.Minute,
-						Insecure: true,
-						Logger:   &logger.Logger{Stdout: &buff, Stderr: &buff, Verbose: true},
+					executor: task.NewExecutor(
+						task.WithDir(dir),
+						task.WithStdout(&buff),
+						task.WithStderr(&buff),
+						task.WithTimeout(time.Minute),
+						task.WithInsecure(true),
+						task.WithStdout(&buff),
+						task.WithStderr(&buff),
+						task.WithVerbose(true),
 
 						// Without caching
-						AssumeYes: true,
-						Download:  true,
-					},
+						task.WithAssumeYes(true),
+						task.WithDownload(true),
+					),
 				},
 				{
 					name: "offline, use cache",
-					executor: &task.Executor{
-						Dir:      dir,
-						Stdout:   &buff,
-						Stderr:   &buff,
-						Timeout:  time.Minute,
-						Insecure: true,
-						Logger:   &logger.Logger{Stdout: &buff, Stderr: &buff, Verbose: true},
+					executor: task.NewExecutor(
+						task.WithDir(dir),
+						task.WithStdout(&buff),
+						task.WithStderr(&buff),
+						task.WithTimeout(time.Minute),
+						task.WithInsecure(true),
+						task.WithStdout(&buff),
+						task.WithStderr(&buff),
+						task.WithVerbose(true),
 
 						// With caching
-						AssumeYes: false,
-						Download:  false,
-						Offline:   true,
-					},
+						task.WithAssumeYes(false),
+						task.WithDownload(false),
+						task.WithOffline(true),
+					),
 				},
 			}
 
@@ -1325,12 +1327,12 @@ func TestIncludeCycle(t *testing.T) {
 	const dir = "testdata/includes_cycle"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-		Silent: true,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSilent(true),
+	)
 
 	err := e.Setup()
 	require.Error(t, err)
@@ -1343,12 +1345,12 @@ func TestIncludesIncorrect(t *testing.T) {
 	const dir = "testdata/includes_incorrect"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-		Silent: true,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSilent(true),
+	)
 
 	err := e.Setup()
 	require.Error(t, err)
@@ -1414,17 +1416,19 @@ func TestIncludesHttp(t *testing.T) {
 					entrypoint := filepath.Join(dir, taskfile)
 
 					var buff SyncBuffer
-					e := task.Executor{
-						Entrypoint: entrypoint,
-						Dir:        dir,
-						Stdout:     &buff,
-						Stderr:     &buff,
-						Insecure:   true,
-						Download:   true,
-						AssumeYes:  true,
-						Logger:     &logger.Logger{Stdout: &buff, Stderr: &buff, Verbose: true},
-						Timeout:    time.Minute,
-					}
+					e := task.NewExecutor(
+						task.WithEntrypoint(entrypoint),
+						task.WithDir(dir),
+						task.WithStdout(&buff),
+						task.WithStderr(&buff),
+						task.WithInsecure(true),
+						task.WithDownload(true),
+						task.WithAssumeYes(true),
+						task.WithStdout(&buff),
+						task.WithStderr(&buff),
+						task.WithVerbose(true),
+						task.WithTimeout(time.Minute),
+					)
 					require.NoError(t, e.Setup())
 					defer func() { t.Log("output:", buff.buf.String()) }()
 
@@ -1516,11 +1520,11 @@ func TestIncludesOptionalImplicitFalse(t *testing.T) {
 	message := "stat %s/%s/TaskfileOptional.yml: no such file or directory"
 	expected := fmt.Sprintf(message, wd, dir)
 
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: io.Discard,
-		Stderr: io.Discard,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(io.Discard),
+		task.WithStderr(io.Discard),
+	)
 
 	err := e.Setup()
 	require.Error(t, err)
@@ -1536,11 +1540,11 @@ func TestIncludesOptionalExplicitFalse(t *testing.T) {
 	message := "stat %s/%s/TaskfileOptional.yml: no such file or directory"
 	expected := fmt.Sprintf(message, wd, dir)
 
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: io.Discard,
-		Stderr: io.Discard,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(io.Discard),
+		task.WithStderr(io.Discard),
+	)
 
 	err := e.Setup()
 	require.Error(t, err)
@@ -1573,11 +1577,11 @@ func TestIncludesRelativePath(t *testing.T) {
 	const dir = "testdata/includes_rel_path"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 
 	require.NoError(t, e.Setup())
 
@@ -1609,12 +1613,12 @@ func TestIncludesInternal(t *testing.T) {
 			t.Parallel()
 
 			var buff bytes.Buffer
-			e := task.Executor{
-				Dir:    dir,
-				Stdout: &buff,
-				Stderr: &buff,
-				Silent: true,
-			}
+			e := task.NewExecutor(
+				task.WithDir(dir),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+				task.WithSilent(true),
+			)
 			require.NoError(t, e.Setup())
 
 			err := e.Run(context.Background(), &task.Call{Task: test.task})
@@ -1652,13 +1656,13 @@ func TestIncludesFlatten(t *testing.T) {
 			t.Parallel()
 
 			var buff bytes.Buffer
-			e := task.Executor{
-				Dir:        dir,
-				Entrypoint: dir + "/" + test.taskfile,
-				Stdout:     &buff,
-				Stderr:     &buff,
-				Silent:     true,
-			}
+			e := task.NewExecutor(
+				task.WithDir(dir),
+				task.WithEntrypoint(dir+"/"+test.taskfile),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+				task.WithSilent(true),
+			)
 			err := e.Setup()
 			if test.expectedErr {
 				assert.EqualError(t, err, test.expectedOutput)
@@ -1688,12 +1692,12 @@ func TestIncludesInterpolation(t *testing.T) { // nolint:paralleltest // cannot 
 	for _, test := range tests { // nolint:paralleltest // cannot run in parallel
 		t.Run(test.name, func(t *testing.T) {
 			var buff bytes.Buffer
-			e := task.Executor{
-				Dir:    filepath.Join(dir, test.name),
-				Stdout: &buff,
-				Stderr: &buff,
-				Silent: true,
-			}
+			e := task.NewExecutor(
+				task.WithDir(filepath.Join(dir, test.name)),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+				task.WithSilent(true),
+			)
 			require.NoError(t, e.Setup())
 
 			err := e.Run(context.Background(), &task.Call{Task: test.task})
@@ -1711,12 +1715,12 @@ func TestIncludesWithExclude(t *testing.T) {
 	t.Parallel()
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    "testdata/includes_with_excludes",
-		Silent: true,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/includes_with_excludes"),
+		task.WithSilent(true),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	err := e.Run(context.Background(), &task.Call{Task: "included:bar"})
@@ -1754,12 +1758,12 @@ func TestIncludedTaskfileVarMerging(t *testing.T) {
 			t.Parallel()
 
 			var buff bytes.Buffer
-			e := task.Executor{
-				Dir:    dir,
-				Stdout: &buff,
-				Stderr: &buff,
-				Silent: true,
-			}
+			e := task.NewExecutor(
+				task.WithDir(dir),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+				task.WithSilent(true),
+			)
 			require.NoError(t, e.Setup())
 
 			err := e.Run(context.Background(), &task.Call{Task: test.task})
@@ -1789,12 +1793,12 @@ func TestInternalTask(t *testing.T) {
 			t.Parallel()
 
 			var buff bytes.Buffer
-			e := task.Executor{
-				Dir:    dir,
-				Stdout: &buff,
-				Stderr: &buff,
-				Silent: true,
-			}
+			e := task.NewExecutor(
+				task.WithDir(dir),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+				task.WithSilent(true),
+			)
 			require.NoError(t, e.Setup())
 
 			err := e.Run(context.Background(), &task.Call{Task: test.task})
@@ -1874,13 +1878,13 @@ func TestSummary(t *testing.T) {
 	const dir = "testdata/summary"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:     dir,
-		Stdout:  &buff,
-		Stderr:  &buff,
-		Summary: true,
-		Silent:  true,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSummary(true),
+		task.WithSilent(true),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "task-with-summary"}, &task.Call{Task: "other-task-with-summary"}))
 
@@ -1901,11 +1905,11 @@ func TestWhenNoDirAttributeItRunsInSameDirAsTaskfile(t *testing.T) {
 	const expected = "dir"
 	const dir = "testdata/" + expected
 	var out bytes.Buffer
-	e := &task.Executor{
-		Dir:    dir,
-		Stdout: &out,
-		Stderr: &out,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&out),
+		task.WithStderr(&out),
+	)
 
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "whereami"}))
@@ -1921,11 +1925,11 @@ func TestWhenDirAttributeAndDirExistsItRunsInThatDir(t *testing.T) {
 	const expected = "exists"
 	const dir = "testdata/dir/explicit_exists"
 	var out bytes.Buffer
-	e := &task.Executor{
-		Dir:    dir,
-		Stdout: &out,
-		Stderr: &out,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&out),
+		task.WithStderr(&out),
+	)
 
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "whereami"}))
@@ -1942,11 +1946,11 @@ func TestWhenDirAttributeItCreatesMissingAndRunsInThatDir(t *testing.T) {
 	const toBeCreated = dir + expected
 	const target = "whereami"
 	var out bytes.Buffer
-	e := &task.Executor{
-		Dir:    dir,
-		Stdout: &out,
-		Stderr: &out,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&out),
+		task.WithStderr(&out),
+	)
 
 	// Ensure that the directory to be created doesn't actually exist.
 	_ = os.RemoveAll(toBeCreated)
@@ -1971,11 +1975,11 @@ func TestDynamicVariablesRunOnTheNewCreatedDir(t *testing.T) {
 	const toBeCreated = dir + expected
 	const target = "default"
 	var out bytes.Buffer
-	e := &task.Executor{
-		Dir:    dir,
-		Stdout: &out,
-		Stderr: &out,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&out),
+		task.WithStderr(&out),
+	)
 
 	// Ensure that the directory to be created doesn't actually exist.
 	_ = os.RemoveAll(toBeCreated)
@@ -2015,12 +2019,12 @@ func TestDynamicVariablesShouldRunOnTheTaskDir(t *testing.T) {
 func TestDisplaysErrorOnVersion1Schema(t *testing.T) {
 	t.Parallel()
 
-	e := task.Executor{
-		Dir:                "testdata/version/v1",
-		Stdout:             io.Discard,
-		Stderr:             io.Discard,
-		EnableVersionCheck: true,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/version/v1"),
+		task.WithStdout(io.Discard),
+		task.WithStderr(io.Discard),
+		task.WithVersionCheck(true),
+	)
 	err := e.Setup()
 	require.Error(t, err)
 	assert.Regexp(t, regexp.MustCompile(`task: Invalid schema version in Taskfile \".*testdata\/version\/v1\/Taskfile\.yml\":\nSchema version \(1\.0\.0\) no longer supported\. Please use v3 or above`), err.Error())
@@ -2030,12 +2034,12 @@ func TestDisplaysErrorOnVersion2Schema(t *testing.T) {
 	t.Parallel()
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:                "testdata/version/v2",
-		Stdout:             io.Discard,
-		Stderr:             &buff,
-		EnableVersionCheck: true,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/version/v2"),
+		task.WithStdout(io.Discard),
+		task.WithStderr(&buff),
+		task.WithVersionCheck(true),
+	)
 	err := e.Setup()
 	require.Error(t, err)
 	assert.Regexp(t, regexp.MustCompile(`task: Invalid schema version in Taskfile \".*testdata\/version\/v2\/Taskfile\.yml\":\nSchema version \(2\.0\.0\) no longer supported\. Please use v3 or above`), err.Error())
@@ -2047,12 +2051,12 @@ func TestShortTaskNotation(t *testing.T) {
 	const dir = "testdata/short_task_notation"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-		Silent: true,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSilent(true),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "default"}))
 	assert.Equal(t, "string-slice-1\nstring-slice-2\nstring\n", buff.String())
@@ -2079,12 +2083,12 @@ func TestDotenvShouldErrorWhenIncludingDependantDotenvs(t *testing.T) {
 	t.Parallel()
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:     "testdata/dotenv/error_included_envs",
-		Summary: true,
-		Stdout:  &buff,
-		Stderr:  &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/dotenv/error_included_envs"),
+		task.WithSummary(true),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 
 	err := e.Setup()
 	require.Error(t, err)
@@ -2159,9 +2163,9 @@ func TestDotenvHasEnvVarInPath(t *testing.T) { // nolint:paralleltest // cannot 
 func TestTaskDotenvParseErrorMessage(t *testing.T) {
 	t.Parallel()
 
-	e := task.Executor{
-		Dir: "testdata/dotenv/parse_error",
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/dotenv/parse_error"),
+	)
 
 	path, _ := filepath.Abs(filepath.Join(e.Dir, ".env-with-error"))
 	expected := fmt.Sprintf("error reading env file %s:", path)
@@ -2244,12 +2248,12 @@ func TestExitImmediately(t *testing.T) {
 	const dir = "testdata/exit_immediately"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-		Silent: true,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSilent(true),
+	)
 	require.NoError(t, e.Setup())
 
 	require.Error(t, e.Run(context.Background(), &task.Call{Task: "default"}))
@@ -2278,12 +2282,12 @@ func TestRunOnceSharedDeps(t *testing.T) {
 	const dir = "testdata/run_once_shared_deps"
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:      dir,
-		Stdout:   &buff,
-		Stderr:   &buff,
-		ForceAll: true,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithForceAll(true),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "build"}))
 
@@ -2299,11 +2303,11 @@ func TestDeferredCmds(t *testing.T) {
 
 	const dir = "testdata/deferred"
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	expectedOutputOrder := strings.TrimSpace(`
@@ -2326,11 +2330,11 @@ func TestExitCodeZero(t *testing.T) {
 
 	const dir = "testdata/exit_code"
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "exit-zero"}))
@@ -2342,11 +2346,11 @@ func TestExitCodeOne(t *testing.T) {
 
 	const dir = "testdata/exit_code"
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	require.Error(t, e.Run(context.Background(), &task.Call{Task: "exit-one"}))
@@ -2371,12 +2375,12 @@ func TestIgnoreNilElements(t *testing.T) {
 			t.Parallel()
 
 			var buff bytes.Buffer
-			e := task.Executor{
-				Dir:    test.dir,
-				Stdout: &buff,
-				Stderr: &buff,
-				Silent: true,
-			}
+			e := task.NewExecutor(
+				task.WithDir(test.dir),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+				task.WithSilent(true),
+			)
 			require.NoError(t, e.Setup())
 			require.NoError(t, e.Run(context.Background(), &task.Call{Task: "default"}))
 			assert.Equal(t, "string-slice-1\n", buff.String())
@@ -2389,11 +2393,11 @@ func TestOutputGroup(t *testing.T) {
 
 	const dir = "testdata/output_group"
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	expectedOutputOrder := strings.TrimSpace(`
@@ -2416,11 +2420,11 @@ func TestOutputGroupErrorOnlySwallowsOutputOnSuccess(t *testing.T) {
 
 	const dir = "testdata/output_group_error_only"
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "passing"}))
@@ -2433,11 +2437,11 @@ func TestOutputGroupErrorOnlyShowsOutputOnFailure(t *testing.T) {
 
 	const dir = "testdata/output_group_error_only"
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	require.Error(t, e.Run(context.Background(), &task.Call{Task: "failing"}))
@@ -2451,11 +2455,11 @@ func TestIncludedVars(t *testing.T) {
 
 	const dir = "testdata/include_with_vars"
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	expectedOutputOrder := strings.TrimSpace(`
@@ -2482,11 +2486,11 @@ func TestIncludedVarsMultiLevel(t *testing.T) {
 
 	const dir = "testdata/include_with_vars_multi_level"
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	expectedOutputOrder := strings.TrimSpace(`
@@ -2527,12 +2531,12 @@ func TestErrorCode(t *testing.T) {
 			t.Parallel()
 
 			var buff bytes.Buffer
-			e := &task.Executor{
-				Dir:    dir,
-				Stdout: &buff,
-				Stderr: &buff,
-				Silent: true,
-			}
+			e := task.NewExecutor(
+				task.WithDir(dir),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+				task.WithSilent(true),
+			)
 			require.NoError(t, e.Setup())
 
 			err := e.Run(context.Background(), &task.Call{Task: test.task})
@@ -2547,12 +2551,12 @@ func TestErrorCode(t *testing.T) {
 func TestEvaluateSymlinksInPaths(t *testing.T) { // nolint:paralleltest // cannot run in parallel
 	const dir = "testdata/evaluate_symlinks_in_paths"
 	var buff bytes.Buffer
-	e := &task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-		Silent: false,
-	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSilent(false),
+	)
 	tests := []struct {
 		name     string
 		task     string
@@ -2624,11 +2628,11 @@ func TestTaskfileWalk(t *testing.T) {
 			t.Parallel()
 
 			var buff bytes.Buffer
-			e := task.Executor{
-				Dir:    test.dir,
-				Stdout: &buff,
-				Stderr: &buff,
-			}
+			e := task.NewExecutor(
+				task.WithDir(test.dir),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+			)
 			require.NoError(t, e.Setup())
 			require.NoError(t, e.Run(context.Background(), &task.Call{Task: "default"}))
 			assert.Equal(t, test.expected, buff.String())
@@ -2640,11 +2644,11 @@ func TestUserWorkingDirectory(t *testing.T) {
 	t.Parallel()
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    "testdata/user_working_dir",
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/user_working_dir"),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	wd, err := os.Getwd()
 	require.NoError(t, err)
 	require.NoError(t, e.Setup())
@@ -2661,12 +2665,12 @@ func TestUserWorkingDirectoryWithIncluded(t *testing.T) {
 	wd = filepathext.SmartJoin(wd, "testdata/user_working_dir_with_includes/somedir")
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		UserWorkingDir: wd,
-		Dir:            "testdata/user_working_dir_with_includes",
-		Stdout:         &buff,
-		Stderr:         &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/user_working_dir_with_includes"),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
+	e.UserWorkingDir = wd
 
 	require.NoError(t, err)
 	require.NoError(t, e.Setup())
@@ -2678,11 +2682,11 @@ func TestPlatforms(t *testing.T) {
 	t.Parallel()
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    "testdata/platforms",
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/platforms"),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "build-" + runtime.GOOS}))
 	assert.Equal(t, fmt.Sprintf("task: [build-%s] echo 'Running task on %s'\nRunning task on %s\n", runtime.GOOS, runtime.GOOS, runtime.GOOS), buff.String())
@@ -2692,11 +2696,11 @@ func TestPOSIXShellOptsGlobalLevel(t *testing.T) {
 	t.Parallel()
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    "testdata/shopts/global_level",
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/shopts/global_level"),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	err := e.Run(context.Background(), &task.Call{Task: "pipefail"})
@@ -2708,11 +2712,11 @@ func TestPOSIXShellOptsTaskLevel(t *testing.T) {
 	t.Parallel()
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    "testdata/shopts/task_level",
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/shopts/task_level"),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	err := e.Run(context.Background(), &task.Call{Task: "pipefail"})
@@ -2724,11 +2728,11 @@ func TestPOSIXShellOptsCommandLevel(t *testing.T) {
 	t.Parallel()
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    "testdata/shopts/command_level",
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/shopts/command_level"),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	err := e.Run(context.Background(), &task.Call{Task: "pipefail"})
@@ -2740,11 +2744,11 @@ func TestBashShellOptsGlobalLevel(t *testing.T) {
 	t.Parallel()
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    "testdata/shopts/global_level",
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/shopts/global_level"),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	err := e.Run(context.Background(), &task.Call{Task: "globstar"})
@@ -2756,11 +2760,11 @@ func TestBashShellOptsTaskLevel(t *testing.T) {
 	t.Parallel()
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    "testdata/shopts/task_level",
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/shopts/task_level"),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	err := e.Run(context.Background(), &task.Call{Task: "globstar"})
@@ -2772,11 +2776,11 @@ func TestBashShellOptsCommandLevel(t *testing.T) {
 	t.Parallel()
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    "testdata/shopts/command_level",
-		Stdout: &buff,
-		Stderr: &buff,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/shopts/command_level"),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
 	require.NoError(t, e.Setup())
 
 	err := e.Run(context.Background(), &task.Call{Task: "globstar"})
@@ -2788,12 +2792,12 @@ func TestSplitArgs(t *testing.T) {
 	t.Parallel()
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    "testdata/split_args",
-		Stdout: &buff,
-		Stderr: &buff,
-		Silent: true,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/split_args"),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSilent(true),
+	)
 	require.NoError(t, e.Setup())
 
 	vars := ast.NewVars()
@@ -2825,12 +2829,12 @@ func TestSilence(t *testing.T) {
 	t.Parallel()
 
 	var buff bytes.Buffer
-	e := task.Executor{
-		Dir:    "testdata/silent",
-		Stdout: &buff,
-		Stderr: &buff,
-		Silent: false,
-	}
+	e := task.NewExecutor(
+		task.WithDir("testdata/silent"),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSilent(false),
+	)
 	require.NoError(t, e.Setup())
 
 	// First verify that the silent flag is in place.
@@ -2956,13 +2960,13 @@ func TestForce(t *testing.T) {
 			t.Parallel()
 
 			var buff bytes.Buffer
-			e := task.Executor{
-				Dir:      "testdata/force",
-				Stdout:   &buff,
-				Stderr:   &buff,
-				Force:    tt.force,
-				ForceAll: tt.forceAll,
-			}
+			e := task.NewExecutor(
+				task.WithDir("testdata/force"),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+				task.WithForce(tt.force),
+				task.WithForceAll(tt.forceAll),
+			)
 			require.NoError(t, e.Setup())
 			require.NoError(t, e.Run(context.Background(), &task.Call{Task: "task-with-dep"}))
 		})
@@ -3028,13 +3032,13 @@ func TestForCmds(t *testing.T) {
 			t.Parallel()
 
 			buf := &bytes.Buffer{}
-			e := &task.Executor{
-				Dir:    "testdata/for/cmds",
-				Stdout: buf,
-				Stderr: buf,
-				Silent: true,
-				Force:  true,
-			}
+			e := task.NewExecutor(
+				task.WithDir("testdata/for/cmds"),
+				task.WithStdout(buf),
+				task.WithStderr(buf),
+				task.WithSilent(true),
+				task.WithForce(true),
+			)
 			require.NoError(t, e.Setup())
 			err := e.Run(context.Background(), &task.Call{Task: test.name})
 			if test.wantErr {
@@ -3121,15 +3125,15 @@ func TestForDeps(t *testing.T) {
 
 			// We need to use a sync buffer here as deps are run concurrently
 			buf := &SyncBuffer{}
-			e := &task.Executor{
-				Dir:    "testdata/for/deps",
-				Stdout: buf,
-				Stderr: buf,
-				Silent: true,
-				Force:  true,
+			e := task.NewExecutor(
+				task.WithDir("testdata/for/deps"),
+				task.WithStdout(buf),
+				task.WithStderr(buf),
+				task.WithSilent(true),
+				task.WithForce(true),
 				// Force output of each dep to be grouped together to prevent interleaving
-				OutputStyle: ast.Output{Name: "group"},
-			}
+				task.WithOutputStyle(ast.Output{Name: "group"}),
+			)
 			require.NoError(t, e.Setup())
 			err := e.Run(context.Background(), &task.Call{Task: test.name})
 			if test.wantErr {
@@ -3190,13 +3194,13 @@ func TestWildcard(t *testing.T) {
 			t.Parallel()
 
 			var buff bytes.Buffer
-			e := task.Executor{
-				Dir:    "testdata/wildcards",
-				Stdout: &buff,
-				Stderr: &buff,
-				Silent: true,
-				Force:  true,
-			}
+			e := task.NewExecutor(
+				task.WithDir("testdata/wildcards"),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+				task.WithSilent(true),
+				task.WithForce(true),
+			)
 			require.NoError(t, e.Setup())
 			if test.wantErr {
 				require.Error(t, e.Run(context.Background(), &task.Call{Task: test.call}))
@@ -3243,13 +3247,13 @@ func TestReference(t *testing.T) {
 			t.Parallel()
 
 			var buff bytes.Buffer
-			e := task.Executor{
-				Dir:    "testdata/var_references",
-				Stdout: &buff,
-				Stderr: &buff,
-				Silent: true,
-				Force:  true,
-			}
+			e := task.NewExecutor(
+				task.WithDir("testdata/var_references"),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+				task.WithSilent(true),
+				task.WithForce(true),
+			)
 			require.NoError(t, e.Setup())
 			require.NoError(t, e.Run(context.Background(), &task.Call{Task: test.call}))
 			assert.Equal(t, test.expectedOutput, buff.String())
@@ -3346,13 +3350,13 @@ func TestVarInheritance(t *testing.T) {
 			var buff bytes.Buffer
 			t.Setenv("VAR", "shell")
 			t.Setenv("ENV", "shell")
-			e := task.Executor{
-				Dir:    fmt.Sprintf("testdata/var_inheritance/v3/%s", test.name),
-				Stdout: &buff,
-				Stderr: &buff,
-				Silent: true,
-				Force:  true,
-			}
+			e := task.NewExecutor(
+				task.WithDir(fmt.Sprintf("testdata/var_inheritance/v3/%s", test.name)),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+				task.WithSilent(true),
+				task.WithForce(true),
+			)
 			call := cmp.Or(test.call, "default")
 			require.NoError(t, e.Setup())
 			require.NoError(t, e.Run(context.Background(), &task.Call{Task: call}))

--- a/task_test.go
+++ b/task_test.go
@@ -71,14 +71,14 @@ func (fct fileContentTest) Run(t *testing.T) {
 	}
 
 	e := task.NewExecutor(
-		task.WithDir(fct.Dir),
-		task.WithTempDir(task.TempDir{
+		task.ExecutorWithDir(fct.Dir),
+		task.ExecutorWithTempDir(task.TempDir{
 			Remote:      filepathext.SmartJoin(fct.Dir, ".task"),
 			Fingerprint: filepathext.SmartJoin(fct.Dir, ".task"),
 		}),
-		task.WithEntrypoint(fct.Entrypoint),
-		task.WithStdout(io.Discard),
-		task.WithStderr(io.Discard),
+		task.ExecutorWithEntrypoint(fct.Entrypoint),
+		task.ExecutorWithStdout(io.Discard),
+		task.ExecutorWithStderr(io.Discard),
 	)
 
 	require.NoError(t, e.Setup(), "e.Setup()")
@@ -101,9 +101,9 @@ func TestEmptyTask(t *testing.T) {
 	t.Parallel()
 
 	e := task.NewExecutor(
-		task.WithDir("testdata/empty_task"),
-		task.WithStdout(io.Discard),
-		task.WithStderr(io.Discard),
+		task.ExecutorWithDir("testdata/empty_task"),
+		task.ExecutorWithStdout(io.Discard),
+		task.ExecutorWithStderr(io.Discard),
 	)
 
 	require.NoError(t, e.Setup(), "e.Setup()")
@@ -114,9 +114,9 @@ func TestEmptyTaskfile(t *testing.T) {
 	t.Parallel()
 
 	e := task.NewExecutor(
-		task.WithDir("testdata/empty_taskfile"),
-		task.WithStdout(io.Discard),
-		task.WithStderr(io.Discard),
+		task.ExecutorWithDir("testdata/empty_taskfile"),
+		task.ExecutorWithStdout(io.Discard),
+		task.ExecutorWithStderr(io.Discard),
 	)
 
 	require.Error(t, e.Setup(), "e.Setup()")
@@ -176,9 +176,9 @@ func TestRequires(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 
 	require.NoError(t, e.Setup())
@@ -259,11 +259,11 @@ func TestSpecialVars(t *testing.T) {
 
 				var buff bytes.Buffer
 				e := task.NewExecutor(
-					task.WithDir(dir),
-					task.WithStdout(&buff),
-					task.WithStderr(&buff),
-					task.WithSilent(true),
-					task.WithVersionCheck(true),
+					task.ExecutorWithDir(dir),
+					task.ExecutorWithStdout(&buff),
+					task.ExecutorWithStderr(&buff),
+					task.ExecutorWithSilent(true),
+					task.ExecutorWithVersionCheck(true),
 				)
 				require.NoError(t, e.Setup())
 				require.NoError(t, e.Run(context.Background(), &task.Call{Task: test.target}))
@@ -281,10 +281,10 @@ func TestConcurrency(t *testing.T) {
 		target = "default"
 	)
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(io.Discard),
-		task.WithStderr(io.Discard),
-		task.WithConcurrency(1),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(io.Discard),
+		task.ExecutorWithStderr(io.Discard),
+		task.ExecutorWithConcurrency(1),
 	)
 	require.NoError(t, e.Setup(), "e.Setup()")
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: target}), "e.Run(target)")
@@ -341,9 +341,9 @@ func TestDeps(t *testing.T) {
 	}
 
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(io.Discard),
-		task.WithStderr(io.Discard),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(io.Discard),
+		task.ExecutorWithStderr(io.Discard),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "default"}))
@@ -377,11 +377,11 @@ func TestStatus(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
-		task.WithSilent(true),
-		task.WithTempDir(task.TempDir{
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithSilent(true),
+		task.ExecutorWithTempDir(task.TempDir{
 			Remote:      filepathext.SmartJoin(dir, ".task"),
 			Fingerprint: filepathext.SmartJoin(dir, ".task"),
 		}),
@@ -464,9 +464,9 @@ func TestPrecondition(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 
 	// A precondition that has been met
@@ -524,9 +524,9 @@ func TestGenerates(t *testing.T) {
 
 	buff := bytes.NewBuffer(nil)
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(buff),
-		task.WithStderr(buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(buff),
+		task.ExecutorWithStderr(buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -585,10 +585,10 @@ func TestStatusChecksum(t *testing.T) { // nolint:paralleltest // cannot run in 
 				Fingerprint: filepathext.SmartJoin(dir, ".task"),
 			}
 			e := task.NewExecutor(
-				task.WithDir(dir),
-				task.WithStdout(&buff),
-				task.WithStderr(&buff),
-				task.WithTempDir(tempDir),
+				task.ExecutorWithDir(dir),
+				task.ExecutorWithStdout(&buff),
+				task.ExecutorWithStderr(&buff),
+				task.ExecutorWithTempDir(tempDir),
 			)
 			require.NoError(t, e.Setup())
 
@@ -625,9 +625,9 @@ func TestAlias(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "f"}))
@@ -641,9 +641,9 @@ func TestDuplicateAlias(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 	require.Error(t, e.Run(context.Background(), &task.Call{Task: "x"}))
@@ -660,10 +660,10 @@ func TestAliasSummary(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
-		task.WithSummary(true),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithSummary(true),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "f"}))
@@ -677,9 +677,9 @@ func TestLabelUpToDate(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "foo"}))
@@ -693,10 +693,10 @@ func TestLabelSummary(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
-		task.WithSummary(true),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithSummary(true),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "foo"}))
@@ -709,7 +709,7 @@ func TestLabelInStatus(t *testing.T) {
 	const dir = "testdata/label_status"
 
 	e := task.NewExecutor(
-		task.WithDir(dir),
+		task.ExecutorWithDir(dir),
 	)
 	require.NoError(t, e.Setup())
 	err := e.Status(context.Background(), &task.Call{Task: "foo"})
@@ -723,9 +723,9 @@ func TestLabelWithVariableExpansion(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "foo"}))
@@ -739,9 +739,9 @@ func TestLabelInSummary(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "foo"}))
@@ -776,10 +776,10 @@ func TestPromptInSummary(t *testing.T) {
 			inBuff.Write([]byte(test.input))
 
 			e := task.NewExecutor(
-				task.WithDir(dir),
-				task.WithStdin(&inBuff),
-				task.WithStdout(&outBuff),
-				task.WithStderr(&errBuff),
+				task.ExecutorWithDir(dir),
+				task.ExecutorWithStdin(&inBuff),
+				task.ExecutorWithStdout(&outBuff),
+				task.ExecutorWithStderr(&errBuff),
 			)
 			e.AssumeTerm = true
 			require.NoError(t, e.Setup())
@@ -806,10 +806,10 @@ func TestPromptWithIndirectTask(t *testing.T) {
 	inBuff.Write([]byte("y\n"))
 
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdin(&inBuff),
-		task.WithStdout(&outBuff),
-		task.WithStderr(&errBuff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdin(&inBuff),
+		task.ExecutorWithStdout(&outBuff),
+		task.ExecutorWithStderr(&errBuff),
 	)
 	e.AssumeTerm = true
 	require.NoError(t, e.Setup())
@@ -843,10 +843,10 @@ func TestPromptAssumeYes(t *testing.T) {
 			inBuff.Write([]byte("\n"))
 
 			e := task.NewExecutor(
-				task.WithDir(dir),
-				task.WithStdin(&inBuff),
-				task.WithStdout(&outBuff),
-				task.WithStderr(&errBuff),
+				task.ExecutorWithDir(dir),
+				task.ExecutorWithStdin(&inBuff),
+				task.ExecutorWithStdout(&outBuff),
+				task.ExecutorWithStderr(&errBuff),
 			)
 			e.AssumeTerm = true
 			require.NoError(t, e.Setup())
@@ -868,9 +868,9 @@ func TestNoLabelInList(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 	if _, err := e.ListTasks(task.ListOptions{ListOnlyTasksWithDescriptions: true}); err != nil {
@@ -887,9 +887,9 @@ func TestListAllShowsNoDesc(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -914,9 +914,9 @@ func TestListCanListDescOnly(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 	if _, err := e.ListTasks(task.ListOptions{ListOnlyTasksWithDescriptions: true}); err != nil {
@@ -940,9 +940,9 @@ func TestListDescInterpolation(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 	if _, err := e.ListTasks(task.ListOptions{ListOnlyTasksWithDescriptions: true}); err != nil {
@@ -963,15 +963,15 @@ func TestStatusVariables(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithTempDir(task.TempDir{
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithTempDir(task.TempDir{
 			Remote:      filepathext.SmartJoin(dir, ".task"),
 			Fingerprint: filepathext.SmartJoin(dir, ".task"),
 		}),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
-		task.WithSilent(false),
-		task.WithVerbose(true),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithSilent(false),
+		task.ExecutorWithVerbose(true),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "build-checksum"}))
@@ -999,15 +999,15 @@ func TestCmdsVariables(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithTempDir(task.TempDir{
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithTempDir(task.TempDir{
 			Remote:      filepathext.SmartJoin(dir, ".task"),
 			Fingerprint: filepathext.SmartJoin(dir, ".task"),
 		}),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
-		task.WithSilent(false),
-		task.WithVerbose(true),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithSilent(false),
+		task.ExecutorWithVerbose(true),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "build-checksum"}))
@@ -1031,9 +1031,9 @@ func TestCyclicDep(t *testing.T) {
 	const dir = "testdata/cyclic"
 
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(io.Discard),
-		task.WithStderr(io.Discard),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(io.Discard),
+		task.ExecutorWithStderr(io.Discard),
 	)
 	require.NoError(t, e.Setup())
 	assert.IsType(t, &errors.TaskCalledTooManyTimesError{}, e.Run(context.Background(), &task.Call{Task: "task-1"}))
@@ -1057,10 +1057,10 @@ func TestTaskVersion(t *testing.T) {
 			t.Parallel()
 
 			e := task.NewExecutor(
-				task.WithDir(test.Dir),
-				task.WithStdout(io.Discard),
-				task.WithStderr(io.Discard),
-				task.WithVersionCheck(true),
+				task.ExecutorWithDir(test.Dir),
+				task.ExecutorWithStdout(io.Discard),
+				task.ExecutorWithStderr(io.Discard),
+				task.ExecutorWithVersionCheck(true),
 			)
 			err := e.Setup()
 			if test.wantErr {
@@ -1080,9 +1080,9 @@ func TestTaskIgnoreErrors(t *testing.T) {
 	const dir = "testdata/ignore_errors"
 
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(io.Discard),
-		task.WithStderr(io.Discard),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(io.Discard),
+		task.ExecutorWithStderr(io.Discard),
 	)
 	require.NoError(t, e.Setup())
 
@@ -1104,9 +1104,9 @@ func TestExpand(t *testing.T) {
 	var buff bytes.Buffer
 
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "pwd"}))
@@ -1124,10 +1124,10 @@ func TestDry(t *testing.T) {
 	var buff bytes.Buffer
 
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
-		task.WithDry(true),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithDry(true),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "build"}))
@@ -1149,14 +1149,14 @@ func TestDryChecksum(t *testing.T) {
 	_ = os.Remove(checksumFile)
 
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithTempDir(task.TempDir{
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithTempDir(task.TempDir{
 			Remote:      filepathext.SmartJoin(dir, ".task"),
 			Fingerprint: filepathext.SmartJoin(dir, ".task"),
 		}),
-		task.WithStdout(io.Discard),
-		task.WithStderr(io.Discard),
-		task.WithDry(true),
+		task.ExecutorWithStdout(io.Discard),
+		task.ExecutorWithStderr(io.Discard),
+		task.ExecutorWithDry(true),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "default"}))
@@ -1257,36 +1257,36 @@ func TestIncludesRemote(t *testing.T) {
 				{
 					name: "online, always download",
 					executor: task.NewExecutor(
-						task.WithDir(dir),
-						task.WithStdout(&buff),
-						task.WithStderr(&buff),
-						task.WithTimeout(time.Minute),
-						task.WithInsecure(true),
-						task.WithStdout(&buff),
-						task.WithStderr(&buff),
-						task.WithVerbose(true),
+						task.ExecutorWithDir(dir),
+						task.ExecutorWithStdout(&buff),
+						task.ExecutorWithStderr(&buff),
+						task.ExecutorWithTimeout(time.Minute),
+						task.ExecutorWithInsecure(true),
+						task.ExecutorWithStdout(&buff),
+						task.ExecutorWithStderr(&buff),
+						task.ExecutorWithVerbose(true),
 
 						// Without caching
-						task.WithAssumeYes(true),
-						task.WithDownload(true),
+						task.ExecutorWithAssumeYes(true),
+						task.ExecutorWithDownload(true),
 					),
 				},
 				{
 					name: "offline, use cache",
 					executor: task.NewExecutor(
-						task.WithDir(dir),
-						task.WithStdout(&buff),
-						task.WithStderr(&buff),
-						task.WithTimeout(time.Minute),
-						task.WithInsecure(true),
-						task.WithStdout(&buff),
-						task.WithStderr(&buff),
-						task.WithVerbose(true),
+						task.ExecutorWithDir(dir),
+						task.ExecutorWithStdout(&buff),
+						task.ExecutorWithStderr(&buff),
+						task.ExecutorWithTimeout(time.Minute),
+						task.ExecutorWithInsecure(true),
+						task.ExecutorWithStdout(&buff),
+						task.ExecutorWithStderr(&buff),
+						task.ExecutorWithVerbose(true),
 
 						// With caching
-						task.WithAssumeYes(false),
-						task.WithDownload(false),
-						task.WithOffline(true),
+						task.ExecutorWithAssumeYes(false),
+						task.ExecutorWithDownload(false),
+						task.ExecutorWithOffline(true),
 					),
 				},
 			}
@@ -1328,10 +1328,10 @@ func TestIncludeCycle(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
-		task.WithSilent(true),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithSilent(true),
 	)
 
 	err := e.Setup()
@@ -1346,10 +1346,10 @@ func TestIncludesIncorrect(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
-		task.WithSilent(true),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithSilent(true),
 	)
 
 	err := e.Setup()
@@ -1417,17 +1417,17 @@ func TestIncludesHttp(t *testing.T) {
 
 					var buff SyncBuffer
 					e := task.NewExecutor(
-						task.WithEntrypoint(entrypoint),
-						task.WithDir(dir),
-						task.WithStdout(&buff),
-						task.WithStderr(&buff),
-						task.WithInsecure(true),
-						task.WithDownload(true),
-						task.WithAssumeYes(true),
-						task.WithStdout(&buff),
-						task.WithStderr(&buff),
-						task.WithVerbose(true),
-						task.WithTimeout(time.Minute),
+						task.ExecutorWithEntrypoint(entrypoint),
+						task.ExecutorWithDir(dir),
+						task.ExecutorWithStdout(&buff),
+						task.ExecutorWithStderr(&buff),
+						task.ExecutorWithInsecure(true),
+						task.ExecutorWithDownload(true),
+						task.ExecutorWithAssumeYes(true),
+						task.ExecutorWithStdout(&buff),
+						task.ExecutorWithStderr(&buff),
+						task.ExecutorWithVerbose(true),
+						task.ExecutorWithTimeout(time.Minute),
 					)
 					require.NoError(t, e.Setup())
 					defer func() { t.Log("output:", buff.buf.String()) }()
@@ -1521,9 +1521,9 @@ func TestIncludesOptionalImplicitFalse(t *testing.T) {
 	expected := fmt.Sprintf(message, wd, dir)
 
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(io.Discard),
-		task.WithStderr(io.Discard),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(io.Discard),
+		task.ExecutorWithStderr(io.Discard),
 	)
 
 	err := e.Setup()
@@ -1541,9 +1541,9 @@ func TestIncludesOptionalExplicitFalse(t *testing.T) {
 	expected := fmt.Sprintf(message, wd, dir)
 
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(io.Discard),
-		task.WithStderr(io.Discard),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(io.Discard),
+		task.ExecutorWithStderr(io.Discard),
 	)
 
 	err := e.Setup()
@@ -1578,9 +1578,9 @@ func TestIncludesRelativePath(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 
 	require.NoError(t, e.Setup())
@@ -1614,10 +1614,10 @@ func TestIncludesInternal(t *testing.T) {
 
 			var buff bytes.Buffer
 			e := task.NewExecutor(
-				task.WithDir(dir),
-				task.WithStdout(&buff),
-				task.WithStderr(&buff),
-				task.WithSilent(true),
+				task.ExecutorWithDir(dir),
+				task.ExecutorWithStdout(&buff),
+				task.ExecutorWithStderr(&buff),
+				task.ExecutorWithSilent(true),
 			)
 			require.NoError(t, e.Setup())
 
@@ -1657,11 +1657,11 @@ func TestIncludesFlatten(t *testing.T) {
 
 			var buff bytes.Buffer
 			e := task.NewExecutor(
-				task.WithDir(dir),
-				task.WithEntrypoint(dir+"/"+test.taskfile),
-				task.WithStdout(&buff),
-				task.WithStderr(&buff),
-				task.WithSilent(true),
+				task.ExecutorWithDir(dir),
+				task.ExecutorWithEntrypoint(dir+"/"+test.taskfile),
+				task.ExecutorWithStdout(&buff),
+				task.ExecutorWithStderr(&buff),
+				task.ExecutorWithSilent(true),
 			)
 			err := e.Setup()
 			if test.expectedErr {
@@ -1693,10 +1693,10 @@ func TestIncludesInterpolation(t *testing.T) { // nolint:paralleltest // cannot 
 		t.Run(test.name, func(t *testing.T) {
 			var buff bytes.Buffer
 			e := task.NewExecutor(
-				task.WithDir(filepath.Join(dir, test.name)),
-				task.WithStdout(&buff),
-				task.WithStderr(&buff),
-				task.WithSilent(true),
+				task.ExecutorWithDir(filepath.Join(dir, test.name)),
+				task.ExecutorWithStdout(&buff),
+				task.ExecutorWithStderr(&buff),
+				task.ExecutorWithSilent(true),
 			)
 			require.NoError(t, e.Setup())
 
@@ -1716,10 +1716,10 @@ func TestIncludesWithExclude(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir("testdata/includes_with_excludes"),
-		task.WithSilent(true),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir("testdata/includes_with_excludes"),
+		task.ExecutorWithSilent(true),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -1759,10 +1759,10 @@ func TestIncludedTaskfileVarMerging(t *testing.T) {
 
 			var buff bytes.Buffer
 			e := task.NewExecutor(
-				task.WithDir(dir),
-				task.WithStdout(&buff),
-				task.WithStderr(&buff),
-				task.WithSilent(true),
+				task.ExecutorWithDir(dir),
+				task.ExecutorWithStdout(&buff),
+				task.ExecutorWithStderr(&buff),
+				task.ExecutorWithSilent(true),
 			)
 			require.NoError(t, e.Setup())
 
@@ -1794,10 +1794,10 @@ func TestInternalTask(t *testing.T) {
 
 			var buff bytes.Buffer
 			e := task.NewExecutor(
-				task.WithDir(dir),
-				task.WithStdout(&buff),
-				task.WithStderr(&buff),
-				task.WithSilent(true),
+				task.ExecutorWithDir(dir),
+				task.ExecutorWithStdout(&buff),
+				task.ExecutorWithStderr(&buff),
+				task.ExecutorWithSilent(true),
 			)
 			require.NoError(t, e.Setup())
 
@@ -1879,11 +1879,11 @@ func TestSummary(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
-		task.WithSummary(true),
-		task.WithSilent(true),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithSummary(true),
+		task.ExecutorWithSilent(true),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "task-with-summary"}, &task.Call{Task: "other-task-with-summary"}))
@@ -1906,9 +1906,9 @@ func TestWhenNoDirAttributeItRunsInSameDirAsTaskfile(t *testing.T) {
 	const dir = "testdata/" + expected
 	var out bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&out),
-		task.WithStderr(&out),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&out),
+		task.ExecutorWithStderr(&out),
 	)
 
 	require.NoError(t, e.Setup())
@@ -1926,9 +1926,9 @@ func TestWhenDirAttributeAndDirExistsItRunsInThatDir(t *testing.T) {
 	const dir = "testdata/dir/explicit_exists"
 	var out bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&out),
-		task.WithStderr(&out),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&out),
+		task.ExecutorWithStderr(&out),
 	)
 
 	require.NoError(t, e.Setup())
@@ -1947,9 +1947,9 @@ func TestWhenDirAttributeItCreatesMissingAndRunsInThatDir(t *testing.T) {
 	const target = "whereami"
 	var out bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&out),
-		task.WithStderr(&out),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&out),
+		task.ExecutorWithStderr(&out),
 	)
 
 	// Ensure that the directory to be created doesn't actually exist.
@@ -1976,9 +1976,9 @@ func TestDynamicVariablesRunOnTheNewCreatedDir(t *testing.T) {
 	const target = "default"
 	var out bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&out),
-		task.WithStderr(&out),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&out),
+		task.ExecutorWithStderr(&out),
 	)
 
 	// Ensure that the directory to be created doesn't actually exist.
@@ -2020,10 +2020,10 @@ func TestDisplaysErrorOnVersion1Schema(t *testing.T) {
 	t.Parallel()
 
 	e := task.NewExecutor(
-		task.WithDir("testdata/version/v1"),
-		task.WithStdout(io.Discard),
-		task.WithStderr(io.Discard),
-		task.WithVersionCheck(true),
+		task.ExecutorWithDir("testdata/version/v1"),
+		task.ExecutorWithStdout(io.Discard),
+		task.ExecutorWithStderr(io.Discard),
+		task.ExecutorWithVersionCheck(true),
 	)
 	err := e.Setup()
 	require.Error(t, err)
@@ -2035,10 +2035,10 @@ func TestDisplaysErrorOnVersion2Schema(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir("testdata/version/v2"),
-		task.WithStdout(io.Discard),
-		task.WithStderr(&buff),
-		task.WithVersionCheck(true),
+		task.ExecutorWithDir("testdata/version/v2"),
+		task.ExecutorWithStdout(io.Discard),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithVersionCheck(true),
 	)
 	err := e.Setup()
 	require.Error(t, err)
@@ -2052,10 +2052,10 @@ func TestShortTaskNotation(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
-		task.WithSilent(true),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithSilent(true),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "default"}))
@@ -2084,10 +2084,10 @@ func TestDotenvShouldErrorWhenIncludingDependantDotenvs(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir("testdata/dotenv/error_included_envs"),
-		task.WithSummary(true),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir("testdata/dotenv/error_included_envs"),
+		task.ExecutorWithSummary(true),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 
 	err := e.Setup()
@@ -2164,7 +2164,7 @@ func TestTaskDotenvParseErrorMessage(t *testing.T) {
 	t.Parallel()
 
 	e := task.NewExecutor(
-		task.WithDir("testdata/dotenv/parse_error"),
+		task.ExecutorWithDir("testdata/dotenv/parse_error"),
 	)
 
 	path, _ := filepath.Abs(filepath.Join(e.Dir, ".env-with-error"))
@@ -2249,10 +2249,10 @@ func TestExitImmediately(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
-		task.WithSilent(true),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithSilent(true),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2283,10 +2283,10 @@ func TestRunOnceSharedDeps(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
-		task.WithForceAll(true),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithForceAll(true),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "build"}))
@@ -2304,9 +2304,9 @@ func TestDeferredCmds(t *testing.T) {
 	const dir = "testdata/deferred"
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2331,9 +2331,9 @@ func TestExitCodeZero(t *testing.T) {
 	const dir = "testdata/exit_code"
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2347,9 +2347,9 @@ func TestExitCodeOne(t *testing.T) {
 	const dir = "testdata/exit_code"
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2376,10 +2376,10 @@ func TestIgnoreNilElements(t *testing.T) {
 
 			var buff bytes.Buffer
 			e := task.NewExecutor(
-				task.WithDir(test.dir),
-				task.WithStdout(&buff),
-				task.WithStderr(&buff),
-				task.WithSilent(true),
+				task.ExecutorWithDir(test.dir),
+				task.ExecutorWithStdout(&buff),
+				task.ExecutorWithStderr(&buff),
+				task.ExecutorWithSilent(true),
 			)
 			require.NoError(t, e.Setup())
 			require.NoError(t, e.Run(context.Background(), &task.Call{Task: "default"}))
@@ -2394,9 +2394,9 @@ func TestOutputGroup(t *testing.T) {
 	const dir = "testdata/output_group"
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2421,9 +2421,9 @@ func TestOutputGroupErrorOnlySwallowsOutputOnSuccess(t *testing.T) {
 	const dir = "testdata/output_group_error_only"
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2438,9 +2438,9 @@ func TestOutputGroupErrorOnlyShowsOutputOnFailure(t *testing.T) {
 	const dir = "testdata/output_group_error_only"
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2456,9 +2456,9 @@ func TestIncludedVars(t *testing.T) {
 	const dir = "testdata/include_with_vars"
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2487,9 +2487,9 @@ func TestIncludedVarsMultiLevel(t *testing.T) {
 	const dir = "testdata/include_with_vars_multi_level"
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2532,10 +2532,10 @@ func TestErrorCode(t *testing.T) {
 
 			var buff bytes.Buffer
 			e := task.NewExecutor(
-				task.WithDir(dir),
-				task.WithStdout(&buff),
-				task.WithStderr(&buff),
-				task.WithSilent(true),
+				task.ExecutorWithDir(dir),
+				task.ExecutorWithStdout(&buff),
+				task.ExecutorWithStderr(&buff),
+				task.ExecutorWithSilent(true),
 			)
 			require.NoError(t, e.Setup())
 
@@ -2552,10 +2552,10 @@ func TestEvaluateSymlinksInPaths(t *testing.T) { // nolint:paralleltest // canno
 	const dir = "testdata/evaluate_symlinks_in_paths"
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir(dir),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
-		task.WithSilent(false),
+		task.ExecutorWithDir(dir),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithSilent(false),
 	)
 	tests := []struct {
 		name     string
@@ -2629,9 +2629,9 @@ func TestTaskfileWalk(t *testing.T) {
 
 			var buff bytes.Buffer
 			e := task.NewExecutor(
-				task.WithDir(test.dir),
-				task.WithStdout(&buff),
-				task.WithStderr(&buff),
+				task.ExecutorWithDir(test.dir),
+				task.ExecutorWithStdout(&buff),
+				task.ExecutorWithStderr(&buff),
 			)
 			require.NoError(t, e.Setup())
 			require.NoError(t, e.Run(context.Background(), &task.Call{Task: "default"}))
@@ -2645,9 +2645,9 @@ func TestUserWorkingDirectory(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir("testdata/user_working_dir"),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir("testdata/user_working_dir"),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	wd, err := os.Getwd()
 	require.NoError(t, err)
@@ -2666,9 +2666,9 @@ func TestUserWorkingDirectoryWithIncluded(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir("testdata/user_working_dir_with_includes"),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir("testdata/user_working_dir_with_includes"),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	e.UserWorkingDir = wd
 
@@ -2683,9 +2683,9 @@ func TestPlatforms(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir("testdata/platforms"),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir("testdata/platforms"),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 	require.NoError(t, e.Run(context.Background(), &task.Call{Task: "build-" + runtime.GOOS}))
@@ -2697,9 +2697,9 @@ func TestPOSIXShellOptsGlobalLevel(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir("testdata/shopts/global_level"),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir("testdata/shopts/global_level"),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2713,9 +2713,9 @@ func TestPOSIXShellOptsTaskLevel(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir("testdata/shopts/task_level"),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir("testdata/shopts/task_level"),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2729,9 +2729,9 @@ func TestPOSIXShellOptsCommandLevel(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir("testdata/shopts/command_level"),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir("testdata/shopts/command_level"),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2745,9 +2745,9 @@ func TestBashShellOptsGlobalLevel(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir("testdata/shopts/global_level"),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir("testdata/shopts/global_level"),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2761,9 +2761,9 @@ func TestBashShellOptsTaskLevel(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir("testdata/shopts/task_level"),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir("testdata/shopts/task_level"),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2777,9 +2777,9 @@ func TestBashShellOptsCommandLevel(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir("testdata/shopts/command_level"),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
+		task.ExecutorWithDir("testdata/shopts/command_level"),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2793,10 +2793,10 @@ func TestSplitArgs(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir("testdata/split_args"),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
-		task.WithSilent(true),
+		task.ExecutorWithDir("testdata/split_args"),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithSilent(true),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2830,10 +2830,10 @@ func TestSilence(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir("testdata/silent"),
-		task.WithStdout(&buff),
-		task.WithStderr(&buff),
-		task.WithSilent(false),
+		task.ExecutorWithDir("testdata/silent"),
+		task.ExecutorWithStdout(&buff),
+		task.ExecutorWithStderr(&buff),
+		task.ExecutorWithSilent(false),
 	)
 	require.NoError(t, e.Setup())
 
@@ -2961,11 +2961,11 @@ func TestForce(t *testing.T) {
 
 			var buff bytes.Buffer
 			e := task.NewExecutor(
-				task.WithDir("testdata/force"),
-				task.WithStdout(&buff),
-				task.WithStderr(&buff),
-				task.WithForce(tt.force),
-				task.WithForceAll(tt.forceAll),
+				task.ExecutorWithDir("testdata/force"),
+				task.ExecutorWithStdout(&buff),
+				task.ExecutorWithStderr(&buff),
+				task.ExecutorWithForce(tt.force),
+				task.ExecutorWithForceAll(tt.forceAll),
 			)
 			require.NoError(t, e.Setup())
 			require.NoError(t, e.Run(context.Background(), &task.Call{Task: "task-with-dep"}))
@@ -3033,11 +3033,11 @@ func TestForCmds(t *testing.T) {
 
 			buf := &bytes.Buffer{}
 			e := task.NewExecutor(
-				task.WithDir("testdata/for/cmds"),
-				task.WithStdout(buf),
-				task.WithStderr(buf),
-				task.WithSilent(true),
-				task.WithForce(true),
+				task.ExecutorWithDir("testdata/for/cmds"),
+				task.ExecutorWithStdout(buf),
+				task.ExecutorWithStderr(buf),
+				task.ExecutorWithSilent(true),
+				task.ExecutorWithForce(true),
 			)
 			require.NoError(t, e.Setup())
 			err := e.Run(context.Background(), &task.Call{Task: test.name})
@@ -3126,13 +3126,13 @@ func TestForDeps(t *testing.T) {
 			// We need to use a sync buffer here as deps are run concurrently
 			buf := &SyncBuffer{}
 			e := task.NewExecutor(
-				task.WithDir("testdata/for/deps"),
-				task.WithStdout(buf),
-				task.WithStderr(buf),
-				task.WithSilent(true),
-				task.WithForce(true),
+				task.ExecutorWithDir("testdata/for/deps"),
+				task.ExecutorWithStdout(buf),
+				task.ExecutorWithStderr(buf),
+				task.ExecutorWithSilent(true),
+				task.ExecutorWithForce(true),
 				// Force output of each dep to be grouped together to prevent interleaving
-				task.WithOutputStyle(ast.Output{Name: "group"}),
+				task.ExecutorWithOutputStyle(ast.Output{Name: "group"}),
 			)
 			require.NoError(t, e.Setup())
 			err := e.Run(context.Background(), &task.Call{Task: test.name})
@@ -3195,11 +3195,11 @@ func TestWildcard(t *testing.T) {
 
 			var buff bytes.Buffer
 			e := task.NewExecutor(
-				task.WithDir("testdata/wildcards"),
-				task.WithStdout(&buff),
-				task.WithStderr(&buff),
-				task.WithSilent(true),
-				task.WithForce(true),
+				task.ExecutorWithDir("testdata/wildcards"),
+				task.ExecutorWithStdout(&buff),
+				task.ExecutorWithStderr(&buff),
+				task.ExecutorWithSilent(true),
+				task.ExecutorWithForce(true),
 			)
 			require.NoError(t, e.Setup())
 			if test.wantErr {
@@ -3248,11 +3248,11 @@ func TestReference(t *testing.T) {
 
 			var buff bytes.Buffer
 			e := task.NewExecutor(
-				task.WithDir("testdata/var_references"),
-				task.WithStdout(&buff),
-				task.WithStderr(&buff),
-				task.WithSilent(true),
-				task.WithForce(true),
+				task.ExecutorWithDir("testdata/var_references"),
+				task.ExecutorWithStdout(&buff),
+				task.ExecutorWithStderr(&buff),
+				task.ExecutorWithSilent(true),
+				task.ExecutorWithForce(true),
 			)
 			require.NoError(t, e.Setup())
 			require.NoError(t, e.Run(context.Background(), &task.Call{Task: test.call}))
@@ -3351,11 +3351,11 @@ func TestVarInheritance(t *testing.T) {
 			t.Setenv("VAR", "shell")
 			t.Setenv("ENV", "shell")
 			e := task.NewExecutor(
-				task.WithDir(fmt.Sprintf("testdata/var_inheritance/v3/%s", test.name)),
-				task.WithStdout(&buff),
-				task.WithStderr(&buff),
-				task.WithSilent(true),
-				task.WithForce(true),
+				task.ExecutorWithDir(fmt.Sprintf("testdata/var_inheritance/v3/%s", test.name)),
+				task.ExecutorWithStdout(&buff),
+				task.ExecutorWithStderr(&buff),
+				task.ExecutorWithSilent(true),
+				task.ExecutorWithForce(true),
 			)
 			call := cmp.Or(test.call, "default")
 			require.NoError(t, e.Setup())

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -74,72 +74,73 @@ func NewReader(
 	return r
 }
 
-// Options loops through the given [ReaderOption] functions and applies them
-// to the [Reader].
+// Options loops through the given [ReaderOption] functions and applies them to
+// the [Reader].
 func (r *Reader) Options(opts ...ReaderOption) {
 	for _, opt := range opts {
 		opt(r)
 	}
 }
 
-// WithInsecure allows the [Reader] to make insecure connections when reading
-// remote taskfiles. By default, insecure connections are rejected.
-func WithInsecure(insecure bool) ReaderOption {
+// ReaderWithInsecure allows the [Reader] to make insecure connections when
+// reading remote taskfiles. By default, insecure connections are rejected.
+func ReaderWithInsecure(insecure bool) ReaderOption {
 	return func(r *Reader) {
 		r.insecure = insecure
 	}
 }
 
-// WithDownload forces the [Reader] to download a fresh copy of the taskfile
-// from the remote source.
-func WithDownload(download bool) ReaderOption {
+// ReaderWithDownload forces the [Reader] to download a fresh copy of the
+// taskfile from the remote source.
+func ReaderWithDownload(download bool) ReaderOption {
 	return func(r *Reader) {
 		r.download = download
 	}
 }
 
-// WithOffline stops the [Reader] from being able to make network connections.
-// It will still be able to read local files and cached copies of remote files.
-func WithOffline(offline bool) ReaderOption {
+// ReaderWithOffline stops the [Reader] from being able to make network
+// connections. It will still be able to read local files and cached copies of
+// remote files.
+func ReaderWithOffline(offline bool) ReaderOption {
 	return func(r *Reader) {
 		r.offline = offline
 	}
 }
 
-// WithTimeout sets the [Reader]'s timeout for fetching remote taskfiles. By
-// default, the timeout is set to 10 seconds.
-func WithTimeout(timeout time.Duration) ReaderOption {
+// ReaderWithTimeout sets the [Reader]'s timeout for fetching remote taskfiles.
+// By default, the timeout is set to 10 seconds.
+func ReaderWithTimeout(timeout time.Duration) ReaderOption {
 	return func(r *Reader) {
 		r.timeout = timeout
 	}
 }
 
-// WithTempDir sets the temporary directory that will be used by the [Reader].
-// By default, the reader uses [os.TempDir].
-func WithTempDir(tempDir string) ReaderOption {
+// ReaderWithTempDir sets the temporary directory that will be used by the
+// [Reader]. By default, the reader uses [os.TempDir].
+func ReaderWithTempDir(tempDir string) ReaderOption {
 	return func(r *Reader) {
 		r.tempDir = tempDir
 	}
 }
 
-// WithDebugFunc sets the debug function to be used by the [Reader]. If set,
-// this function will be called with debug messages. This can be useful if the
-// caller wants to log debug messages from the [Reader]. By default, no debug
-// function is set and the logs are not written.
-func WithDebugFunc(debugFunc ReaderDebugFunc) ReaderOption {
+// ReaderWithDebugFunc sets the debug function to be used by the [Reader]. If
+// set, this function will be called with debug messages. This can be useful if
+// the caller wants to log debug messages from the [Reader]. By default, no
+// debug function is set and the logs are not written.
+func ReaderWithDebugFunc(debugFunc ReaderDebugFunc) ReaderOption {
 	return func(r *Reader) {
 		r.debugFunc = debugFunc
 	}
 }
 
-// WithPromptFunc sets the prompt function to be used by the [Reader]. If set,
-// this function will be called with prompt messages. The function should
+// ReaderWithPromptFunc sets the prompt function to be used by the [Reader]. If
+// set, this function will be called with prompt messages. The function should
 // optionally log the message to the user and return nil if the prompt is
 // accepted and the execution should continue. Otherwise, it should return an
 // error which describes why the the prompt was rejected. This can then be
 // caught and used later when calling the [Reader.Read] method. By default, no
 // prompt function is set and all prompts are automatically accepted.
-func WithPromptFunc(promptFunc ReaderPromptFunc) ReaderOption {
+func ReaderWithPromptFunc(promptFunc ReaderPromptFunc) ReaderOption {
 	return func(r *Reader) {
 		r.promptFunc = promptFunc
 	}

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -28,16 +28,16 @@ Continue?`
 )
 
 type (
-	// ReaderDebugFunc is a function that is called when the reader wants to
+	// ReaderDebugFunc is a function that is called when the [Reader] wants to
 	// log debug messages
 	ReaderDebugFunc func(string)
-	// ReaderPromptFunc is a function that is called when the reader wants to
+	// ReaderPromptFunc is a function that is called when the [Reader] wants to
 	// prompt the user in some way
 	ReaderPromptFunc func(string) error
-	// ReaderOption is a function that configures a Reader.
+	// ReaderOption is a function that configures a [Reader].
 	ReaderOption func(*Reader)
-	// A Reader will recursively read Taskfiles from a given source using a directed
-	// acyclic graph (DAG).
+	// A Reader will recursively read Taskfiles from a given [Node] and build a
+	// [ast.TaskfileGraph] from them.
 	Reader struct {
 		graph       *ast.TaskfileGraph
 		node        Node
@@ -52,12 +52,13 @@ type (
 	}
 )
 
-// NewReader constructs a new Taskfile Reader using the given Node and options.
+// NewReader constructs a new Taskfile [Reader] using the given Node and
+// options.
 func NewReader(
 	node Node,
 	opts ...ReaderOption,
 ) *Reader {
-	reader := &Reader{
+	r := &Reader{
 		graph:       ast.NewTaskfileGraph(),
 		node:        node,
 		insecure:    false,
@@ -69,29 +70,35 @@ func NewReader(
 		promptFunc:  nil,
 		promptMutex: sync.Mutex{},
 	}
-	for _, opt := range opts {
-		opt(reader)
-	}
-	return reader
+	r.Options(opts...)
+	return r
 }
 
-// WithInsecure enables insecure connections when reading remote taskfiles. By
-// default, insecure connections are rejected.
+// Options loops through the given [ReaderOption] functions and applies them
+// to the [Reader].
+func (r *Reader) Options(opts ...ReaderOption) {
+	for _, opt := range opts {
+		opt(r)
+	}
+}
+
+// WithInsecure allows the [Reader] to make insecure connections when reading
+// remote taskfiles. By default, insecure connections are rejected.
 func WithInsecure(insecure bool) ReaderOption {
 	return func(r *Reader) {
 		r.insecure = insecure
 	}
 }
 
-// WithDownload forces the reader to download a fresh copy of the taskfile from
-// the remote source.
+// WithDownload forces the [Reader] to download a fresh copy of the taskfile
+// from the remote source.
 func WithDownload(download bool) ReaderOption {
 	return func(r *Reader) {
 		r.download = download
 	}
 }
 
-// WithOffline stops the reader from being able to make network connections.
+// WithOffline stops the [Reader] from being able to make network connections.
 // It will still be able to read local files and cached copies of remote files.
 func WithOffline(offline bool) ReaderOption {
 	return func(r *Reader) {
@@ -99,51 +106,53 @@ func WithOffline(offline bool) ReaderOption {
 	}
 }
 
-// WithTimeout sets the timeout for reading remote taskfiles. By default, the
-// timeout is set to 10 seconds.
+// WithTimeout sets the [Reader]'s timeout for fetching remote taskfiles. By
+// default, the timeout is set to 10 seconds.
 func WithTimeout(timeout time.Duration) ReaderOption {
 	return func(r *Reader) {
 		r.timeout = timeout
 	}
 }
 
-// WithTempDir sets the temporary directory to be used by the reader. By
-// default, the reader uses `os.TempDir()`.
+// WithTempDir sets the temporary directory that will be used by the [Reader].
+// By default, the reader uses [os.TempDir].
 func WithTempDir(tempDir string) ReaderOption {
 	return func(r *Reader) {
 		r.tempDir = tempDir
 	}
 }
 
-// WithDebugFunc sets the debug function to be used by the reader. If set, this
-// function will be called with debug messages. This can be useful if the caller
-// wants to log debug messages from the reader. By default, no debug function is
-// set and the logs are not written.
+// WithDebugFunc sets the debug function to be used by the [Reader]. If set,
+// this function will be called with debug messages. This can be useful if the
+// caller wants to log debug messages from the [Reader]. By default, no debug
+// function is set and the logs are not written.
 func WithDebugFunc(debugFunc ReaderDebugFunc) ReaderOption {
 	return func(r *Reader) {
 		r.debugFunc = debugFunc
 	}
 }
 
-// WithPromptFunc sets the prompt function to be used by the reader. If set,
+// WithPromptFunc sets the prompt function to be used by the [Reader]. If set,
 // this function will be called with prompt messages. The function should
 // optionally log the message to the user and return nil if the prompt is
 // accepted and the execution should continue. Otherwise, it should return an
 // error which describes why the the prompt was rejected. This can then be
-// caught and used later when calling the Read method. By default, no prompt
-// function is set and all prompts are automatically accepted.
+// caught and used later when calling the [Reader.Read] method. By default, no
+// prompt function is set and all prompts are automatically accepted.
 func WithPromptFunc(promptFunc ReaderPromptFunc) ReaderOption {
 	return func(r *Reader) {
 		r.promptFunc = promptFunc
 	}
 }
 
+// Read will read the Taskfile defined by the [Reader]'s [Node] and recurse
+// through any [ast.Includes] it finds, reading each included Taskfile and
+// building an [ast.TaskfileGraph] as it goes. If any errors occur, they will be
+// returned immediately.
 func (r *Reader) Read() (*ast.TaskfileGraph, error) {
-	// Recursively loop through each Taskfile, adding vertices/edges to the graph
 	if err := r.include(r.node); err != nil {
 		return nil, err
 	}
-
 	return r.graph, nil
 }
 

--- a/watch_test.go
+++ b/watch_test.go
@@ -31,12 +31,12 @@ Hello, World!
 	`)
 
 	var buff bytes.Buffer
-	e := &task.Executor{
-		Dir:    dir,
-		Stdout: &buff,
-		Stderr: &buff,
-		Watch:  true,
-	}
+	e := &task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithWatch(true),
+	)
 
 	require.NoError(t, e.Setup())
 	buff.Reset()


### PR DESCRIPTION
This PR migrates the `Executor` to use the functional options pattern. This follows other similar changes to `taskfile.Reader` and `taskfile.Snippet`. This allows package API users to easily construct an `Executor` with sensible defaults and only supply a list of things they want to override.

Our internal CLI implementation has a special functional option in `internal/flags` called `WithFlags` which will gather all the CLI flags and pass them in as functional options.