### PR TITLE
feat: `CLI_ARGS_LIST` global variable

### DIFF
--- a/args/args.go
+++ b/args/args.go
@@ -13,24 +13,14 @@ import (
 // Get fetches the remaining arguments after CLI parsing and splits them into
 // two groups: the arguments before the double dash (--) and the arguments after
 // the double dash.
-func Get() ([]string, string, error) {
+func Get() ([]string, []string, error) {
 	args := pflag.Args()
 	doubleDashPos := pflag.CommandLine.ArgsLenAtDash()
 
 	if doubleDashPos == -1 {
-		return args, "", nil
+		return args, nil, nil
 	}
-
-	var quotedCliArgs []string
-	for _, arg := range args[doubleDashPos:] {
-		quotedCliArg, err := syntax.Quote(arg, syntax.LangBash)
-		if err != nil {
-			return nil, "", err
-		}
-		quotedCliArgs = append(quotedCliArgs, quotedCliArg)
-	}
-
-	return args[:doubleDashPos], strings.Join(quotedCliArgs, " "), nil
+	return args[:doubleDashPos], args[doubleDashPos:], nil
 }
 
 // Parse parses command line argument: tasks and global variables
@@ -49,6 +39,18 @@ func Parse(args ...string) ([]*task.Call, *ast.Vars) {
 	}
 
 	return calls, globals
+}
+
+func ToQuotedString(args []string) (string, error) {
+	var quotedCliArgs []string
+	for _, arg := range args {
+		quotedCliArg, err := syntax.Quote(arg, syntax.LangBash)
+		if err != nil {
+			return "", err
+		}
+		quotedCliArgs = append(quotedCliArgs, quotedCliArg)
+	}
+	return strings.Join(quotedCliArgs, " "), nil
 }
 
 func splitVar(s string) (string, string) {

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -144,18 +144,23 @@ func run() error {
 	}
 
 	// Parse the remaining arguments
-	argv, cliArgs, err := args.Get()
+	cliArgsPreDash, cliArgsPostDash, err := args.Get()
 	if err != nil {
 		return err
 	}
-	calls, globals := args.Parse(argv...)
+	calls, globals := args.Parse(cliArgsPreDash...)
 
 	// If there are no calls, run the default task instead
 	if len(calls) == 0 {
 		calls = append(calls, &task.Call{Task: "default"})
 	}
 
-	globals.Set("CLI_ARGS", ast.Var{Value: cliArgs})
+	cliArgsPostDashQuoted, err := args.ToQuotedString(cliArgsPostDash)
+	if err != nil {
+		return err
+	}
+	globals.Set("CLI_ARGS", ast.Var{Value: cliArgsPostDashQuoted})
+	globals.Set("CLI_ARGS_LIST", ast.Var{Value: cliArgsPostDash})
 	globals.Set("CLI_FORCE", ast.Var{Value: flags.Force || flags.ForceAll})
 	globals.Set("CLI_SILENT", ast.Var{Value: flags.Silent})
 	globals.Set("CLI_VERBOSE", ast.Var{Value: flags.Verbose})

--- a/website/docs/reference/templating.mdx
+++ b/website/docs/reference/templating.mdx
@@ -102,7 +102,8 @@ special variable will be overridden.
 
 | Var                | Description                                                                                                                                              |
 |--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `CLI_ARGS`         | Contain all extra arguments passed after `--` when calling Task through the CLI.                                                                         |
+| `CLI_ARGS`         | Contain all extra arguments passed after `--` when calling Task through the CLI as a string.                                                             |
+| `CLI_ARGS_LIST`    | Contain all extra arguments passed after `--` when calling Task through the CLI as a shell parsed list.                                                  |
 | `CLI_FORCE`        | A boolean containing whether the `--force` or `--force-all` flags were set.                                                                              |
 | `CLI_SILENT`       | A boolean containing whether the `--silent`  flag was set.                                                                                               |
 | `CLI_VERBOSE`      | A boolean containing whether the `--verbose`  flag was set.                                                                                              |


### PR DESCRIPTION
Fixes #2139 
Fixes #2138

Adds a new `CLI_ARGS_LIST` global variable which contains the pre-dash arguments in an array.