### PR TITLE
fix: RPM upload for Cloudsmith

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,7 +69,7 @@ nfpms:
       - deb
       - rpm
       - apk
-    file_name_template: '{{.ProjectName}}_{{.Os}}_{{.Arch}}'
+    file_name_template: '{{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}'
     contents:
       - src: completion/bash/task.bash
         dst: /etc/bash_completion.d/task
@@ -167,6 +167,6 @@ cloudsmiths:
       rpm:
         - "any-distro/any-version"
       alpine:
-        - "alpine/any-version"
+        - "any-distro/any-version"
     component: main
     republish: true


### PR DESCRIPTION
For the last two release, the RPM packages has not been uploaded to Cloudsmith. It seems, based on the error, that the filename must be unique.

Error : 
```
This package synchronization failed or was canceled while  Adding Package to Repository. Reason given: A package file with filename 'task_linux_arm64.rpm' and remote_path 'rpm/any-distro/any-version/aarch64/task_linux_arm64.rpm' already exists in the 'task_linux_arm64rpm-cn0z' package - This package should be deleted.
```


I've added the version in the filename