### PR TITLE
fix: corrected substr templating example in docs (#2517)

### DIFF
--- a/website/src/docs/reference/templating.md
+++ b/website/src/docs/reference/templating.md
@@ -434,7 +434,7 @@ tasks:
       - echo "{{.MESSAGE | lower}}"         # "hello world"
       - echo "{{.NAME | trunc 4}}"          # "john"
       - echo "{{"test" | repeat 3}}"        # "testtesttest"
-      - echo "{{substr .TEXT 0 5}}"      # "Hello"
+      - echo "{{.TEXT | substr 0 5}}"       # "Hello"
 ```
 
 #### String Testing and Searching


### PR DESCRIPTION
Fixes #2517, I used the solution that best matched the other examples.

To test it, I ran the website locally and verified that the change propagated, then copied that to a taskfile and ran it.  The output for that command was "Hello" as expected.

I looked through the page for any similar errors and didn't find any.