### PR TITLE
docs: remove padding in team page and fix redirect

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -294,5 +294,8 @@ export default defineConfig({
       message:
         'Built with <a target="_blank" href="https://www.netlify.com">Netlify</a>'
     }
+  },
+  sitemap: {
+    hostname: 'https://taskfile.dev'
   }
 });

--- a/website/.vitepress/theme/custom.css
+++ b/website/.vitepress/theme/custom.css
@@ -140,3 +140,8 @@ img[src*='custom-icon-badges.demolab.com'] {
     content: '🔥';
   }
 }
+
+
+.VPTeamPage > .VPTeamPageTitle {
+  padding-top: 0
+}

--- a/website/Taskfile.yml
+++ b/website/Taskfile.yml
@@ -47,13 +47,11 @@ tasks:
       - rm -rf ./vitepress/dist
 
   deploy:next:
-    deps: [build]
     desc: Build and deploy next.taskfile.dev
     cmds:
       - pnpm netlify deploy --prod --site=4e13dfcf-fc0d-4bec-ad60-b918a8dc3942
 
   deploy:prod:
-    deps: [build]
     desc: Build and deploy taskfile.dev
     cmds:
       - pnpm netlify deploy --prod --site=e625bc6a-1cd3-465d-ad30-7bbddaeb4f31

--- a/website/package.json
+++ b/website/package.json
@@ -21,5 +21,6 @@
     "vitepress-plugin-group-icons": "^1.6.1",
     "vitepress-plugin-tabs": "^0.7.1",
     "vue": "^3.5.18"
-  }
+  },
+  "packageManager": "pnpm@9.15.6+sha512.139cab068fdf0b751268179ac5f909b5be72afb4a75c513d1905d151befc8977b593d3cf8671ed83d4d6637c5c94b98ffbce108125de4a5a27a31233601a99de"
 }

--- a/website/src/public/_redirects
+++ b/website/src/public/_redirects
@@ -13,7 +13,7 @@
 
 # Redirect some group docs pages
 /deprecations/*    /docs/deprecations/:splat
-/experiments/*     /docs/experiments:splat
+/experiments/*     /docs/experiments/:splat
 /reference/*       /docs/reference/:splat
 
 # Redirect root /docs to something useful


### PR DESCRIPTION
Remove the padding in the team page
Also one redirect was wrong, a / was missing
