### PR TITLE
When importing a Taskfile, apply that Taskfiles global Run to all imported Tasks (if not set).

### DIFF
--- a/taskfile/ast/taskfile.go
+++ b/taskfile/ast/taskfile.go
@@ -61,6 +61,11 @@ func (t1 *Taskfile) Merge(t2 *Taskfile, include *Include) error {
 	}
 	t1.Vars.Merge(t2.Vars, include)
 	t1.Env.Merge(t2.Env, include)
+	if t2.Run != "" {
+		for _, v := range t2.Tasks.All(nil) {
+			v.Run = t2.Run
+		}
+	}
 	return t1.Tasks.Merge(t2.Tasks, include, t1.Vars)
 }
 

--- a/taskfile/ast/taskfile.go
+++ b/taskfile/ast/taskfile.go
@@ -62,8 +62,13 @@ func (t1 *Taskfile) Merge(t2 *Taskfile, include *Include) error {
 	t1.Vars.Merge(t2.Vars, include)
 	t1.Env.Merge(t2.Env, include)
 	if t2.Run != "" {
+		// Apply t2.Run to all t2.Tasks (if not explicitly set). This
+		// ensures the global `Run` of the imported/merged taskfile is
+		// retained for those tasks.
 		for _, v := range t2.Tasks.All(nil) {
-			v.Run = t2.Run
+			if v.Run == "" {
+				v.Run = t2.Run
+			}
 		}
 	}
 	return t1.Tasks.Merge(t2.Tasks, include, t1.Vars)


### PR DESCRIPTION
It seems reasonable, that if a Taskfile is designed with the global Run property assigned, then it should probably be retained if that Taskfile is imported.

It could be that the logic in 
```
func (e *Executor) GetHash(t *ast.Task) (string, error) {
	r := cmp.Or(t.Run, e.Taskfile.Run)
```
should be revised to match; which is to suggest that task.Run should be set for the importing Taskfile too (and e.Taskfile.Run removed from the above logic).

fixes #1738