### PR TITLE
fix: spaces in path

### DIFF
--- a/internal/execext/exec.go
+++ b/internal/execext/exec.go
@@ -90,6 +90,15 @@ func RunCommand(ctx context.Context, opts *RunCommandOptions) error {
 	return r.Run(ctx, p)
 }
 
+func escape(s string) string {
+	s = filepath.ToSlash(s)
+	s = strings.ReplaceAll(s, " ", `\ `)
+	s = strings.ReplaceAll(s, "&", `\&`)
+	s = strings.ReplaceAll(s, "(", `\(`)
+	s = strings.ReplaceAll(s, ")", `\)`)
+	return s
+}
+
 // ExpandLiteral is a wrapper around [expand.Literal]. It will escape the input
 // string, expand any shell symbols (such as '~') and resolve any environment
 // variables.
@@ -115,6 +124,7 @@ func ExpandLiteral(s string) (string, error) {
 // variables. It also expands brace expressions ({a.b}) and globs (*/**) and
 // returns the results as a list of strings.
 func ExpandFields(s string) ([]string, error) {
+	s = escape(s)
 	p := syntax.NewParser()
 	var words []*syntax.Word
 	err := p.Words(strings.NewReader(s), func(w *syntax.Word) bool {


### PR DESCRIPTION
Fixes #2321 which was caused by the changes in #2216. Looks like the `escape` is still needed for globbing. I have (again) checked that all previous issues in this chain are still working as expected. Hopefully this is resolved once and for all now.