### PR TITLE
chore: publish nightly

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,0 +1,31 @@
+name: Realease nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 0 * * *
+
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.x
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          args: release --clean --nightly
+        env:
+          GITHUB_TOKEN: ${{secrets.GH_PAT}}
+          GORELEASER_KEY: ${{secrets.GORELEASER_KEY}}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: 0 0 * * *
-
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,12 +51,12 @@ release:
 
 git:
   ignore_tags:
-    - "{{ if not .IsNightly }}nightly{{ end }}"
+    - "{{if not .IsNightly}}nightly{{end}}"
 
 nightly:
   publish_release: true
   keep_single_release: true
-  version_template: "{{ incminor .Version }}-nightly"
+  version_template: "{{incminor .Version}}-nightly"
 
 snapshot:
   version_template: "{{.Version}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,6 +48,16 @@ archives:
 release:
   draft: true
 
+
+git:
+  ignore_tags:
+    - "{{ if not .IsNightly }}nightly{{ end }}"
+
+nightly:
+  publish_release: true
+  keep_single_release: true
+  version_template: "{{ incminor .Version }}-nightly"
+
 snapshot:
   version_template: "{{.Version}}"
 


### PR DESCRIPTION
Now that we have GoReleaser Pro, it might be a good idea to publish nightly pre-releases.
Some other projects have it. I took inspiration from GoReleaser itself.

I wasn’t able to test it yet because I don’t have the KEY.