### PR TITLE
fix: allow application/octet-stream for a Remote taskfile

### DIFF
--- a/taskfile/taskfile.go
+++ b/taskfile/taskfile.go
@@ -28,6 +28,7 @@ var (
 		"text/x-yaml",
 		"application/yaml",
 		"application/x-yaml",
+		"application/octet-stream",
 	}
 )
 


### PR DESCRIPTION
fixes https://github.com/go-task/task/issues/1944