### PR TITLE
feat: add task name to the json output

### DIFF
--- a/formatter_test.go
+++ b/formatter_test.go
@@ -218,3 +218,23 @@ func TestListDescInterpolation(t *testing.T) {
 		}),
 	)
 }
+
+func TestJsonListFormat(t *testing.T) {
+	t.Parallel()
+
+	fp, err := filepath.Abs("testdata/json_list_format/Taskfile.yml")
+	require.NoError(t, err)
+	NewFormatterTest(t,
+		WithExecutorOptions(
+			task.WithDir("testdata/json_list_format"),
+		),
+		WithListOptions(task.ListOptions{
+			FormatTaskListAsJSON: true,
+		}),
+		WithFixtureTemplateData(struct {
+			TaskfileLocation string
+		}{
+			TaskfileLocation: fp,
+		}),
+	)
+}

--- a/help.go
+++ b/help.go
@@ -149,6 +149,7 @@ func (e *Executor) ToEditorOutput(tasks []*ast.Task, noStatus bool) (*editors.Ta
 		g.Go(func() error {
 			o.Tasks[i] = editors.Task{
 				Name:     tasks[i].Name(),
+				Task:     tasks[i].Task,
 				Desc:     tasks[i].Desc,
 				Summary:  tasks[i].Summary,
 				Aliases:  aliases,

--- a/internal/editors/output.go
+++ b/internal/editors/output.go
@@ -9,6 +9,7 @@ type (
 	// Task describes a single task
 	Task struct {
 		Name     string    `json:"name"`
+		Task     string    `json:"task"`
 		Desc     string    `json:"desc"`
 		Summary  string    `json:"summary"`
 		Aliases  []string  `json:"aliases"`

--- a/testdata/json_list_format/Taskfile.yml
+++ b/testdata/json_list_format/Taskfile.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+tasks:
+  foo:
+    label: "foobar"
+    desc: "task description"

--- a/testdata/json_list_format/testdata/TestJsonListFormat.golden
+++ b/testdata/json_list_format/testdata/TestJsonListFormat.golden
@@ -1,0 +1,18 @@
+{
+  "tasks": [
+    {
+      "name": "foobar",
+      "task": "foo",
+      "desc": "task description",
+      "summary": "",
+      "aliases": [],
+      "up_to_date": false,
+      "location": {
+        "line": 4,
+        "column": 3,
+        "taskfile": "{{ .TaskfileLocation }}"
+      }
+    }
+  ],
+  "location": "{{ .TaskfileLocation }}"
+}

--- a/website/docs/reference/cli.mdx
+++ b/website/docs/reference/cli.mdx
@@ -104,6 +104,7 @@ structure:
   "tasks": [
     {
       "name": "",
+      "task": "",
       "desc": "",
       "summary": "",
       "up_to_date": false,


### PR DESCRIPTION
Hi, nice to meet you, and thanks for developing the task tool!

## Rationale

I'm implementing [the tui client](https://github.com/aleksandersh/task-tui) for the task. I have decided that the best way to integrate a user interface is to use the JSON output feature (`task --list --json`).

All works fine except [the labels](https://taskfile.dev/usage/#overriding-task-name). If some tasks have the label field, the JSON output will contain it instead of the real name. Since I can't request the execution by the task label, the client is stuck here.

https://github.com/go-task/task/blob/da4ce5b0a58c328f83c5813806ab5e6265e93fdc/taskfile/ast/task.go#L53

I found the same problem in the vscode plugin (https://github.com/go-task/vscode-task/issues/167) since it is integrated with the task in the same way.

## Changes

I assume that it's not right to change the behavior of this field, because there are some tools which can rely on this. Therefore, I decided to add a separate field (`task`) with the real task name, which can be used exactly for the purpose of executing the task.

The new JSON output will look like below

```json
{
  "tasks": [
    {
      "name": "foobar",
      "task": "foo",
      "desc": "task description",
      "summary": "",
      "aliases": [],
      "up_to_date": false,
      "location": {
        "line": 0,
        "column": 0,
        "taskfile": ""
      }
    }
  ],
  "location": ""
}
```