### PR TITLE
feat: migrate to golangci-lint v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,9 +23,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.64.2
+          version: v2.0.2
 
   lint-jsonschema:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,38 +1,56 @@
-# NOTE(@andreynering): The linters listed here are additions on top of
-# those enabled by default:
-#
-# https://golangci-lint.run/usage/linters/#enabled-by-default
+version: "2"
+
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any
+    gofumpt:
+      module-path: github.com/go-task/task/v3
+    goimports:
+      local-prefixes:
+        - github.com/go-task
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
 linters:
   enable:
     - depguard
-    - goimports
-    - gofmt
-    - gofumpt
     - mirror
     - misspell
     - noctx
     - paralleltest
-    - usetesting
     - thelper
     - tparallel
-
-linters-settings:
-  depguard:
-    rules:
-      main:
-        files:
-          - "$all"
-          - "!$test"
-          - "!**/errors/*.go"
-        deny:
-          - pkg: "errors"
-            desc: "Use github.com/go-task/task/v3/errors instead"
-  goimports:
-    local-prefixes: github.com/go-task
-  gofumpt:
-    module-path: github.com/go-task/task/v3
-  gofmt:
-    rewrite-rules:
-      - pattern: 'interface{}'
-        replacement: 'any'
+    - usetesting
+  settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - $all
+            - '!$test'
+            - '!**/errors/*.go'
+          deny:
+            - pkg: errors
+              desc: Use github.com/go-task/task/v3/errors instead
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
[golangci-lint](https://golangci-lint.run/) released v2 recently, I have simply run their [migration tool](https://golangci-lint.run/product/migration-guide/) on our existing config for now.