### PR TITLE
docs: add reference to slim-sprig in the templating page

### DIFF
--- a/website/src/docs/reference/templating.md
+++ b/website/src/docs/reference/templating.md
@@ -11,7 +11,8 @@ outline: deep
 Task's templating engine uses Go's
 [text/template](https://pkg.go.dev/text/template) package to interpolate values.
 This reference covers the main features and all available functions for creating
-dynamic Taskfiles.
+dynamic Taskfiles. Most of the provided functions come from the 
+[slim-sprig](https://sprig.taskfile.dev/) library.
 
 ## Basic Usage
 


### PR DESCRIPTION
As a new user of `task` I had some trouble finding all the available template functions and info or examples on how to use them. This improved significantly when I dove into the `task`'s source code and found out that it's using sprig with it's own docs, which are little more helpful than templating.md.

I do understand that some more functions are added by task itself, so I tried to adjust the wording accordingly (`Most of the ...`). 

The part that says `covers all available functions` is actually a little confusing, not all are covered, but the sprig link will help a lot anyways and I want to keep the change minimal.