### PR TITLE
Task packaging as container image.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,60 @@
+name: Docker
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read
+  pull-requests: read
+  packages: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/task
+  # SEMVER_VALUE: ",value=v0.0.4" # use this when testing
+  SEMVER_VALUE: ""
+jobs:
+  docker:
+    name: Docker Container Images
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}${{ env.SEMVER_VALUE }}
+            type=semver,pattern={{major}}${{ env.SEMVER_VALUE }}
+            type=semver,pattern={{major}}.{{minor}}${{ env.SEMVER_VALUE }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./build/package/task/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          push: true

--- a/build/package/task/Dockerfile
+++ b/build/package/task/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang AS builder
+COPY . /src
+WORKDIR /src
+RUN GOBIN=/go/bin go install ./cmd/task
+
+FROM scratch
+COPY --from=builder /go/bin/task /task
+ENTRYPOINT ["/task"]


### PR DESCRIPTION
This is a dockerfile and workflow for distributing Task in a scratch based image. Images would be pushed to GHCR, which is significantly less a pain in the arse than pushing images to Docker Hub, but you can do that too ... I doubt its worth the effort!

Workflow integration is tedious, the example I have provided should work out-of-the-box.

fixes #1801 