### PR TITLE
fix: bug where undefined/null variables resolve to "" instead of nil

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -75,7 +75,7 @@ func (c *Compiler) getVariables(t *ast.Task, call *Call, evaluateShVars bool) (*
 				return err
 			}
 			// If the variable is already set, we can set it and return
-			if newVar.Value != nil {
+			if newVar.Value != nil || newVar.Sh == nil {
 				result.Set(k, ast.Var{Value: newVar.Value})
 				return nil
 			}


### PR DESCRIPTION
Fixes #1911

A small bug was introduced in #1904 where undefined/null variables were resolved as an empty string instead on `nil`.