### PR TITLE
FIx calculation of task.Dir for tasks in included taskfiles.

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -91,17 +91,6 @@ func (c *Compiler) getVariables(t *ast.Task, call *Call, evaluateShVars bool) (*
 	rangeFunc := getRangeFunc(c.Dir)
 
 	var taskRangeFunc func(k string, v ast.Var) error
-	if t != nil {
-		// NOTE(@andreynering): We're manually joining these paths here because
-		// this is the raw task, not the compiled one.
-		cache := &templater.Cache{Vars: result}
-		dir := templater.Replace(t.Dir, cache)
-		if err := cache.Err(); err != nil {
-			return nil, err
-		}
-		dir = filepathext.SmartJoin(c.Dir, dir)
-		taskRangeFunc = getRangeFunc(dir)
-	}
 
 	for k, v := range c.TaskfileEnv.All() {
 		if err := rangeFunc(k, v); err != nil {
@@ -119,6 +108,22 @@ func (c *Compiler) getVariables(t *ast.Task, call *Call, evaluateShVars bool) (*
 				return nil, err
 			}
 		}
+
+		// NOTE: Calculate the task.Dir and taskRangeFunc here, after
+		// IncludeVars have been added to the templater. The call to SmartJoin()
+		// will then work as expected (i.e. when `dir` becomes an absolute path
+		// after the templater.Replace() call).
+		// NOTE: taskRangeFunc() will be available to subsequent calls
+		// in this function despite the convoluted code structure here.
+		cache := &templater.Cache{Vars: result}
+		dir := templater.Replace(t.Dir, cache)
+		t.Dir = filepathext.SmartJoin(t.IncludeDir, dir)
+		if err := cache.Err(); err != nil {
+			return nil, err
+		}
+		dir = filepathext.SmartJoin(c.Dir, dir)
+		taskRangeFunc = getRangeFunc(dir)
+
 		for k, v := range t.IncludedTaskfileVars.All() {
 			if err := taskRangeFunc(k, v); err != nil {
 				return nil, err

--- a/taskfile/ast/task.go
+++ b/taskfile/ast/task.go
@@ -44,6 +44,7 @@ type Task struct {
 	Location      *Location
 	// Populated during merging
 	Namespace            string
+	IncludeDir           string
 	IncludeVars          *Vars
 	IncludedTaskfileVars *Vars
 }

--- a/taskfile/ast/tasks.go
+++ b/taskfile/ast/tasks.go
@@ -11,7 +11,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/go-task/task/v3/errors"
-	"github.com/go-task/task/v3/internal/filepathext"
 	"github.com/go-task/task/v3/internal/sort"
 )
 
@@ -171,7 +170,7 @@ func (t1 *Tasks) Merge(t2 *Tasks, include *Include, includedTaskfileVars *Vars) 
 		}
 
 		if include.AdvancedImport {
-			task.Dir = filepathext.SmartJoin(include.Dir, task.Dir)
+			task.IncludeDir = include.Dir
 			if task.IncludeVars == nil {
 				task.IncludeVars = NewVars()
 			}


### PR DESCRIPTION
Relocate the calculation of an included tasks task.Dir until the templating is available. 

Previously, task.DIr would be calculated earlier which resulted in SmartJoin() incorrectly evaluating the second parameter, which had not been expanded (i.e. {{.FOO}}. To get correct behaviour, SmartJoin() needed to be called later, during compilation of the imported task, so that the second parameter could first be expanded, and then used correctly with SmartJoin().

fixes #2443