### PR TITLE
Improve handling of TaskfileInvalidError.

### DIFF
--- a/errors/errors_taskfile.go
+++ b/errors/errors_taskfile.go
@@ -47,7 +47,7 @@ type TaskfileInvalidError struct {
 }
 
 func (err TaskfileInvalidError) Error() string {
-	return fmt.Sprintf("task: Failed to parse %s:\n%v", err.URI, err.Err)
+	return fmt.Sprintf("task: Taskfile %q is not valid (failed parsing).\n%v", err.URI, err.Err)
 }
 
 func (err TaskfileInvalidError) Code() int {

--- a/task_test.go
+++ b/task_test.go
@@ -1352,7 +1352,7 @@ func TestIncludesIncorrect(t *testing.T) {
 
 	err := e.Setup()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Failed to parse testdata/includes_incorrect/incomplete.yml:", err.Error())
+	assert.Contains(t, err.Error(), "Taskfile \"testdata/includes_incorrect/incomplete.yml\" is not valid", err.Error())
 }
 
 func TestIncludesEmptyMain(t *testing.T) {

--- a/taskfile/node_stdin.go
+++ b/taskfile/node_stdin.go
@@ -23,7 +23,7 @@ func NewStdinNode(dir string) (*StdinNode, error) {
 }
 
 func (node *StdinNode) Location() string {
-	return "__stdin__"
+	return "stdin"
 }
 
 func (node *StdinNode) Remote() bool {
@@ -74,5 +74,5 @@ func (node *StdinNode) ResolveDir(dir string) (string, error) {
 }
 
 func (node *StdinNode) FilenameAndLastDir() (string, string) {
-	return "", "__stdin__"
+	return "", "stdin"
 }


### PR DESCRIPTION
Change TaskfileInvalidError error formatting to match the prevent error message style. 
Change name of StdinNode.

$ go run ./cmd/task -t help.go
task: Taskfile "help.go" is not valid (failed parsing). yaml: line 32: mapping values are not allowed in this context exit status 109

fixes #2067
