### PR TITLE
fix: search for all taskrc work as expected

### DIFF
--- a/taskrc/taskrc.go
+++ b/taskrc/taskrc.go
@@ -57,7 +57,11 @@ func GetConfig(dir string) (*ast.TaskRC, error) {
 	}
 
 	// Find all the nodes from the given directory up to the users home directory
-	entrypoints, err := fsext.SearchAll("", dir, defaultTaskRCs)
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+	entrypoints, err := fsext.SearchAll("", absDir, defaultTaskRCs)
 	if err != nil {
 		return nil, err
 	}
@@ -84,6 +88,5 @@ func GetConfig(dir string) (*ast.TaskRC, error) {
 		}
 		config.Merge(localConfig)
 	}
-
 	return config, nil
 }


### PR DESCRIPTION
Reading a `.taskrc.yml` in a parent folder does not work anymore. As the dir is not absolute, we cannot take the parent, so SearchAll stop at the first iteration.
