### PR TITLE
Add templating support to CLI flags list/list-all

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -128,6 +128,7 @@ func run() error {
 		flags.ListAll,
 		flags.ListJson,
 		flags.NoStatus,
+		flags.Template,
 	)
 	if listOptions.ShouldListTasks() {
 		if flags.Silent {

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -69,6 +69,7 @@ var (
 	Color               bool
 	Interval            time.Duration
 	Global              bool
+	Template            string
 	Experiments         bool
 	Download            bool
 	Offline             bool
@@ -137,6 +138,7 @@ func init() {
 	pflag.IntVarP(&Concurrency, "concurrency", "C", 0, "Limit number of tasks to run concurrently.")
 	pflag.DurationVarP(&Interval, "interval", "I", 0, "Interval to watch for changes.")
 	pflag.BoolVarP(&Global, "global", "g", false, "Runs global Taskfile, from $HOME/{T,t}askfile.{yml,yaml}.")
+	pflag.StringVar(&Template, "template", "", "Format output using a template. Select commands [list|list-all].")
 	pflag.BoolVar(&Experiments, "experiments", false, "Lists all the available experiments and whether or not they are enabled.")
 
 	// Gentle force experiment will override the force flag and add a new force-all flag


### PR DESCRIPTION
This PR is adding template support for CLI commands --list / --list-all. The implementation adds an optional flag (--template) which is used to specify a template file(s). When specified, the template files(s) are loaded and rendered. The templating mechanism makes use of the existing slim-sprig functions available in Task.

Primary motivation for the PR is to generate documentation for a library of Taskfiles. Some of the documentation can be extracted from the existing Taskfile schema, and other elements of the documentation are embedded in the Taskfiles. This later embedded documentation ([example here](https://github.com/boschglobal/dse.fmi/blob/main/Taskfile.yml)) would be made available to the templating mechanism as well (PR in development).


As it currently stands, the PR replaces the `--list` code (a for loop) with the templating mechanism.

## Example

### mddoc.template
```
# Taskfile
Available tasks for this project:
{{ range . }}
## {{.Task}}
{{.Desc}}
{{if len .Aliases}}
### Aliases
{{range .Aliases}}- {{.}}
{{end}}{{end}}{{end}}
```

### Console Output
```bash
$ task --list-all --template mddoc.template
# Taskfile
Available tasks for this project:

## clean
Cleans temp files and folders

### Aliases
- clear

## default


## format
Runs golangci-lint and formats any Go files

### Aliases
- fmt
- f

## generate
Runs all generate tasks

### Aliases
- gen
- g
```

## Notes:

fixes #1695
fixes #2261
related #1916
related #931 (perhaps)
related #2091

Outstanding items needed to complete PR:
* Refinement of operation - e.g. relationship between list list-all and template CLI options.
* Documentation with examples.
* Application to the --summary command?
* Support template definition in the taskrc file.?