### PR TITLE
fix: include with dynamic vars

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -2477,6 +2477,19 @@ VAR_2 is included-default-var2
 	assert.Equal(t, strings.TrimSpace(buff.String()), expectedOutputOrder)
 }
 
+func TestIncludeWithVarsInInclude(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/include_with_vars_inside_include"
+	var buff bytes.Buffer
+	e := task.Executor{
+		Dir:    dir,
+		Stdout: &buff,
+		Stderr: &buff,
+	}
+	require.NoError(t, e.Setup())
+}
+
 func TestIncludedVarsMultiLevel(t *testing.T) {
 	t.Parallel()
 

--- a/taskfile/ast/vars.go
+++ b/taskfile/ast/vars.go
@@ -105,7 +105,7 @@ func (vars *Vars) ToCacheMap() (m map[string]any) {
 		if v.Sh != nil && *v.Sh != "" {
 			// Dynamic variable is not yet resolved; trigger
 			// <no value> to be used in templates.
-			return nil
+			continue
 		}
 		if v.Live != nil {
 			m[k] = v.Live

--- a/testdata/include_with_vars_inside_include/Taskfile.yml
+++ b/testdata/include_with_vars_inside_include/Taskfile.yml
@@ -1,0 +1,10 @@
+version: "3"
+
+vars:
+  INCLUDE: include
+  FOO:
+    sh : echo bar
+
+includes:
+  included1:
+    taskfile: '{{.INCLUDE}}/Taskfile.include.yml'

--- a/testdata/include_with_vars_inside_include/include/Taskfile.include.yml
+++ b/testdata/include_with_vars_inside_include/include/Taskfile.include.yml
@@ -1,0 +1,11 @@
+version: "3"
+
+vars:
+  VAR_1: '{{.VAR_1 | default "included-default-var1"}}'
+  VAR_2: '{{.VAR_2 | default "included-default-var2"}}'
+
+tasks:
+  task1:
+    cmds:
+      - echo "VAR_1 is {{.VAR_1}}"
+      - echo "VAR_2 is {{.VAR_2}}"

--- a/testdata/include_with_vars_inside_include/include/Taskfile.include.yml
+++ b/testdata/include_with_vars_inside_include/include/Taskfile.include.yml
@@ -1,11 +1,1 @@
 version: "3"
-
-vars:
-  VAR_1: '{{.VAR_1 | default "included-default-var1"}}'
-  VAR_2: '{{.VAR_2 | default "included-default-var2"}}'
-
-tasks:
-  task1:
-    cmds:
-      - echo "VAR_1 is {{.VAR_1}}"
-      - echo "VAR_2 is {{.VAR_2}}"


### PR DESCRIPTION
A regression was introduced in this [PR](https://github.com/go-task/task/pull/1797).

When a dynamic variable is provided, even if it is not used, all other variables become unavailable in the templating system.