### PR TITLE
Support init and exit tasks.

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -177,5 +177,20 @@ func run() error {
 		return e.Status(ctx, calls...)
 	}
 
-	return e.Run(ctx, calls...)
+	getRunCalls := func(run string) ([]*task.Call) {
+		var calls = []*task.Call{}
+		for t := range e.Taskfile.Tasks.Values(nil) {
+			if t.Run == run {
+				calls = append(calls, &task.Call{Task: t.Name()})
+			}
+		}
+		return calls
+	}
+
+	calls = append(getRunCalls("init"), calls...)
+	if err := e.Run(ctx, calls...); err != nil {
+		e.Run(ctx, getRunCalls("exit")...)
+		return err
+	}
+	return e.Run(ctx, getRunCalls("exit")...)
 }

--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -177,7 +177,7 @@ func run() error {
 		return e.Status(ctx, calls...)
 	}
 
-	getRunCalls := func(run string) ([]*task.Call) {
+	getRunCalls := func(run string) []*task.Call {
 		var calls = []*task.Call{}
 		for t := range e.Taskfile.Tasks.Values(nil) {
 			if t.Run == run {

--- a/hash.go
+++ b/hash.go
@@ -18,6 +18,10 @@ func (e *Executor) GetHash(t *ast.Task) (string, error) {
 		h = hash.Name
 	case "when_changed":
 		h = hash.Hash
+	case "init":
+		h = hash.Name  // Run init tasks _once_ only.
+	case "exit":
+		h = hash.Empty  // Run exit tasks _always_.
 	default:
 		return "", fmt.Errorf(`task: invalid run "%s"`, r)
 	}

--- a/hash.go
+++ b/hash.go
@@ -19,9 +19,9 @@ func (e *Executor) GetHash(t *ast.Task) (string, error) {
 	case "when_changed":
 		h = hash.Hash
 	case "init":
-		h = hash.Name  // Run init tasks _once_ only.
+		h = hash.Name // Run init tasks _once_ only.
 	case "exit":
-		h = hash.Empty  // Run exit tasks _always_.
+		h = hash.Empty // Run exit tasks _always_.
 	default:
 		return "", fmt.Errorf(`task: invalid run "%s"`, r)
 	}


### PR DESCRIPTION
Outline suggestion (only) for supporting `init` and `exit` tasks using the task.run field. Further testing and refactoring likely required.

General operation; init tasks (run = "init") run before all other tasks, exit tasks (run = "exit") run _after_ all other tasks. 

As a result there is some amount of lifecycle management for starting services, containers, or authentication.

Relates to #2273 