### PR TITLE
feat: Improve verbose logging - print failed task

### DIFF
--- a/task.go
+++ b/task.go
@@ -226,6 +226,7 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 						e.Logger.VerboseErrf(logger.Yellow, "task: task error ignored: %v\n", err)
 						continue
 					}
+					e.Logger.VerboseErrf(logger.Red, "task: %q failed: %v\n", call.Task, err)
 					deferredExitCode = exitCode
 				}
 

--- a/task.go
+++ b/task.go
@@ -272,6 +272,7 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 						e.Logger.VerboseErrf(logger.Yellow, "task: task error ignored: %v\n", err)
 						continue
 					}
+					e.Logger.VerboseErrf(logger.Red, "task: %q failed: %v\n", call.Task, err)
 					deferredExitCode = uint8(exitCode)
 				}
 


### PR DESCRIPTION
Add a message to verbose log to simplify understanding which task caused overall failure.

Before:
```
$ cat Taskfile.yml
version: '3'

tasks:
  default:
    deps: [hello, fails]
    
  hello:
    cmds: [echo "Hello"]
     
  fails:
    cmds: ['sleep 2 && exit 42']
$ ./task -v
task: "default" started
task: "fails" started
task: [fails] sleep 2 && exit 42
task: "hello" started
task: [hello] echo "Hello"
Hello
task: "hello" finished
exit status 42
```
After:
```
$ ./task -v
task: "default" started
task: "fails" started
task: [fails] sleep 2 && exit 42
task: "hello" started
task: [hello] echo "Hello"
Hello
task: "hello" finished
task: "fails" failed: exit status 42
exit status 42
```