### PR TITLE
Fix concurrent writes to stdout in tests.

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -144,12 +144,12 @@ func (tt *ExecutorTest) run(t *testing.T) {
 	t.Helper()
 	f := func(t *testing.T) {
 		t.Helper()
-		var buf bytes.Buffer
+		var buffer SyncBuffer
 
 		opts := append(
 			tt.executorOpts,
-			task.WithStdout(&buf),
-			task.WithStderr(&buf),
+			task.WithStdout(&buffer),
+			task.WithStderr(&buffer),
 		)
 
 		// If the test has input, create a reader for it and add it to the
@@ -172,7 +172,7 @@ func (tt *ExecutorTest) run(t *testing.T) {
 		if err := e.Setup(); tt.wantSetupError {
 			require.Error(t, err)
 			tt.writeFixtureErrSetup(t, g, err)
-			tt.writeFixtureBuffer(t, g, buf)
+			tt.writeFixtureBuffer(t, g, buffer.buf)
 			return
 		} else {
 			require.NoError(t, err)
@@ -193,7 +193,7 @@ func (tt *ExecutorTest) run(t *testing.T) {
 		if err := e.Run(ctx, call); tt.wantRunError {
 			require.Error(t, err)
 			tt.writeFixtureErrRun(t, g, err)
-			tt.writeFixtureBuffer(t, g, buf)
+			tt.writeFixtureBuffer(t, g, buffer.buf)
 			return
 		} else {
 			require.NoError(t, err)
@@ -206,7 +206,7 @@ func (tt *ExecutorTest) run(t *testing.T) {
 			}
 		}
 
-		tt.writeFixtureBuffer(t, g, buf)
+		tt.writeFixtureBuffer(t, g, buffer.buf)
 	}
 
 	// Run the test (with a name if it has one)

--- a/internal/output/group.go
+++ b/internal/output/group.go
@@ -44,10 +44,15 @@ func (gw *groupWriter) close() error {
 		// don't print begin/end messages if there's no buffered entries
 		return nil
 	}
-	if _, err := io.WriteString(gw.writer, gw.begin); err != nil {
-		return err
+	if len(gw.begin) > 0 {
+		// Rewrite the gw.buff with the beginning text.
+		s := gw.buff.String()
+		gw.buff.Reset()
+		gw.buff.WriteString(gw.begin)
+		gw.buff.WriteString(s)
 	}
 	gw.buff.WriteString(gw.end)
+	// Return the entire gw.buff to ensure the group is written atomically to stdout.
 	_, err := io.Copy(gw.writer, &gw.buff)
 	return err
 }


### PR DESCRIPTION
Writes to stdout from `deps` are occasionally "mixed up" because of stdout buffering. To prevent this, the _entire_ grouped output is written with _one_ call to `gw.buffer.WriteString()` rather than the previous two calls.

Additionally, to reduce flaky tests, use a SyncBuffer which prevents interleaving of stdout/err (typically from `deps` which run in parallel).


fixes #2349
fixes #1208