### PR TITLE
fix: globals vars are available in vars at root level

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -165,8 +165,7 @@ func run() error {
 	globals.Set("CLI_SILENT", ast.Var{Value: flags.Silent})
 	globals.Set("CLI_VERBOSE", ast.Var{Value: flags.Verbose})
 	globals.Set("CLI_OFFLINE", ast.Var{Value: flags.Offline})
-	e.Taskfile.Vars.Merge(globals, nil)
-
+	e.Taskfile.Vars.ReverseMerge(globals, nil)
 	if !flags.Watch {
 		e.InterceptInterruptSignals()
 	}


### PR DESCRIPTION
Fixes #2397
From @trulede :  
fixes #1580
fixes #1565 (probably)
fixes #2090 
fixes #1108

Global vars are currently added after Taskfile variables, making them unavailable. This PR applies a `ReverseMerge` so globals are added first, then Taskfile variables.