### PR TITLE
include generated files in the checksum method

### DIFF
--- a/internal/fingerprint/sources_checksum.go
+++ b/internal/fingerprint/sources_checksum.go
@@ -15,7 +15,7 @@ import (
 )
 
 // ChecksumChecker validates if a task is up to date by calculating its source
-// files checksum
+// and destination (generates) files checksum
 type ChecksumChecker struct {
 	tempDir string
 	dry     bool
@@ -92,10 +92,15 @@ func (c *ChecksumChecker) checksum(t *ast.Task) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	generates, err := Globs(t.Dir, t.Generates)
+	if err != nil {
+		return "", err
+	}
+	files := append(sources, generates...)
 
 	h := xxh3.New()
 	buf := make([]byte, 128*1024)
-	for _, f := range sources {
+	for _, f := range files {
 		// also sum the filename, so checksum changes for renaming a file
 		if _, err := io.CopyBuffer(h, strings.NewReader(filepath.Base(f)), buf); err != nil {
 			return "", err

--- a/task.go
+++ b/task.go
@@ -236,6 +236,26 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 				return &errors.TaskRunError{TaskName: t.Task, Err: err}
 			}
 		}
+
+		if !skipFingerprinting {
+			// Get the fingerprinting method to use
+			method := e.Taskfile.Method
+			if t.Method != "" {
+				method = t.Method
+			}
+
+			// Finalize the task fingerprinting
+			err := fingerprint.FinalizeTask(ctx, t,
+				fingerprint.WithMethod(method),
+				fingerprint.WithTempDir(e.TempDir.Fingerprint),
+				fingerprint.WithDry(e.Dry),
+				fingerprint.WithLogger(e.Logger),
+			)
+			if err != nil {
+				return err
+			}
+		}
+
 		e.Logger.VerboseErrf(logger.Magenta, "task: %q finished\n", call.Task)
 		return nil
 	})


### PR DESCRIPTION
This PR includes generated files into the calculated checksum to trigger task only when needed.

Namely, that implements:
https://github.com/go-task/task/issues/2181
and closes:
https://github.com/go-task/task/issues/2301 (original bug report for timestamp method but this PR will allow to use default checksum method and preserves original timestamp method behavior)

Example Taskfile.yml:
```
version: '3'

tasks:
  default:
    sources:
      - input/*.in
    generates:
      - output/*.out
    cmds:
      - mkdir -p output
      - cp input/one.in output/one.out
      - cp input/two.in output/two.out
```

- initial task run will generate one.out and two.out
- subsequent task run will report task is up to date
- rename of any *.out file and running task will generate the files again
- removal of any *.out file and running task will generate the files again