### PR TITLE
feature: add task duration to verbose output

### DIFF
--- a/task.go
+++ b/task.go
@@ -206,10 +206,12 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 	defer release()
 
 	return e.startExecution(ctx, t, func(ctx context.Context) error {
-		e.Logger.VerboseErrf(logger.Magenta, "task: %q started\n", call.Task)
+		e.Logger.VerboseErrf(logger.Magenta, "task: %q started\n", t.Name())
 		if err := e.runDeps(ctx, t); err != nil {
 			return err
 		}
+
+		startedAt := time.Now()
 
 		skipFingerprinting := e.ForceAll || (!call.Indirect && e.Force)
 		if !skipFingerprinting {
@@ -291,7 +293,10 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 				return &errors.TaskRunError{TaskName: t.Task, Err: err}
 			}
 		}
-		e.Logger.VerboseErrf(logger.Magenta, "task: %q finished\n", call.Task)
+
+		taskDuration := time.Since(startedAt)
+
+		e.Logger.VerboseErrf(logger.Magenta, "task: %q finished in %v\n", t.Name(), taskDuration)
 		return nil
 	})
 }


### PR DESCRIPTION
For debugging purposes, in a highly-parallel setup, it's quite hard to tell where the bottlenecks are.

This PR includes a simple "started/finished" timing of a task (excluding execution of dependencies).

Also, uses `task.Name()` for log lines, otherwise for labeled task it's unclear, which of the instance is being started or was finished. This mirrors task's progress logs, where `Name()` is also being used. 