### PR TITLE
build: honor version set by ldflag

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -11,13 +11,14 @@ var (
 )
 
 func init() {
-	info, ok := debug.ReadBuildInfo()
-	if !ok || info.Main.Version == "(devel)" || info.Main.Version == "" {
-		version = "unknown"
-	} else {
-		if version == "" {
+	if version == "" {
+		info, ok := debug.ReadBuildInfo()
+		if !ok || info.Main.Version == "(devel)" || info.Main.Version == "" {
+			version = "unknown"
+		} else {
 			version = info.Main.Version
 		}
+
 		if sum == "" {
 			sum = info.Main.Sum
 		}


### PR DESCRIPTION
Seeing some version report issue in https://github.com/Homebrew/homebrew-core/pull/210289, update to honor the ldflag set.