### PR TITLE
fix: properly resolve remote entrypoints when including Taskfiles

### DIFF
--- a/taskfile/node.go
+++ b/taskfile/node.go
@@ -72,6 +72,16 @@ func NewNode(
 	return node, err
 }
 
+func isRemoteEntrypoint(entrypoint string) bool {
+	scheme, _ := getScheme(entrypoint)
+	switch scheme {
+	case "git", "http", "https":
+		return true
+	default:
+		return false
+	}
+}
+
 func getScheme(uri string) (string, error) {
 	u, err := giturls.Parse(uri)
 	if u == nil {

--- a/taskfile/node_file.go
+++ b/taskfile/node_file.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
@@ -51,10 +50,7 @@ func (node *FileNode) Read() ([]byte, error) {
 
 func (node *FileNode) ResolveEntrypoint(entrypoint string) (string, error) {
 	// If the file is remote, we don't need to resolve the path
-	if strings.Contains(entrypoint, "://") {
-		return entrypoint, nil
-	}
-	if strings.HasPrefix(entrypoint, "git") {
+	if isRemoteEntrypoint(entrypoint) {
 		return entrypoint, nil
 	}
 

--- a/taskfile/node_git.go
+++ b/taskfile/node_git.go
@@ -98,6 +98,11 @@ func (node *GitNode) ReadContext(_ context.Context) ([]byte, error) {
 }
 
 func (node *GitNode) ResolveEntrypoint(entrypoint string) (string, error) {
+	// If the file is remote, we don't need to resolve the path
+	if isRemoteEntrypoint(entrypoint) {
+		return entrypoint, nil
+	}
+
 	dir, _ := filepath.Split(node.path)
 	resolvedEntrypoint := fmt.Sprintf("%s//%s", node.url, filepath.Join(dir, entrypoint))
 	if node.ref != "" {

--- a/taskfile/node_git_test.go
+++ b/taskfile/node_git_test.go
@@ -21,6 +21,17 @@ func TestGitNode_ssh(t *testing.T) {
 	assert.Equal(t, "ssh://git@github.com/foo/bar.git//common.yml?ref=main", entrypoint)
 }
 
+func TestGitNode_sshWithAltRepo(t *testing.T) {
+	t.Parallel()
+
+	node, err := NewGitNode("git@github.com:foo/bar.git//Taskfile.yml?ref=main", "", false)
+	assert.NoError(t, err)
+
+	entrypoint, err := node.ResolveEntrypoint("git@github.com:foo/other.git//Taskfile.yml?ref=dev")
+	assert.NoError(t, err)
+	assert.Equal(t, "git@github.com:foo/other.git//Taskfile.yml?ref=dev", entrypoint)
+}
+
 func TestGitNode_sshWithDir(t *testing.T) {
 	t.Parallel()
 

--- a/taskfile/node_stdin.go
+++ b/taskfile/node_stdin.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
@@ -43,7 +42,7 @@ func (node *StdinNode) Read() ([]byte, error) {
 
 func (node *StdinNode) ResolveEntrypoint(entrypoint string) (string, error) {
 	// If the file is remote, we don't need to resolve the path
-	if strings.Contains(entrypoint, "://") {
+	if isRemoteEntrypoint(entrypoint) {
 		return entrypoint, nil
 	}
 


### PR DESCRIPTION
This MR fixes the `ResolveEntrypoint` methods for each of the Node types so that they consistently handle remote URI values.

Notes: 

- Not touching [`HTTPNode`](https://github.com/go-task/task/blob/67a02255b574a0f8bfbdbde5b7973c32d00b2302/taskfile/node_http.go#L90), because [`ResolveReference`](https://pkg.go.dev/net/url#URL.ResolveReference) already does the right thing:

  > If ref is an absolute URL, then ResolveReference ignores base and returns a copy of ref.

Fixes: #2437

### Before

```
TASK_X_REMOTE_TASKFILES=1 task --list --verbose --taskfile git@gist.github.com:b703b1d39811a14dd405d33b023075dd.git//Taskfile.yml
checking cache for "ssh://git@gist.github.com/b703b1d39811a14dd405d33b023075dd.git//Taskfile.yml" in ".task/remote/git.gist.github.com.Taskfile.yml.a63a8af6fbeb2e855727b010c68f11213d87b1405a2c7cba3898e974d7cc3925.yaml"
cache expired at 2025-09-22T06:23:02Z
downloading remote file: ssh://git@gist.github.com/b703b1d39811a14dd405d33b023075dd.git//Taskfile.yml
found remote file at "ssh://git@gist.github.com/b703b1d39811a14dd405d33b023075dd.git//Taskfile.yml"
caching "ssh://git@gist.github.com/b703b1d39811a14dd405d33b023075dd.git//Taskfile.yml" to ".task/remote/git.gist.github.com.Taskfile.yml.a63a8af6fbeb2e855727b010c68f11213d87b1405a2c7cba3898e974d7cc3925.yaml"
checking cache for "ssh://git@gist.github.com/b703b1d39811a14dd405d33b023075dd.git//git@gist.github.com:84af5ee983564bb42f1cc327a54e3139.git/Taskfile.yml" in ".task/remote/git.gist.github.com.git@gist.github.com:84af5ee983564bb42f1cc327a54e3139.git.Taskfile.yml.98e064eb9cd820ed9758fbdba39532701f95ab2638d4d89bdcfb49a9b33f1ba1.yaml"
no cache found
downloading remote file: ssh://git@gist.github.com/b703b1d39811a14dd405d33b023075dd.git//git@gist.github.com:84af5ee983564bb42f1cc327a54e3139.git/Taskfile.yml
file does not exist
```

### After

```
TASK_X_REMOTE_TASKFILES=1 /Users/sbaney/go/bin/task --list --verbose --taskfile git@gist.github.com:b703b1d39811a14dd405d33b023075dd.git//Taskfile.yml
checking cache for "ssh://git@gist.github.com/b703b1d39811a14dd405d33b023075dd.git//Taskfile.yml" in ".task/remote/git.gist.github.com.Taskfile.yml.a63a8af6fbeb2e855727b010c68f11213d87b1405a2c7cba3898e974d7cc3925.yaml"
cache expired at 2025-09-22T06:34:34Z
downloading remote file: ssh://git@gist.github.com/b703b1d39811a14dd405d33b023075dd.git//Taskfile.yml
found remote file at "ssh://git@gist.github.com/b703b1d39811a14dd405d33b023075dd.git//Taskfile.yml"
caching "ssh://git@gist.github.com/b703b1d39811a14dd405d33b023075dd.git//Taskfile.yml" to ".task/remote/git.gist.github.com.Taskfile.yml.a63a8af6fbeb2e855727b010c68f11213d87b1405a2c7cba3898e974d7cc3925.yaml"
checking cache for "ssh://git@gist.github.com/84af5ee983564bb42f1cc327a54e3139.git//Taskfile.yml" in ".task/remote/git.gist.github.com.Taskfile.yml.503af95376af030f1a9e899a5c704622c387198e6624d789d62d47b476b631ba.yaml"
cache expired at 2025-09-22T06:21:33Z
downloading remote file: ssh://git@gist.github.com/84af5ee983564bb42f1cc327a54e3139.git//Taskfile.yml
found remote file at "ssh://git@gist.github.com/84af5ee983564bb42f1cc327a54e3139.git//Taskfile.yml"
caching "ssh://git@gist.github.com/84af5ee983564bb42f1cc327a54e3139.git//Taskfile.yml" to ".task/remote/git.gist.github.com.Taskfile.yml.503af95376af030f1a9e899a5c704622c387198e6624d789d62d47b476b631ba.yaml"
checking cache for "ssh://git@github.com/go-task/examples.git//go-web-app/Taskfile.yml?ref=main" in ".task/remote/git.github.com.go-web-app.Taskfile.yml.f457482754778e7b9002a49aa34aaa1ce24b74d9b969109e6016bae1814d1446.yaml"
cache expired at 2025-09-22T06:21:36Z
downloading remote file: ssh://git@github.com/go-task/examples.git//go-web-app/Taskfile.yml?ref=main
checking cache for "ssh://git@github.com/go-task/task.git//website/Taskfile.yml?ref=main" in ".task/remote/git.github.com.website.Taskfile.yml.b9ca263cca8ded24b43a7000102e2b2ca5be8aed88d048802baf5b368d124cb8.yaml"
cache expired at 2025-09-22T06:21:36Z
downloading remote file: ssh://git@github.com/go-task/task.git//website/Taskfile.yml?ref=main
found remote file at "ssh://git@github.com/go-task/examples.git//go-web-app/Taskfile.yml?ref=main"
caching "ssh://git@github.com/go-task/examples.git//go-web-app/Taskfile.yml?ref=main" to ".task/remote/git.github.com.go-web-app.Taskfile.yml.f457482754778e7b9002a49aa34aaa1ce24b74d9b969109e6016bae1814d1446.yaml"
found remote file at "ssh://git@github.com/go-task/task.git//website/Taskfile.yml?ref=main"
caching "ssh://git@github.com/go-task/task.git//website/Taskfile.yml?ref=main" to ".task/remote/git.github.com.website.Taskfile.yml.b9ca263cca8ded24b43a7000102e2b2ca5be8aed88d048802baf5b368d124cb8.yaml"
task: Available tasks for this project:
* app:go:build:                  Build the web app
* app:go:clean:                  Clean every generated file
* app:go:css:                    Bundle CSS using esbuild
* app:go:default:                Build and run the web app      (aliases: app:go:run, app:go)
* app:go:js:                     Bundle JS using esbuild
* app:website:build:             Build website
* app:website:clean:             Clean temp directories
* app:website:default:           Start website      (aliases: app:website:s, app:website:start, app:website)
* app:website:deploy:next:       Build and deploy next.taskfile.dev
* app:website:deploy:prod:       Build and deploy taskfile.dev
* app:website:install:           Setup VitePress locally
* app:website:lint:              Lint website
* app:website:preview:           Preview Website      (aliases: app:website:serve)
```

