### PR TITLE
Improve taskfile not found error message

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -115,6 +115,10 @@ func run() error {
 		task.WithVersionCheck(true),
 	)
 	if err := e.Setup(); err != nil {
+		if errors.Is(err, errors.TaskfileNotFoundError{}) {
+			return errors.New("No supported taskfile was found: " +
+				"please check the documentation for a list of supported file names.")
+		}
 		return err
 	}
 

--- a/errors/errors_taskfile.go
+++ b/errors/errors_taskfile.go
@@ -27,6 +27,14 @@ func (err TaskfileNotFoundError) Code() int {
 	return CodeTaskfileNotFound
 }
 
+func (err TaskfileNotFoundError) Is(target error) bool {
+	_, ok := target.(TaskfileNotFoundError)
+	if ok {
+		return true
+	}
+	return false
+}
+
 // TaskfileAlreadyExistsError is returned on creating a Taskfile if one already
 // exists.
 type TaskfileAlreadyExistsError struct{}


### PR DESCRIPTION
Improves the error that is printed when no taskfile was found from: `file does not exist`
to a more informative message that explains what happened and refers to the documentations for a list of supported taskfile file names.