### PR TITLE
feat(completion): let fish complete global tasks if -g or --global is passed

### DIFF
--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -6,10 +6,10 @@ function __task_get_tasks --description "Prints all available tasks with their d
   set -l cmd_args
   eval "set cmd_args $(commandline --current-process)" # split commandline by arguments considering quotes and escapes
   for arg in $cmd_args
-    if test _$arg = _"--"
+    if test "_$arg" = "_--"
       break # ignore arguments to be passed to the task
     end
-    if test _$arg = _--global -o _$arg = _-g
+    if test "_$arg" = "_--global" -o "_$arg" = "_-g"
       set global_task true
       break
     end

--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -1,8 +1,26 @@
 set -l GO_TASK_PROGNAME task
 
 function __task_get_tasks --description "Prints all available tasks with their description" --inherit-variable GO_TASK_PROGNAME
+  # Check if the global task is requested
+  set -l global_task false
+  set -l cmd_args
+  eval "set cmd_args $(commandline -b)" # split arguments by spaces while taking into account of quotes and escapes
+  for arg in $cmd_args
+    if test _$arg = _"--"
+      break # ignore arguments to be passed to the task
+    end
+    if test _$arg = _--global -o _$arg = _-g
+      set global_task true
+      break
+    end
+  end
+
   # Read the list of tasks (and potential errors)
-  $GO_TASK_PROGNAME --list-all 2>&1 | read -lz rawOutput
+  if $global_task
+    $GO_TASK_PROGNAME --global --list-all
+  else
+    $GO_TASK_PROGNAME --list-all
+  end 2>&1 | read -lz rawOutput
 
   # Return on non-zero exit code (for cases when there is no Taskfile found or etc.)
   if test $status -ne 0

--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -4,7 +4,7 @@ function __task_get_tasks --description "Prints all available tasks with their d
   # Check if the global task is requested
   set -l global_task false
   set -l cmd_args
-  eval "set cmd_args $(commandline -b)" # split arguments by spaces while taking into account of quotes and escapes
+  eval "set cmd_args $(commandline --current-process)" # split commandline by arguments considering quotes and escapes
   for arg in $cmd_args
     if test _$arg = _"--"
       break # ignore arguments to be passed to the task

--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -1,4 +1,4 @@
-set GO_TASK_PROGNAME task
+set -l GO_TASK_PROGNAME task
 
 function __task_get_tasks --description "Prints all available tasks with their description" --inherit-variable GO_TASK_PROGNAME
   # Read the list of tasks (and potential errors)

--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -3,8 +3,7 @@ set -l GO_TASK_PROGNAME task
 function __task_get_tasks --description "Prints all available tasks with their description" --inherit-variable GO_TASK_PROGNAME
   # Check if the global task is requested
   set -l global_task false
-  set -l cmd_args
-  eval "set cmd_args $(commandline --current-process)" # split commandline by arguments considering quotes and escapes
+  commandline --current-process | read --tokenize --list --local cmd_args
   for arg in $cmd_args
     if test "_$arg" = "_--"
       break # ignore arguments to be passed to the task


### PR DESCRIPTION
In the current implementation, fish completion suggests local tasks regardless of `-g` or `--global` options.
This PR fixes the problem by adding a feature to detect these options and then suggesting global tasks if likely.

I hope this PR can be merged although I do not implement the feature for bash and zsh.
I am not familiar with them...