### PR TITLE
'Section' field added to deb package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,6 +59,7 @@ nfpms:
     homepage: https://taskfile.dev
     maintainer: The Task authors <task@taskfile.dev>
     description: Simple task runner written in Go
+    section: golang
     license: MIT
     conflicts:
       - taskwarrior


### PR DESCRIPTION
Added the `section` field to `.goreleaser.yml` to classify the deb package in repositories