### PR TITLE
schema: allow singular precondition on task

### DIFF
--- a/website/static/schema.json
+++ b/website/static/schema.json
@@ -123,6 +123,10 @@
             "$ref": "#/definitions/precondition"
           }
         },
+        "precondition": {
+          "description": "A single command to check if this task should run. If a condition is not met, the task will error. Use `preconditions` for multiple checks.",
+          "$ref": "#/definitions/precondition"
+        },
         "dir": {
           "description": "The directory in which this task should run. Defaults to the current working directory.",
           "type": "string"


### PR DESCRIPTION
The docs explicitly show using a singular "precondition" on a Task at
<https://taskfile.dev/reference/schema/#precondition>, but the schema only
allowed the plural "preconditions" as a list.

This updates the schema to match the documented easy path.

---

### Examples

Given a Task of:

```yaml
  format:
    desc: Format the config files for consistency
    precondition: test -f {{.POLICY_FILE}}
    cmds:
      - hujsonfmt -w {{.POLICY_FILE}}
```

then running `task format` runs just fine.  But without this change, my text
editor displays:

```
E     precondition: test -f {{.POLICY_FILE}}     ■ Property precondition is not allowed.
```

Switching to a local schema file and making the change in this PR, the warning
disappears and LSP/yamlls in neovim agrees with Task about what's valid.
