### PR TITLE
fix: fix message shown when a taskfile was not found

### DIFF
--- a/errors/errors_taskfile.go
+++ b/errors/errors_taskfile.go
@@ -11,14 +11,18 @@ import (
 // TaskfileNotFoundError is returned when no appropriate Taskfile is found when
 // searching the filesystem.
 type TaskfileNotFoundError struct {
-	URI  string
-	Walk bool
+	URI     string
+	Walk    bool
+	AskInit bool
 }
 
 func (err TaskfileNotFoundError) Error() string {
 	var walkText string
 	if err.Walk {
-		walkText = " (or any of the parent directories)"
+		walkText = " (or any of the parent directories)."
+	}
+	if err.AskInit {
+		walkText += " Run `task --init` to create a new Taskfile."
 	}
 	return fmt.Sprintf(`task: No Taskfile found at %q%s`, err.URI, walkText)
 }

--- a/setup.go
+++ b/setup.go
@@ -16,6 +16,7 @@ import (
 	"github.com/go-task/task/v3/internal/env"
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
+	"github.com/go-task/task/v3/internal/fsext"
 	"github.com/go-task/task/v3/internal/logger"
 	"github.com/go-task/task/v3/internal/output"
 	"github.com/go-task/task/v3/internal/version"
@@ -56,6 +57,13 @@ func (e *Executor) Setup() error {
 
 func (e *Executor) getRootNode() (taskfile.Node, error) {
 	node, err := taskfile.NewRootNode(e.Entrypoint, e.Dir, e.Insecure, e.Timeout)
+	if os.IsNotExist(err) {
+		return nil, errors.TaskfileNotFoundError{
+			URI:     fsext.DefaultDir(e.Entrypoint, e.Dir),
+			Walk:    true,
+			AskInit: true,
+		}
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Before this patch, a generic `file does not exist` is being shown, which is not useful enough.

We used to have a user-friendlier message in the past, but it probably was lost in the recent refactors.

Before:

```bash
$ task
file does not exist
```

After:

```bash
$ task
task: No Taskfile found at "/Users/andrey/Developer/repo" (or any of the parent directories). Run `task --init` to create a new Taskfile.
```