### PR TITLE
Package API: Support in-memory taskfile nodes with task.Executor.

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -57,8 +57,10 @@ type (
 		Stdout io.Writer
 		Stderr io.Writer
 
+		// Taskfile
+		Taskfile *ast.Taskfile
+
 		// Internal
-		Taskfile           *ast.Taskfile
 		Logger             *logger.Logger
 		Compiler           *Compiler
 		Output             output.Output
@@ -91,6 +93,7 @@ func NewExecutor(opts ...ExecutorOption) *Executor {
 		Stdin:                os.Stdin,
 		Stdout:               os.Stdout,
 		Stderr:               os.Stderr,
+		Taskfile:             nil,
 		Logger:               nil,
 		Compiler:             nil,
 		Output:               nil,
@@ -559,4 +562,17 @@ type failfastOption struct {
 
 func (o *failfastOption) ApplyToExecutor(e *Executor) {
 	e.Failfast = o.failfast
+}
+
+// WithTaskfile set the [Executor]'s Taskfile to the provided [ast.Taskfile].
+func WithTaskfile(taskfile *ast.Taskfile) ExecutorOption {
+	return &taskfileOption{taskfile}
+}
+
+type taskfileOption struct {
+	taskfile *ast.Taskfile
+}
+
+func (o *taskfileOption) ApplyToExecutor(e *Executor) {
+	e.Taskfile = o.taskfile
 }

--- a/setup.go
+++ b/setup.go
@@ -26,15 +26,17 @@ import (
 
 func (e *Executor) Setup() error {
 	e.setupLogger()
-	node, err := e.getRootNode()
-	if err != nil {
-		return err
-	}
 	if err := e.setupTempDir(); err != nil {
 		return err
 	}
-	if err := e.readTaskfile(node); err != nil {
-		return err
+	if e.Taskfile == nil {
+		node, err := e.getRootNode()
+		if err != nil {
+			return err
+		}
+		if err := e.readTaskfile(node); err != nil {
+			return err
+		}
 	}
 	e.setupStdFiles()
 	if err := e.setupOutput(); err != nil {

--- a/taskfile/node_byte.go
+++ b/taskfile/node_byte.go
@@ -1,0 +1,49 @@
+package taskfile
+
+import (
+	"github.com/go-task/task/v3/internal/execext"
+	"github.com/go-task/task/v3/internal/filepathext"
+)
+
+// A ByteNode is a node that reads a taskfile direct from a []byte object.
+type ByteNode struct {
+	*baseNode
+	data []byte
+}
+
+func NewByteNode(data []byte, dir string) (*ByteNode, error) {
+	return &ByteNode{
+		baseNode: NewBaseNode(dir),
+		data:     data,
+	}, nil
+}
+
+func (node *ByteNode) Location() string {
+	return "__bytes__"
+}
+
+func (node *ByteNode) Remote() bool {
+	return true
+}
+
+func (node *ByteNode) Read() ([]byte, error) {
+	return node.data, nil
+}
+
+func (node *ByteNode) ResolveEntrypoint(entrypoint string) (string, error) {
+	// A ByteNode has no presence on the local file system.
+	return entrypoint, nil
+}
+
+func (node *ByteNode) ResolveDir(dir string) (string, error) {
+	path, err := execext.ExpandLiteral(dir)
+	if err != nil {
+		return "", err
+	}
+
+	if filepathext.IsAbs(path) {
+		return path, nil
+	}
+
+	return filepathext.SmartJoin(node.Dir(), path), nil
+}

--- a/taskfile/node_byte_test.go
+++ b/taskfile/node_byte_test.go
@@ -1,0 +1,25 @@
+package taskfile
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+//go:embed testdata/node_byte_taskfile.yaml
+var taskfileYamlBytes []byte
+
+func TestByteNode(t *testing.T) {
+	t.Parallel()
+	workingDir := t.TempDir()
+
+	node, err := NewByteNode(taskfileYamlBytes, workingDir)
+	assert.NoError(t, err)
+	assert.Equal(t, "__bytes__", node.Location())
+	assert.Equal(t, workingDir, node.Dir())
+	assert.True(t, node.Remote())
+	data, err := node.Read()
+	assert.NoError(t, err)
+	assert.Equal(t, taskfileYamlBytes, data)
+}

--- a/taskfile/testdata/node_byte_taskfile.yaml
+++ b/taskfile/testdata/node_byte_taskfile.yaml
@@ -1,0 +1,10 @@
+version: '3'
+
+vars:
+  GREETING: Hello, World!
+
+tasks:
+  default:
+    cmds:
+      - echo "{{.GREETING}}"
+    silent: true

--- a/testdata/with_taskfile/build/Taskfile.yml
+++ b/testdata/with_taskfile/build/Taskfile.yml
@@ -1,0 +1,6 @@
+version: "3"
+
+tasks:
+  default:
+    cmds:
+      - echo "Fubar"

--- a/testdata/with_taskfile/build/testdata/TestWithTaskfile-WithTaskfile_build.golden
+++ b/testdata/with_taskfile/build/testdata/TestWithTaskfile-WithTaskfile_build.golden
@@ -1,0 +1,1 @@
+task: [default] echo "Fubar"

--- a/testdata/with_taskfile/run/testdata/TestWithTaskfile-WithTaskfile_run.golden
+++ b/testdata/with_taskfile/run/testdata/TestWithTaskfile-WithTaskfile_run.golden
@@ -1,0 +1,2 @@
+task: [default] echo "Fubar"
+Fubar


### PR DESCRIPTION
When using the Package API, make it possible to create taskfile objects from []byte/memory objects (i.e. raw unparsed YAML data).

This use case only exists when using the Package API. Its behaviour/operation is similar to `NodeStdin`.