### PR TITLE
Relocate CLI special variable handling

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -20,7 +20,6 @@ import (
 	"github.com/go-task/task/v3/internal/sort"
 	ver "github.com/go-task/task/v3/internal/version"
 	"github.com/go-task/task/v3/taskfile"
-	"github.com/go-task/task/v3/taskfile/ast"
 )
 
 func main() {
@@ -201,28 +200,21 @@ func run() error {
 	}
 
 	var (
-		calls   []*task.Call
-		globals *ast.Vars
+		calls []*task.Call
 	)
 
 	tasksAndVars, cliArgs, err := getArgs()
 	if err != nil {
 		return err
 	}
+	flags.CliArgs = cliArgs
 
-	calls, globals = args.Parse(tasksAndVars...)
+	calls, _ = args.Parse(tasksAndVars...)
 
 	// If there are no calls, run the default task instead
 	if len(calls) == 0 {
 		calls = append(calls, &task.Call{Task: "default"})
 	}
-
-	globals.Set("CLI_ARGS", ast.Var{Value: cliArgs})
-	globals.Set("CLI_FORCE", ast.Var{Value: flags.Force || flags.ForceAll})
-	globals.Set("CLI_SILENT", ast.Var{Value: flags.Silent})
-	globals.Set("CLI_VERBOSE", ast.Var{Value: flags.Verbose})
-	globals.Set("CLI_OFFLINE", ast.Var{Value: flags.Offline})
-	e.Taskfile.Vars.Merge(globals, nil)
 
 	if !flags.Watch {
 		e.InterceptInterruptSignals()

--- a/compiler.go
+++ b/compiler.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/go-task/task/v3/internal/env"
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
+	"github.com/go-task/task/v3/internal/flags"
 	"github.com/go-task/task/v3/internal/logger"
 	"github.com/go-task/task/v3/internal/templater"
 	"github.com/go-task/task/v3/internal/version"
@@ -203,6 +205,11 @@ func (c *Compiler) getSpecialVars(t *ast.Task, call *Call) (map[string]string, e
 		"ROOT_DIR":         c.Dir,
 		"USER_WORKING_DIR": c.UserWorkingDir,
 		"TASK_VERSION":     version.GetVersion(),
+		"CLI_ARGS":         flags.CliArgs,
+		"CLI_FORCE":        strconv.FormatBool(flags.Force || flags.ForceAll),
+		"CLI_SILENT":       strconv.FormatBool(flags.Silent),
+		"CLI_VERBOSE":      strconv.FormatBool(flags.Verbose),
+		"CLI_OFFLINE":      strconv.FormatBool(flags.Offline),
 	}
 	if t != nil {
 		allVars["TASK"] = t.Task

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -71,6 +71,7 @@ var (
 	Offline     bool
 	ClearCache  bool
 	Timeout     time.Duration
+	CliArgs     string // Set indirectly.
 )
 
 func init() {


### PR DESCRIPTION
fixes #2090

This relocates the CLI special vars, with an 
indirection via flags for CLI_ARGS which is done to preserve the associated error handling; since it could not be located in the flags package init() function.

I'm not certain if the handling of Bools is correct with respect  to the overall mechanism (i.e. converting to a string).