### PR TITLE
build: publish deb and rpm to cloudsmith

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -135,3 +135,19 @@ winget:
           owner: microsoft
           name: winget-pkgs
           branch: master
+
+cloudsmiths:
+  - organization: "task"
+    repository: "task"
+    formats:
+      - deb
+      - rpm
+    distributions:
+      deb:
+        - "ubuntu/any-version"
+        - "debian/any-version"
+      rpm:
+        - "el/any-version"
+        - "fedora/any-version"
+    component: main
+    republish: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -142,6 +142,7 @@ cloudsmiths:
     formats:
       - deb
       - rpm
+      - apk
     distributions:
       deb:
         - "ubuntu/any-version"
@@ -149,5 +150,7 @@ cloudsmiths:
       rpm:
         - "el/any-version"
         - "fedora/any-version"
+      alpine:
+        - "alpine/any-version"
     component: main
     republish: true


### PR DESCRIPTION
I’ve created a team, and we’re using the Open Source free tier, which should be sufficient for our needs!
I’ve added the `CLOUDSMITH_TOKEN` as a secret variable in the GitHub Actions workflow.

I haven’t been able to test it yet, but according to Cloudsmith, we can use `any-version` since our binary is statically compiled.

I haven’t updated the documentation yet because the website is being rewritten. Also, I wanted to test how it works first before making any updates.