### PR TITLE
Fix var decode from empty map.

### DIFF
--- a/taskfile/ast/var.go
+++ b/taskfile/ast/var.go
@@ -18,7 +18,10 @@ type Var struct {
 func (v *Var) UnmarshalYAML(node *yaml.Node) error {
 	switch node.Kind {
 	case yaml.MappingNode:
-		key := node.Content[0].Value
+		key := "<none>"
+		if len(node.Content) > 0 {
+			key = node.Content[0].Value
+		}
 		switch key {
 		case "sh", "ref", "map":
 			var m struct {


### PR DESCRIPTION
Simple fix. The value `<none>` is in service of the error log message.

`err:  "<none>" is not a valid variable type. Try "sh", "ref", "map" or using a scalar value
`

fixes #2416 