### PR TITLE
Fix install script for armv5/6/7.

### DIFF
--- a/install-task.sh
+++ b/install-task.sh
@@ -64,21 +64,15 @@ get_binaries() {
   case "$PLATFORM" in
     darwin/amd64) BINARIES="task" ;;
     darwin/arm64) BINARIES="task" ;;
-    darwin/armv5) BINARIES="task" ;;
-    darwin/armv6) BINARIES="task" ;;
-    darwin/armv7) BINARIES="task" ;;
+    darwin/arm) BINARIES="task" ;;
     linux/386) BINARIES="task" ;;
     linux/amd64) BINARIES="task" ;;
     linux/arm64) BINARIES="task" ;;
-    linux/armv5) BINARIES="task" ;;
-    linux/armv6) BINARIES="task" ;;
-    linux/armv7) BINARIES="task" ;;
+    linux/arm) BINARIES="task" ;;
     windows/386) BINARIES="task" ;;
     windows/amd64) BINARIES="task" ;;
     windows/arm64) BINARIES="task" ;;
-    windows/armv5) BINARIES="task" ;;
-    windows/armv6) BINARIES="task" ;;
-    windows/armv7) BINARIES="task" ;;
+    windows/arm) BINARIES="task" ;;
     *)
       log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
       exit 1

--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -64,21 +64,15 @@ get_binaries() {
   case "$PLATFORM" in
     darwin/amd64) BINARIES="task" ;;
     darwin/arm64) BINARIES="task" ;;
-    darwin/armv5) BINARIES="task" ;;
-    darwin/armv6) BINARIES="task" ;;
-    darwin/armv7) BINARIES="task" ;;
+    darwin/arm) BINARIES="task" ;;
     linux/386) BINARIES="task" ;;
     linux/amd64) BINARIES="task" ;;
     linux/arm64) BINARIES="task" ;;
-    linux/armv5) BINARIES="task" ;;
-    linux/armv6) BINARIES="task" ;;
-    linux/armv7) BINARIES="task" ;;
+    linux/arm) BINARIES="task" ;;
     windows/386) BINARIES="task" ;;
     windows/amd64) BINARIES="task" ;;
     windows/arm64) BINARIES="task" ;;
-    windows/armv5) BINARIES="task" ;;
-    windows/armv6) BINARIES="task" ;;
-    windows/armv7) BINARIES="task" ;;
+    windows/arm) BINARIES="task" ;;
     *)
       log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
       exit 1


### PR DESCRIPTION
The install-task.sh script was converting "armv7*" to "arm" in function `uname_arch()`, checking that "arm" value in `uname_arch_check()`, and then finally using a case condition based on "armv7" in function `get_binaries()`. So of course the download would fail.

[GO Arch only includes linux/arm](https://pkg.go.dev/internal/platform#pkg-variables) variant.

Solution is to fix the `get_binaries()` function.

fixes #1516 

Download tested on PI aarch64, script modified with hardcoded arch as "arm7l". Expected version of task was downloaded.
