### PR TITLE
Fix handling of CLI provided global vars.

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -149,7 +149,6 @@ func run() error {
 		return err
 	}
 	calls, globals := args.Parse(cliArgsPreDash...)
-
 	// If there are no calls, run the default task instead
 	if len(calls) == 0 {
 		calls = append(calls, &task.Call{Task: "default"})
@@ -165,6 +164,10 @@ func run() error {
 	globals.Set("CLI_SILENT", ast.Var{Value: flags.Silent})
 	globals.Set("CLI_VERBOSE", ast.Var{Value: flags.Verbose})
 	globals.Set("CLI_OFFLINE", ast.Var{Value: flags.Offline})
+	// Merge the CLI globals before the Taskfile globals.
+	e.Taskfile.Vars.ReverseMerge(globals)
+	// Do a normal merge to ensure that CLI provided global values have priority (as the
+	// reverse merge will give priority to the Taskfile globals - last value wins).
 	e.Taskfile.Vars.Merge(globals, nil)
 
 	if !flags.Watch {

--- a/taskfile/ast/vars.go
+++ b/taskfile/ast/vars.go
@@ -133,6 +133,20 @@ func (vars *Vars) Merge(other *Vars, include *Include) {
 	}
 }
 
+// Reverse the merge order; first `other` then merge in the existing `vars`.
+func (vars *Vars) ReverseMerge(other *Vars) {
+	if vars == nil || vars.om == nil || other == nil {
+		return
+	}
+	defer other.mutex.RUnlock()
+	other.mutex.RLock()
+	new := other.DeepCopy().om
+	for pair := vars.om.Front(); pair != nil; pair = pair.Next() {
+		new.Set(pair.Key, pair.Value)
+	}
+	vars.om = new
+}
+
 func (vs *Vars) DeepCopy() *Vars {
 	if vs == nil {
 		return nil


### PR DESCRIPTION
When CLI provided global vars are provided, they are placed in `e.Taskfile.Vars` after the global vars from the Taskfile. As a result, global vars defined in the Taskfile cannot reference those provided at the CLI. This PR changes the order that those CLI provided global vars are merged into `e.Taskfile.Vars` but/and retains priority for the CLI provided global vars.

fixes #1580
fixes #1565 (probably)
fixes #2090 
fixes #1108
