### PR TITLE
feat: Command timeouts

### DIFF
--- a/task.go
+++ b/task.go
@@ -307,6 +307,13 @@ func (e *Executor) runDeferred(t *ast.Task, call *Call, i int, deferredExitCode 
 func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i int) error {
 	cmd := t.Cmds[i]
 
+	// Apply command timeout if specified
+	if cmd.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cmd.Timeout)
+		defer cancel()
+	}
+
 	switch {
 	case cmd.Task != "":
 		reacquire := e.releaseConcurrencyLimit()
@@ -354,6 +361,9 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 		})
 		if closeErr := closer(err); closeErr != nil {
 			e.Logger.Errf(logger.Red, "task: unable to close writer: %v\n", closeErr)
+		}
+		if err != nil && ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("task: [%s] command timeout exceeded (%s): %w", t.Name(), cmd.Timeout, err)
 		}
 		var exitCode interp.ExitStatus
 		if errors.As(err, &exitCode) && cmd.IgnoreError {

--- a/testdata/timeout/Taskfile.yml
+++ b/testdata/timeout/Taskfile.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+tasks:
+  timeout-exceeded:
+    desc: Command that should timeout
+    cmds:
+      - cmd: sleep 10
+        timeout: 1s
+
+  timeout-not-exceeded:
+    desc: Command that completes within timeout
+    cmds:
+      - cmd: echo "quick command"
+        timeout: 5s
+
+  no-timeout:
+    desc: Command with no timeout specified
+    cmds:
+      - echo "no timeout"
+
+  multiple-cmds-timeout:
+    desc: Multiple commands with different timeouts
+    cmds:
+      - cmd: echo "first"
+        timeout: 1s
+      - cmd: sleep 10
+        timeout: 1s
+      - cmd: echo "third"
+        timeout: 1s

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -693,6 +693,7 @@ tasks:
         platforms: [linux, darwin]
         set: [errexit]
         shopt: [globstar]
+        timeout: 5m
 ```
 
 ### Task References
@@ -787,6 +788,35 @@ tasks:
         vars:
           SERVICE: '{{.ITEM}}'
 ```
+
+## Command Properties
+
+### `timeout`
+
+- **Type**: `string`
+- **Description**: Maximum duration a command can run before being
+  terminated. Uses Go duration syntax.
+- **Examples**: `"30s"`, `"5m"`, `"1h30m"`
+
+```yaml
+tasks:
+  deploy:
+    cmds:
+      # Build step with 5 minute timeout
+      - cmd: npm run build
+        timeout: 5m
+
+      # Deploy with 30 minute timeout
+      - cmd: ./deploy.sh
+        timeout: 30m
+
+      # Quick health check with 10 second timeout
+      - cmd: curl -f https://api.example.com/health
+        timeout: 10s
+```
+
+Commands that exceed their timeout will be terminated and return an error,
+preventing indefinite hangs in task pipelines.
 
 ## Shell Options
 

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -361,6 +361,10 @@
         "platforms": {
           "description": "Specifies which platforms the command should be run on.",
           "$ref": "#/definitions/platforms"
+        },
+        "timeout": {
+          "description": "Maximum duration the command is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -421,6 +425,10 @@
         "platforms": {
           "description": "Specifies which platforms the command should be run on.",
           "$ref": "#/definitions/platforms"
+        },
+        "timeout": {
+          "description": "Maximum duration the command is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
+          "type": "string"
         }
       },
       "oneOf": [{ "required": ["cmd"] }, { "required": ["task"] }],


### PR DESCRIPTION
## Summary

Add command-level timeout support to prevent commands from hanging indefinitely in task pipelines.

Closes #1569

## Usage

```yaml
version: '3'

tasks:
  deploy:
    cmds:
      - cmd: npm run build
        timeout: 5m

      - cmd: ./deploy.sh
        timeout: 30m
```

Commands exceeding their timeout are terminated:

```
task: Failed to run task "deploy": task: [deploy] command timeout exceeded (5m): context deadline exceeded
```

Implementation Details

- Timeout applies per command, not per task
- Works with both shell commands and task calls
- Deferred commands use separate context and run even if parent times out
- ignore_error flag does not suppress timeout errors
- Zero/unspecified timeout maintains current behavior (no timeout)
