### PR TITLE
Correct the version number in env_precedence experiment

### DIFF
--- a/website/docs/experiments/env_precedence.mdx
+++ b/website/docs/experiments/env_precedence.mdx
@@ -35,7 +35,7 @@ environment variable take precedence over the OS variable.
 Consider the following example:
 
 ```yml
-version: '3'
+version: '3.39'  # Environment precedence experiment was added in v3.39.0
 
 tasks:
   default:
@@ -51,7 +51,7 @@ If you still want to get the OS variable, you can use the template function env
 like follow : `{{env "OS_VAR"}}`.
 
 ```yml
-version: '3'
+version: '3.39'
 
 tasks:
   default:


### PR DESCRIPTION
<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->

I simply updated the version number in the example files for the Environment Precedence experiment, so it's clearly communicated to users the experiment is only available after release v3.39.0.
