### PR TITLE
fix(fish): fish completion error due to variable shadowing

### DIFF
--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -1,6 +1,6 @@
 set GO_TASK_PROGNAME task
 
-function __task_get_tasks --description "Prints all available tasks with their description"
+function __task_get_tasks --description "Prints all available tasks with their description" --inherit-variable GO_TASK_PROGNAME
   # Read the list of tasks (and potential errors)
   $GO_TASK_PROGNAME --list-all 2>&1 | read -lz rawOutput
 


### PR DESCRIPTION
This PR fixes the following error on fish 4.0.1.

```
~/.config/fish/completions/task.fish (line 5): The expanded command was empty.
  $GO_TASK_PROGNAME --list-all 2>&1 | read -lz rawOutput
  ^~~~~~~~~~~~~~~~^
```

In the commit, I specified `function --inherit-variable GO_TASK_PROGNAME`.
I consider this is safe as the option is introduced 10 years ago <https://github.com/fish-shell/fish-shell/commit/cfc06203>.
I tested fish 3.0.2 (2020) and 3.7.1 (2025) and 4.0.1 (2025) and all of them works fine.

<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->
