### PR TITLE
Pass task vars to deferred tasks.

### DIFF
--- a/task.go
+++ b/task.go
@@ -211,7 +211,7 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 
 		for i := range t.Cmds {
 			if t.Cmds[i].Defer {
-				defer e.runDeferred(t, call, i, &deferredExitCode)
+				defer e.runDeferred(t, call, i, t.Vars, &deferredExitCode)
 				continue
 			}
 
@@ -278,17 +278,11 @@ func (e *Executor) runDeps(ctx context.Context, t *ast.Task) error {
 	return g.Wait()
 }
 
-func (e *Executor) runDeferred(t *ast.Task, call *Call, i int, deferredExitCode *uint8) {
+func (e *Executor) runDeferred(t *ast.Task, call *Call, i int, vars *ast.Vars, deferredExitCode *uint8) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	origTask, err := e.GetTask(call)
-	if err != nil {
-		return
-	}
-
 	cmd := t.Cmds[i]
-	vars, _ := e.Compiler.GetVariables(origTask, call)
 	cache := &templater.Cache{Vars: vars}
 	extra := map[string]any{}
 


### PR DESCRIPTION
A deferred task was recalculating vars which results in re-evaluation of _templated_ and _sh_ vars. This might not be desired in the case where values change with each evaluation; e.g. template function `randInt`.

This PR passes the task Vars to the deferred task, and removes the code which previously re-evaluated the vars. This works and I do not notice any point in the code where the task Vars would be mutilated (changed) so I did not use the DeepCopy() function of the Vars object when calling `runDeferred()`. I think this will be OK, but I would still review that part again.

fixes #2244 

