### PR TITLE
feat: allow wildcards to match multiple tasks

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -3196,9 +3196,9 @@ func TestWildcard(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "multiple matches",
-			call:    "wildcard-foo-bar",
-			wantErr: true,
+			name:           "multiple matches",
+			call:           "wildcard-foo-bar",
+			expectedOutput: "Hello foo-bar\n",
 		},
 	}
 

--- a/website/docs/usage.mdx
+++ b/website/docs/usage.mdx
@@ -1702,8 +1702,9 @@ $ task run-foo-bar
 foo bar
 ```
 
-If multiple matching tasks are found, an error occurs. If you are using included
-Taskfiles, tasks in parent files will be considered first.
+If multiple matching tasks are found, the first one listed in the Taskfile will
+be used. If you are using included Taskfiles, tasks in parent files will be
+considered first.
 
 ## Doing task cleanup with `defer`
 

--- a/website/docs/usage.mdx
+++ b/website/docs/usage.mdx
@@ -1674,37 +1674,45 @@ clear what they contain:
 version: '3'
 
 tasks:
-  echo-*:
+  start:*:*:
     vars:
-      TEXT: '{{index .MATCH 0}}'
+      SERVICE: "{{index .MATCH 0}}"
+      REPLICAS: "{{index .MATCH 1}}"
     cmds:
-      - echo {{.TEXT}}
+      - echo "Starting {{.SERVICE}} with {{.REPLICAS}} replicas"
 
-  run-*-*:
+  start:*:
     vars:
-      ARG_1: '{{index .MATCH 0}}'
-      ARG_2: '{{index .MATCH 1}}'
+      SERVICE: "{{index .MATCH 0}}"
     cmds:
-      - echo {{.ARG_1}} {{.ARG_2}}
+      - echo "Starting {{.SERVICE}}"
 ```
 
+This call matches the `start:*` task and the string "foo" is captured by the
+wildcard and stored in the `.MATCH` variable. We then index the `.MATCH` array
+and store the result in the `.SERVICE` variable which is then echoed out in the
+cmds:
+
 ```shell
-# This call matches the "echo-*" task and the string "hello" is captured by the
-# wildcard and stored in the .MATCH variable. We then index the .MATCH array and
-# store the result in the .TEXT variable which is then echoed out in the cmds.
-$ task echo-hello
-hello
-# You can use whitespace in your arguments as long as you quote the task name
-$ task "echo-hello world"
-hello world
-# And you can pass multiple arguments
-$ task run-foo-bar
-foo bar
+$ task start:foo
+Starting foo
+```
+
+You can use whitespace in your arguments as long as you quote the task name:
+
+```shell
+$ task "start:foo bar"
+Starting foo bar
 ```
 
 If multiple matching tasks are found, the first one listed in the Taskfile will
 be used. If you are using included Taskfiles, tasks in parent files will be
 considered first.
+
+```shell
+$ task start:foo:3
+Starting foo with 3 replicas
+```
 
 ## Doing task cleanup with `defer`
 


### PR DESCRIPTION
Fixes #2072 

As discussed in #2072 and https://github.com/go-task/task/pull/1489#discussion_r1499811332, this PR allows calls to match multiple tasks when using wildcards. For example, given the following Taskfile:

```yaml
version: 3

tasks:
  start:*:*:
    vars:
      SERVICE: "{{index .MATCH 0}}"
      REPLICAS: "{{index .MATCH 1}}"
    cmds:
      - echo "Starting {{.SERVICE}} with {{.REPLICAS}} replicas"

  start:*:
    vars:
      SERVICE: "{{index .MATCH 0}}"
    cmds:
      - echo "Starting {{.SERVICE}}" 
```

Currently, if you run `task start:foo:1`, you will get an error:

```
task: Found multiple tasks (start:*:*, start:*) that match "start:foo:1"
```

However, after this change you will see

```
Starting foo with 1 replicas
```

and if you run `task start:foo`, you will get

```
Starting foo
```

Worth noting that the order is important. If you swap the tasks around, then you will be unable to call `start:*:*`. This is because if multiple tasks match, Task will use the task that is listed first in the Taskfile. In general, it is recommended to write more specific tasks (i.e. ones with more parameters) first.