### PR TITLE
feat: change XDG taskrc naming

### DIFF
--- a/taskrc/node.go
+++ b/taskrc/node.go
@@ -11,9 +11,10 @@ type Node struct {
 func NewNode(
 	entrypoint string,
 	dir string,
+	possibleFileNames []string,
 ) (*Node, error) {
 	dir = fsext.DefaultDir(entrypoint, dir)
-	resolvedEntrypoint, err := fsext.SearchPath(dir, defaultTaskRCs)
+	resolvedEntrypoint, err := fsext.SearchPath(dir, possibleFileNames)
 	if err != nil {
 		return nil, err
 	}

--- a/taskrc/taskrc_test.go
+++ b/taskrc/taskrc_test.go
@@ -66,7 +66,7 @@ func TestGetConfig_NoConfigFiles(t *testing.T) { //nolint:paralleltest // cannot
 func TestGetConfig_OnlyXDG(t *testing.T) { //nolint:paralleltest // cannot run in parallel
 	xdgDir, _, localDir := setupDirs(t)
 
-	writeFile(t, xdgDir, ".taskrc.yml", xdgConfigYAML)
+	writeFile(t, xdgDir, "taskrc.yml", xdgConfigYAML)
 
 	cfg, err := GetConfig(localDir)
 	assert.NoError(t, err)
@@ -121,7 +121,7 @@ func TestGetConfig_All(t *testing.T) { //nolint:paralleltest // cannot run in pa
 	writeFile(t, homeDir, ".taskrc.yml", homeConfigYAML)
 
 	// Write XDG config
-	writeFile(t, xdgConfigDir, ".taskrc.yml", xdgConfigYAML)
+	writeFile(t, xdgConfigDir, "taskrc.yml", xdgConfigYAML)
 
 	cfg, err := GetConfig(localDir)
 	assert.NoError(t, err)

--- a/website/src/docs/reference/config.md
+++ b/website/src/docs/reference/config.md
@@ -19,16 +19,21 @@ files.
 
 ## File Precedence
 
-Task's configuration files are named `.taskrc.yml` or `.taskrc.yaml`. Task will
-automatically look for directories containing files with these names in the
-following order with the highest priority first:
+Task will automatically look for directories containing configuration files in
+the following order with the highest priority first:
 
 - Current directory (or the one specified by the `--taskfile`/`--entrypoint`
   flags).
 - Each directory walking up the file tree from the current directory (or the one
   specified by the `--taskfile`/`--entrypoint` flags) until we reach the user's
   home directory or the root directory of that drive.
-- `$XDG_CONFIG_HOME/task`.
+- The users `$HOME` directory.
+- The `$XDG_CONFIG_HOME/task` directory.
+
+Config files in the current directory, its parent folders or home directory
+should be called `.taskrc.yml` or `.taskrc.yaml`. Config files in the
+`$XDG_CONFIG_HOME/task` directory are named the same way, but should not contain
+the `.` prefix.
 
 All config files will be merged together into a unified config, starting with
 the lowest priority file in `$XDG_CONFIG_HOME/task` with each subsequent file
@@ -36,7 +41,7 @@ overwriting the previous one if values are set.
 
 For example, given the following files:
 
-```yaml [$XDG_CONFIG_HOME/task/.taskrc.yml]
+```yaml [$XDG_CONFIG_HOME/task/taskrc.yml]
 # lowest priority global config
 option_1: foo
 option_2: foo


### PR DESCRIPTION
Fixes #2390 by changing the name of the `$XDG_CONFIG_HOME/task` config to `taskrc.yml` or `taskrc.yaml` (without the preceding `.`).

@vmaerten @panchoh w.r.t discussion in #2390, I'm not against `config.yml`, but after a bit of thinking I actually feel like ripgrep might have got this right. The naming consistency is valuable IMO. It lets you know that you're editing the same kind of file with the same schema and I think `$XDG_CONFIG_HOME/task/taskrc.yml` is the way to go. Happy to be outvoted on this though!

Once agreed and merged, I will open a PR to the schemastore repo.

---

Also the related discussion on Discord around the inclusion of the `$HOME` directory when running from a directory that does not have `$HOME` as a parent.

See updated docs for a full description.