### PR TITLE
docs: add `fzf-make` to "Community Integrations"

### DIFF
--- a/website/src/docs/integrations.md
+++ b/website/src/docs/integrations.md
@@ -82,6 +82,8 @@ developers who have created their own integrations for Task:
   [[source](https://github.com/lechuckroh/task-intellij-plugin)] by @lechuckroh
 - [mk](https://github.com/pycontribs/mk) command line tool recognizes Taskfiles
   natively.
+- [fzf-make](https://github.com/kyu08/fzf-make) fuzzy finder with preview window
+  for make, pnpm, yarn, just & task.
 
 If you have made something that integrates with Task, please feel free to open a
 PR to add it to this list.


### PR DESCRIPTION
<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->

Hi, thanks for maintaining such a cool project!
I'm building fuzzy finder with preview window for various task runner called [fzf-make](https://github.com/kyu08/fzf-make).

fzf-make became able to handle taskfile from previous release [v0.60.0](https://github.com/kyu08/fzf-make/releases/tag/v0.60.0)!

This is what you see when you execute `fzf-make` in `website` directory.
<img width="1677" height="1013" alt="image" src="https://github.com/user-attachments/assets/51ac47e0-9327-4c50-9bbc-8c53bd2e5172" />


So I added fzf-make to "Community Integrations".
Please let me know if this addition doesn't fit the context.

By the way, `task --list-all --json` is super useful for tool developers like me.