### PR TITLE
fix: a couple of fixes and improvements on `task --init`

### DIFF
--- a/taskfile/node_file.go
+++ b/taskfile/node_file.go
@@ -19,7 +19,7 @@ type FileNode struct {
 
 func NewFileNode(entrypoint, dir string, opts ...NodeOption) (*FileNode, error) {
 	// Find the entrypoint file
-	resolvedEntrypoint, err := fsext.Search(entrypoint, dir, defaultTaskfiles)
+	resolvedEntrypoint, err := fsext.Search(entrypoint, dir, DefaultTaskfiles)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, errors.TaskfileNotFoundError{URI: entrypoint, Walk: false}

--- a/taskfile/taskfile.go
+++ b/taskfile/taskfile.go
@@ -12,7 +12,8 @@ import (
 )
 
 var (
-	defaultTaskfiles = []string{
+	// DefaultTaskfiles is the list of Taskfile file names supported by default.
+	DefaultTaskfiles = []string{
 		"Taskfile.yml",
 		"taskfile.yml",
 		"Taskfile.yaml",
@@ -67,7 +68,7 @@ func RemoteExists(ctx context.Context, u url.URL) (*url.URL, error) {
 
 	// If the request was not successful, append the default Taskfile names to
 	// the URL and return the URL of the first successful request
-	for _, taskfile := range defaultTaskfiles {
+	for _, taskfile := range DefaultTaskfiles {
 		// Fixes a bug with JoinPath where a leading slash is not added to the
 		// path if it is empty
 		if u.Path == "" {

--- a/taskfile/templates/default.yml
+++ b/taskfile/templates/default.yml
@@ -1,12 +1,13 @@
-# https://taskfile.dev
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
 
 version: '3'
 
 vars:
-  GREETING: Hello, World!
+  GREETING: Hello, world!
 
 tasks:
   default:
+    desc: Print a greeting message
     cmds:
       - echo "{{.GREETING}}"
     silent: true

--- a/website/src/docs/getting-started.md
+++ b/website/src/docs/getting-started.md
@@ -43,6 +43,7 @@ vars:
 
 tasks:
   default:
+    desc: Print a greeting message
     cmds:
       - echo "{{.GREETING}}"
     silent: true
@@ -111,6 +112,7 @@ vars:
 
 tasks:
   default:
+    desc: Print a greeting message
     cmds:
       - echo "{{.GREETING}}"
     silent: true


### PR DESCRIPTION
* Fixed check for an existing Taskfile: look for all possibilities, and not only `Taskfile.yml` specifically.
* Added a description (`desc`) to the `default` task. Important to at lest `task --list` work by default (a core feature).
* ~Changed default extension from `.yml` to `.yaml`.~
* ~Added `yaml-language-server` comment.~
