### PR TITLE
fix: goreleaser with cloudsmith and npm

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -27,3 +27,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GH_PAT}}
           GORELEASER_KEY: ${{secrets.GORELEASER_KEY}}
+          CLOUDSMITH_TOKEN: ${{secrets.CLOUDSMITH_TOKEN}}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: latest
-          args: release --clean --nightly -f .goreleaser-nightly.yml
+          args: release --verbose --clean --nightly -f .goreleaser-nightly.yml
         env:
           GITHUB_TOKEN: ${{secrets.GH_PAT}}
           GORELEASER_KEY: ${{secrets.GORELEASER_KEY}}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: latest
-          args: release --verbose --clean --nightly -f .goreleaser-nightly.yml
+          args: release --clean --nightly -f .goreleaser-nightly.yml
         env:
           GITHUB_TOKEN: ${{secrets.GH_PAT}}
           GORELEASER_KEY: ${{secrets.GORELEASER_KEY}}

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,4 +1,4 @@
-name: Realease nightly
+name: Release nightly
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GH_PAT}}
           GORELEASER_KEY: ${{secrets.GORELEASER_KEY}}
+          CLOUDSMITH_TOKEN: ${{secrets.CLOUDSMITH_TOKEN}}
 
       - name: Deploy Website
         shell: bash

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -27,7 +27,7 @@ cloudsmiths:
         - "fedora/any-version"
       alpine:
         - "alpine/any-version"
-    component: unstable
+    component: main
     republish: true
     ids:
       - "!*arm64*"

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -11,6 +11,27 @@ nightly:
   version_template: "{{incminor .Version}}-nightly"
 
 
+cloudsmiths:
+  - organization: "task"
+    repository: "task"
+    formats:
+      - deb
+      - rpm
+      - apk
+    distributions:
+      deb:
+        - "ubuntu/any-version"
+        - "debian/any-version"
+      rpm:
+        - "el/any-version"
+        - "fedora/any-version"
+      alpine:
+        - "alpine/any-version"
+    component: unstable
+    republish: true
+    ids:
+      - "!*arm64*"
+
 
 includes:
   - from_file:

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -11,26 +11,6 @@ nightly:
   version_template: "{{incminor .Version}}-nightly"
 
 
-#cloudsmiths:
-#  - organization: "task"
-#    repository: "task"
-#    formats:
-#      - deb
-#      - rpm
-#      - apk
-#    distributions:
-#      deb:
-#        - "ubuntu/any-version"
-#        - "debian/any-version"
-#      rpm:
-#        - "el/any-version"
-#        - "fedora/any-version"
-#      alpine:
-#        - "alpine/any-version"
-#    component: main
-#    republish: true
-
-
 includes:
   - from_file:
       path: ./.goreleaser.yml

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -29,8 +29,6 @@ cloudsmiths:
         - "alpine/any-version"
     component: main
     republish: true
-    ids:
-      - "!*arm64*"
 
 
 includes:

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -10,6 +10,10 @@ nightly:
   keep_single_release: true
   version_template: "{{incminor .Version}}-nightly"
 
+cloudsmiths:
+  component: unstable
+
+
 includes:
   - from_file:
       path: ./.goreleaser.yml

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -10,7 +10,6 @@ nightly:
   keep_single_release: true
   version_template: "{{incminor .Version}}-nightly"
 
-
 includes:
   - from_file:
       path: ./.goreleaser.yml

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -10,8 +10,6 @@ nightly:
   keep_single_release: true
   version_template: "{{incminor .Version}}-nightly"
 
-cloudsmiths:
-  component: unstable
 
 
 includes:

--- a/.goreleaser-nightly.yml
+++ b/.goreleaser-nightly.yml
@@ -11,24 +11,24 @@ nightly:
   version_template: "{{incminor .Version}}-nightly"
 
 
-cloudsmiths:
-  - organization: "task"
-    repository: "task"
-    formats:
-      - deb
-      - rpm
-      - apk
-    distributions:
-      deb:
-        - "ubuntu/any-version"
-        - "debian/any-version"
-      rpm:
-        - "el/any-version"
-        - "fedora/any-version"
-      alpine:
-        - "alpine/any-version"
-    component: main
-    republish: true
+#cloudsmiths:
+#  - organization: "task"
+#    repository: "task"
+#    formats:
+#      - deb
+#      - rpm
+#      - apk
+#    distributions:
+#      deb:
+#        - "ubuntu/any-version"
+#        - "debian/any-version"
+#      rpm:
+#        - "el/any-version"
+#        - "fedora/any-version"
+#      alpine:
+#        - "alpine/any-version"
+#    component: main
+#    republish: true
 
 
 includes:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -162,9 +162,9 @@ cloudsmiths:
       - rpm
       - apk
     distributions:
-#      deb:
+      deb:
 #        - "ubuntu/any-version"
-#        - "debian/any-version"
+        - "debian/any-version"
       rpm:
         - "el/any-version"
         - "fedora/any-version"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -163,7 +163,7 @@ cloudsmiths:
       - apk
     distributions:
       deb:
-#        - "ubuntu/any-version"
+        - "ubuntu/any-version"
         - "debian/any-version"
       rpm:
         - "el/any-version"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -158,13 +158,13 @@ cloudsmiths:
   - organization: "task"
     repository: "task"
     formats:
-      - deb
+#      - deb
       - rpm
       - apk
     distributions:
-      deb:
-        - "ubuntu/any-version"
-        - "debian/any-version"
+#      deb:
+#        - "ubuntu/any-version"
+#        - "debian/any-version"
       rpm:
         - "el/any-version"
         - "fedora/any-version"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -159,7 +159,6 @@ cloudsmiths:
     formats:
       - deb
       - rpm
-      - apk
     distributions:
       deb:
         - "ubuntu/any-version"
@@ -167,7 +166,5 @@ cloudsmiths:
       rpm:
         - "el/any-version"
         - "fedora/any-version"
-      alpine:
-        - "alpine/any-version"
     component: main
     republish: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -162,13 +162,13 @@ cloudsmiths:
       - rpm
       - apk
     distributions:
-#      deb:
-#        - "ubuntu/any-version"
-#        - "debian/any-version"
+      deb:
+        - "ubuntu/any-version"
+        - "debian/any-version"
       rpm:
         - "el/any-version"
         - "fedora/any-version"
       alpine:
         - "alpine/any-version"
-    component: main
+    component: "{{if .IsNightly}}unstable{{else}}main{{end}}"
     republish: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -162,9 +162,9 @@ cloudsmiths:
       - rpm
       - apk
     distributions:
-      deb:
-        - "ubuntu/any-version"
-        - "debian/any-version"
+#      deb:
+#        - "ubuntu/any-version"
+#        - "debian/any-version"
       rpm:
         - "el/any-version"
         - "fedora/any-version"
@@ -172,5 +172,3 @@ cloudsmiths:
         - "alpine/any-version"
     component: main
     republish: true
-    ids:
-      - "!*arm64*"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -170,7 +170,7 @@ cloudsmiths:
         - "fedora/any-version"
       alpine:
         - "alpine/any-version"
-    component: main
+    component: "{{if .IsNightly}}unstable{{else}}main{{end}}"
     republish: true
     ids:
       - "!*arm64*"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -162,9 +162,9 @@ cloudsmiths:
       - rpm
       - apk
     distributions:
-      deb:
-        - "ubuntu/any-version"
-        - "debian/any-version"
+#      deb:
+#        - "ubuntu/any-version"
+#        - "debian/any-version"
       rpm:
         - "el/any-version"
         - "fedora/any-version"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,7 +68,6 @@ nfpms:
     formats:
       - deb
       - rpm
-
     file_name_template: '{{.ProjectName}}_{{.Os}}_{{.Arch}}'
     contents:
       - src: completion/bash/task.bash
@@ -160,6 +159,7 @@ cloudsmiths:
     formats:
       - deb
       - rpm
+      - apk
     distributions:
       deb:
         - "ubuntu/any-version"
@@ -167,6 +167,8 @@ cloudsmiths:
       rpm:
         - "el/any-version"
         - "fedora/any-version"
+      alpine:
+        - "alpine/any-version"
     component: main
     republish: true
     ids:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -147,9 +147,9 @@ npms:
     author: "The Task authors"
     access: public
     keywords:
-      - "task",
-      - "taskfile",
-      - "build-tool",
+      - "task"
+      - "taskfile"
+      - "build-tool"
       - "task-runner"
 
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,6 +68,13 @@ nfpms:
     formats:
       - deb
       - rpm
+
+    overrides:
+      deb:
+        replacements:
+          386: i386
+          arm: armhf
+          
     file_name_template: '{{.ProjectName}}_{{.Os}}_{{.Arch}}'
     contents:
       - src: completion/bash/task.bash

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,10 +69,6 @@ nfpms:
       - deb
       - rpm
 
-    replacements:
-      386: i386
-      arm: armhf
-      
     file_name_template: '{{.ProjectName}}_{{.Os}}_{{.Arch}}'
     contents:
       - src: completion/bash/task.bash
@@ -173,3 +169,5 @@ cloudsmiths:
         - "fedora/any-version"
     component: main
     republish: true
+    ids:
+      - "!*arm64*"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -158,7 +158,7 @@ cloudsmiths:
   - organization: "task"
     repository: "task"
     formats:
-#      - deb
+      - deb
       - rpm
       - apk
     distributions:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,12 +69,10 @@ nfpms:
       - deb
       - rpm
 
-    overrides:
-      deb:
-        replacements:
-          386: i386
-          arm: armhf
-          
+    replacements:
+      386: i386
+      arm: armhf
+      
     file_name_template: '{{.ProjectName}}_{{.Os}}_{{.Arch}}'
     contents:
       - src: completion/bash/task.bash

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -170,7 +170,7 @@ cloudsmiths:
         - "fedora/any-version"
       alpine:
         - "alpine/any-version"
-    component: "{{if .IsNightly}}unstable{{else}}main{{end}}"
+    component: main
     republish: true
     ids:
       - "!*arm64*"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,6 +68,7 @@ nfpms:
     formats:
       - deb
       - rpm
+      - apk
     file_name_template: '{{.ProjectName}}_{{.Os}}_{{.Arch}}'
     contents:
       - src: completion/bash/task.bash


### PR DESCRIPTION
It fixes multiple issues : 
- Missing `CLOUDSMITH_TOKEN`
- remove some commas to be yaml compliant


The cloudsmiths integration with deb packages does not work and needed to be fixed before merging