### PR TITLE
fix: `.USER_WORKING_DIR` should contain the value of `--dir` if given

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -121,6 +122,7 @@ type dirOption struct {
 }
 
 func (o *dirOption) ApplyToExecutor(e *Executor) {
+	e.UserWorkingDir, _ = filepath.Abs(o.dir)
 	e.Dir = o.dir
 }
 

--- a/task_test.go
+++ b/task_test.go
@@ -2148,7 +2148,7 @@ func TestUserWorkingDirectory(t *testing.T) {
 
 	var buff bytes.Buffer
 	e := task.NewExecutor(
-		task.WithDir("testdata/user_working_dir"),
+		task.WithEntrypoint("testdata/user_working_dir/Taskfile.yml"),
 		task.WithStdout(&buff),
 		task.WithStderr(&buff),
 	)

--- a/website/docs/reference/templating.mdx
+++ b/website/docs/reference/templating.mdx
@@ -115,7 +115,7 @@ special variable will be overridden.
 | `TASKFILE`         | The absolute path of the included Taskfile.                                                                                                              |
 | `TASKFILE_DIR`     | The absolute path of the included Taskfile directory.                                                                                                    |
 | `TASK_DIR`         | The absolute path of the directory where the task is executed.                                                                                           |
-| `USER_WORKING_DIR` | The absolute path of the directory `task` was called from.                                                                                               |
+| `USER_WORKING_DIR` | The absolute path of the directory `task` was called from, or the value of `--dir` (`-d`) if given.                                                      |
 | `CHECKSUM`         | The checksum of the files listed in `sources`. Only available within the `status` prop and if method is set to `checksum`.                               |
 | `TIMESTAMP`        | The date object of the greatest timestamp of the files listed in `sources`. Only available within the `status` prop and if method is set to `timestamp`. |
 | `TASK_VERSION`     | The current version of task.                                                                                                                             |

--- a/website/docs/usage.mdx
+++ b/website/docs/usage.mdx
@@ -61,6 +61,12 @@ In this example, we can run `cd <service>` and `task up` and as long as the
 `<service>` directory contains a `docker-compose.yml`, the Docker composition
 will be brought up.
 
+:::info
+
+`.USER_WORKING_DIR` will contain the value of the `--dir` (`-d`) flag, if given.
+
+:::
+
 ### Running a global Taskfile
 
 If you call Task with the `--global` (alias `-g`) flag, it will look for your


### PR DESCRIPTION
Closes #2102
Closes #2103