### PR TITLE
ci(release): switch to npm trusted publishers with OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-      -
 
 permissions:
   id-token: write  # Required for OIDC


### PR DESCRIPTION
# Summary 

npm is deprecating legacy access tokens on **December 9th, 2025**. This PR migrates to https://docs.npmjs.com/trusted-publishers, which use OIDC (OpenID Connect) for authentication. (https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/)

## Benefits:
  - No more long-lived secrets to manage
  - Short-lived, workflow-scoped tokens
  - Cryptographically verified publishing origin