### PR TITLE
Adjust when_changed to work with imported tasks.

### DIFF
--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -20,5 +20,5 @@ func Name(t *ast.Task) (string, error) {
 
 func Hash(t *ast.Task) (string, error) {
 	h, err := hashstructure.Hash(t, hashstructure.FormatV2, nil)
-	return fmt.Sprintf("%s:%d", t.Task, h), err
+	return fmt.Sprintf("%s:%s:%d", t.Location.Taskfile, t.LocalName(), h), err
 }

--- a/task_test.go
+++ b/task_test.go
@@ -1851,6 +1851,29 @@ func TestRunOnceSharedDeps(t *testing.T) {
 	assert.Contains(t, buff.String(), `task: [service-b:build] echo "build b"`)
 }
 
+func TestRunWhenChanged(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/run_when_changed"
+
+	var buff bytes.Buffer
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithForceAll(true),
+		task.WithSilent(true),
+	)
+	require.NoError(t, e.Setup())
+	require.NoError(t, e.Run(t.Context(), &task.Call{Task: "start"}))
+	expectedOutputOrder := strings.TrimSpace(`
+login server=fubar user=fubar
+login server=foo user=foo
+login server=bar user=bar
+`)
+	assert.Contains(t, buff.String(), expectedOutputOrder)
+}
+
 func TestDeferredCmds(t *testing.T) {
 	t.Parallel()
 

--- a/taskfile/ast/task.go
+++ b/taskfile/ast/task.go
@@ -13,7 +13,7 @@ import (
 
 // Task represents a task
 type Task struct {
-	Task          string
+	Task          string `hash:"ignore"`
 	Cmds          []*Cmd
 	Deps          []*Dep
 	Label         string
@@ -36,18 +36,18 @@ type Task struct {
 	Interactive   bool
 	Internal      bool
 	Method        string
-	Prefix        string
+	Prefix        string `hash:"ignore"`
 	IgnoreError   bool
 	Run           string
 	Platforms     []*Platform
 	Watch         bool
 	Location      *Location
 	// Populated during merging
-	Namespace            string
+	Namespace            string `hash:"ignore"`
 	IncludeVars          *Vars
 	IncludedTaskfileVars *Vars
 
-	FullName string
+	FullName string `hash:"ignore"`
 }
 
 func (t *Task) Name() string {

--- a/testdata/run_when_changed/Taskfile.yml
+++ b/testdata/run_when_changed/Taskfile.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+includes:
+  service-a: ./service-a
+  service-b: ./service-b
+
+tasks:
+  start:
+    cmds:
+      - task: service-a:start
+      - task: service-b:start

--- a/testdata/run_when_changed/library/Taskfile.yml
+++ b/testdata/run_when_changed/library/Taskfile.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+tasks:
+  login:
+    run: when_changed
+    cmds:
+      - echo "login server={{.SERVER}} user={{.USER}}"

--- a/testdata/run_when_changed/service-a/Taskfile.yml
+++ b/testdata/run_when_changed/service-a/Taskfile.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+includes:
+  library:
+    taskfile: ../library/Taskfile.yml
+    dir: ../library
+
+tasks:
+  start:
+    cmds:
+      - task: library:login
+        vars:
+          SERVER: fubar
+          USER: fubar
+      - task: library:login
+        vars:
+          SERVER: foo
+          USER: foo

--- a/testdata/run_when_changed/service-b/Taskfile.yml
+++ b/testdata/run_when_changed/service-b/Taskfile.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+includes:
+  library:
+    taskfile: ../library/Taskfile.yml
+    dir: ../library
+
+tasks:
+  start:
+    cmds:
+      - task: library:login
+        vars:
+          SERVER: fubar
+          USER: fubar
+      - task: library:login
+        vars:
+          SERVER: bar
+          USER: bar


### PR DESCRIPTION
This PR adjusts the `when_changed` behaviour to work more effectively with imported tasks, with reasoning similar to that behind PR #1655. A task imported several times with `when_changed` probably should only be run once per "variable set" regardless of how many times that task is imported (by other taskfiles).

I'm not certain if this change is the correct behaviour, it could be that this use case also represents a new `run` condition.

Fixes #2508 