### PR TITLE
docs: mention that method key is allowed at root level

### DIFF
--- a/website/docs/usage.mdx
+++ b/website/docs/usage.mdx
@@ -781,7 +781,10 @@ tasks:
 
 If you prefer these check to be made by the modification timestamp of the files,
 instead of its checksum (content), just set the `method` property to
-`timestamp`.
+`timestamp`. This can be done at two levels:
+
+At the task level for a specific task:
+
 
 ```yaml
 version: '3'
@@ -796,6 +799,24 @@ tasks:
       - app{{exeExt}}
     method: timestamp
 ```
+
+At the root level of the Taskfile to apply it globally to all tasks:
+
+```yaml
+version: '3'
+
+method: timestamp  # Will be the default for all tasks
+
+tasks:
+  build:
+    cmds:
+      - go build .
+    sources:
+      - ./*.go
+    generates:
+      - app{{exeExt}}
+```
+
 
 In situations where you need more flexibility the `status` keyword can be used.
 You can even combine the two. See the documentation for


### PR DESCRIPTION
# Summary

The docs does not mention that `method` can be used at root level.

Fixes #975
