### PR TITLE
fix: don't suggest internal tasks

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -957,6 +957,15 @@ func TestFuzzyModel(t *testing.T) {
 		),
 		WithTask("install"),
 	)
+
+	NewExecutorTest(t,
+		WithName("intern"),
+		WithExecutorOptions(
+			task.WithDir("testdata/fuzzy"),
+		),
+		WithTask("intern"),
+		WithRunError(),
+	)
 }
 
 func TestIncludeChecksum(t *testing.T) {

--- a/setup.go
+++ b/setup.go
@@ -104,6 +104,9 @@ func (e *Executor) setupFuzzyModel() {
 
 	var words []string
 	for name, task := range e.Taskfile.Tasks.All(nil) {
+		if task.Internal {
+			continue
+		}
 		words = append(words, name)
 		words = slices.Concat(words, task.Aliases)
 	}

--- a/testdata/fuzzy/Taskfile.yml
+++ b/testdata/fuzzy/Taskfile.yml
@@ -2,3 +2,8 @@ version: 3
 
 tasks:
   install: echo 'install'
+
+  internal:
+    internal: true
+    cmds:
+      - echo "internal"

--- a/testdata/fuzzy/testdata/TestFuzzyModel-intern-err-run.golden
+++ b/testdata/fuzzy/testdata/TestFuzzyModel-intern-err-run.golden
@@ -1,0 +1,1 @@
+task: Task "intern" does not exist

--- a/testdata/fuzzy/testdata/TestFuzzyModel-intern.golden
+++ b/testdata/fuzzy/testdata/TestFuzzyModel-intern.golden
@@ -1,0 +1,1 @@
+task: No tasks with description available. Try --list-all to list all tasks


### PR DESCRIPTION
fixes https://github.com/go-task/task/issues/2309

Internal tasks cannot be ran from the command line, so it doesn't make sense to suggest them when fixing typos on the command line

Without the changes, the added test fails with

```
    executor_test.go:974:
                Error Trace:    /home/max/task/executor_test.go:205
                Error:          Error message not equal:
                                expected: "task: Task \"intern\" does not exist"
                                actual  : "task: Task \"intern\" does not exist. Did you mean \"internal\"?"
                Test:           TestFuzzyModel/intern
```