### PR TITLE
fix: special variable type errors in vars with no task context

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -209,9 +209,16 @@ func (c *Compiler) getSpecialVars(t *ast.Task, call *Call) (map[string]string, e
 		allVars["TASK_DIR"] = filepathext.SmartJoin(c.Dir, t.Dir)
 		allVars["TASKFILE"] = t.Location.Taskfile
 		allVars["TASKFILE_DIR"] = filepath.Dir(t.Location.Taskfile)
+	} else {
+		allVars["TASK"] = ""
+		allVars["TASK_DIR"] = ""
+		allVars["TASKFILE"] = ""
+		allVars["TASKFILE_DIR"] = ""
 	}
 	if call != nil {
 		allVars["ALIAS"] = call.Task
+	} else {
+		allVars["ALIAS"] = ""
 	}
 
 	return allVars, nil

--- a/setup.go
+++ b/setup.go
@@ -209,6 +209,10 @@ func (e *Executor) setupCompiler() error {
 }
 
 func (e *Executor) readDotEnvFiles() error {
+	if e.Taskfile == nil || len(e.Taskfile.Dotenv) == 0 {
+		return nil
+	}
+
 	if e.Taskfile.Version.LessThan(ast.V3) {
 		return nil
 	}

--- a/taskfile/dotenv.go
+++ b/taskfile/dotenv.go
@@ -12,10 +12,6 @@ import (
 )
 
 func Dotenv(vars *ast.Vars, tf *ast.Taskfile, dir string) (*ast.Vars, error) {
-	if len(tf.Dotenv) == 0 {
-		return nil, nil
-	}
-
 	env := ast.NewVars()
 	cache := &templater.Cache{Vars: vars}
 


### PR DESCRIPTION
Fixes #2106

Also related to:

- #1810

The fundamental issue is that some special variables are not available when evaluating variables outside of a task. This causes the error seen in #2106 and has actually been an issue for a while. However, it was only surfaced in 3.42 because of the refactor in #2084 which moved a call to `GetTaskfileVariables` without moving the corresponding `if len(tf.Dotenv) == 0 {...}` check.

This PR fixes both of these issues:

- Special variables that we are not able to calculate now evaluate to an empty string instead of `nil`. This avoids type errors like the one seen in #2106.
- The validation check for dotenv files has been moved to before the call to `GetTaskfileVariables` again.