### PR TITLE
refactor: embed the default Taskfile instead of defining it in code

### DIFF
--- a/init.go
+++ b/init.go
@@ -1,27 +1,17 @@
 package task
 
 import (
+	_ "embed"
 	"os"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/filepathext"
 )
 
-const DefaultTaskfile = `# https://taskfile.dev
-
-version: '3'
-
-vars:
-  GREETING: Hello, World!
-
-tasks:
-  default:
-    cmds:
-      - echo "{{.GREETING}}"
-    silent: true
-`
-
 const defaultTaskFilename = "Taskfile.yml"
+
+//go:embed taskfile/templates/default.yml
+var DefaultTaskfile string
 
 // InitTaskfile creates a new Taskfile at path.
 //

--- a/taskfile/templates/default.yml
+++ b/taskfile/templates/default.yml
@@ -1,0 +1,12 @@
+# https://taskfile.dev
+
+version: '3'
+
+vars:
+  GREETING: Hello, World!
+
+tasks:
+  default:
+    cmds:
+      - echo "{{.GREETING}}"
+    silent: true


### PR DESCRIPTION
Moves the default Taskfile used when calling `--init` to an embed rather than storing it in the code.