### PR TITLE
fix: Task failure errors include stack of running tasks.

### DIFF
--- a/errors/errors_task.go
+++ b/errors/errors_task.go
@@ -52,6 +52,10 @@ func (err *TaskRunError) TaskExitCode() int {
 	return err.Code()
 }
 
+func (err *TaskRunError) Unwrap() error {
+	return err.Err
+}
+
 // TaskInternalError when the user attempts to invoke a task that is internal.
 type TaskInternalError struct {
 	TaskName string

--- a/task.go
+++ b/task.go
@@ -150,7 +150,7 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 	release := e.acquireConcurrencyLimit()
 	defer release()
 
-	return e.startExecution(ctx, t, func(ctx context.Context) error {
+	if err = e.startExecution(ctx, t, func(ctx context.Context) error {
 		e.Logger.VerboseErrf(logger.Magenta, "task: %q started\n", call.Task)
 		if err := e.runDeps(ctx, t); err != nil {
 			return err
@@ -229,16 +229,16 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 					deferredExitCode = exitCode
 				}
 
-				if call.Indirect {
-					return err
-				}
-
-				return &errors.TaskRunError{TaskName: t.Task, Err: err}
+				return err
 			}
 		}
 		e.Logger.VerboseErrf(logger.Magenta, "task: %q finished\n", call.Task)
 		return nil
-	})
+	}); err != nil {
+		return &errors.TaskRunError{TaskName: t.Task, Err: err}
+	}
+
+	return nil
 }
 
 func (e *Executor) mkdir(t *ast.Task) error {

--- a/task_test.go
+++ b/task_test.go
@@ -547,7 +547,9 @@ func TestCyclicDep(t *testing.T) {
 		task.WithStderr(io.Discard),
 	)
 	require.NoError(t, e.Setup())
-	assert.IsType(t, &errors.TaskCalledTooManyTimesError{}, e.Run(context.Background(), &task.Call{Task: "task-1"}))
+	err := e.Run(context.Background(), &task.Call{Task: "task-1"})
+	var taskCalledTooManyTimesError *errors.TaskCalledTooManyTimesError
+	assert.ErrorAs(t, err, &taskCalledTooManyTimesError)
 }
 
 func TestTaskVersion(t *testing.T) {

--- a/testdata/precondition/testdata/TestPrecondition-a_precondition_was_not_met-err-run.golden
+++ b/testdata/precondition/testdata/TestPrecondition-a_precondition_was_not_met-err-run.golden
@@ -1,1 +1,1 @@
-task: precondition not met
+task: Failed to run task "impossible": task: precondition not met

--- a/testdata/precondition/testdata/TestPrecondition-precondition_in_cmd_fails_the_task-err-run.golden
+++ b/testdata/precondition/testdata/TestPrecondition-precondition_in_cmd_fails_the_task-err-run.golden
@@ -1,1 +1,1 @@
-task: Failed to run task "executes_failing_task_as_cmd": task: precondition not met
+task: Failed to run task "executes_failing_task_as_cmd": task: Failed to run task "impossible": task: precondition not met

--- a/testdata/precondition/testdata/TestPrecondition-precondition_in_dependency_fails_the_task-err-run.golden
+++ b/testdata/precondition/testdata/TestPrecondition-precondition_in_dependency_fails_the_task-err-run.golden
@@ -1,1 +1,1 @@
-task: precondition not met
+task: Failed to run task "depends_on_impossible": task: Failed to run task "impossible": task: precondition not met

--- a/testdata/prompt/testdata/TestPromptAssumeYes-task_should_raise_errors.TaskCancelledError-err-run.golden
+++ b/testdata/prompt/testdata/TestPromptAssumeYes-task_should_raise_errors.TaskCancelledError-err-run.golden
@@ -1,1 +1,1 @@
-task: Task "foo" cancelled by user
+task: Failed to run task "foo": task: Task "foo" cancelled by user

--- a/testdata/prompt/testdata/TestPromptInSummary-test_Enter_stops_task-test_Enter_stops_task-err-run.golden
+++ b/testdata/prompt/testdata/TestPromptInSummary-test_Enter_stops_task-test_Enter_stops_task-err-run.golden
@@ -1,1 +1,1 @@
-task: Task "foo" cancelled by user
+task: Failed to run task "foo": task: Task "foo" cancelled by user

--- a/testdata/prompt/testdata/TestPromptInSummary-test_junk_value_stops_task-test_junk_value_stops_task-err-run.golden
+++ b/testdata/prompt/testdata/TestPromptInSummary-test_junk_value_stops_task-test_junk_value_stops_task-err-run.golden
@@ -1,1 +1,1 @@
-task: Task "foo" cancelled by user
+task: Failed to run task "foo": task: Task "foo" cancelled by user

--- a/testdata/prompt/testdata/TestPromptInSummary-test_stops_task-test_stops_task-err-run.golden
+++ b/testdata/prompt/testdata/TestPromptInSummary-test_stops_task-test_stops_task-err-run.golden
@@ -1,1 +1,1 @@
-task: Task "foo" cancelled by user
+task: Failed to run task "foo": task: Task "foo" cancelled by user


### PR DESCRIPTION
Previously if a task was run as a dependency of another task, the error message simply reported something like:

```
exit status 1
```

It is desirable instead to name the root task and all child tasks in the tree to the failing task.

After this PR, the error message will read:

```
task: Failed to run task "root": task: Failed to run task "failing-task": exit status 1
```

<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->
