### PR TITLE
fix: make list tasks dry to avoid override checksum

### DIFF
--- a/help.go
+++ b/help.go
@@ -60,6 +60,7 @@ func (o ListOptions) Filters() []FilterFunc {
 // The function returns a boolean indicating whether tasks were found
 // and an error if one was encountered while preparing the output.
 func (e *Executor) ListTasks(o ListOptions) (bool, error) {
+	e.Dry = true
 	tasks, err := e.GetTaskList(o.Filters()...)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
When using `--json` option `--list-all` commands update checksum which is not desirable