### PR TITLE
docs: add tasks.task.dir

### DIFF
--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -614,6 +614,21 @@ tasks:
       - ./deploy.sh
 ```
 
+### `dir`
+
+- **Type**: `string`
+- **Description**: The directory in which this task should run
+- **Default**: If the task is in the root Taskfile, the default `dir` is
+  `ROOT_DIR`. For included Taskfiles, the default `dir` is the value specified in
+  their respective `includes.*.dir` field (if any).
+
+```yaml
+tasks:
+  current-dir:
+    dir: '{{.USER_WORKING_DIR}}'
+    cmd: pwd
+```
+
 #### `requires`
 
 - **Type**: `Requires`


### PR DESCRIPTION
This PR documents the `dir` property at the task level.

Maybe should I add a default value? I was thinking about `ROOT_DIR` or `{{.ROOT_DIR}}` or "the location of the root Taskfile" but couldn't find anything suitable. Let me know if you want one.

Closes #2481