### PR TITLE
fix: support error_ignore for a task call

### DIFF
--- a/task.go
+++ b/task.go
@@ -307,10 +307,12 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 		defer reacquire()
 
 		err := e.RunTask(ctx, &Call{Task: cmd.Task, Vars: cmd.Vars, Silent: cmd.Silent, Indirect: true})
-		if err != nil {
-			return err
+		var exitCode interp.ExitStatus
+		if errors.As(err, &exitCode) && cmd.IgnoreError {
+			e.Logger.VerboseErrf(logger.Yellow, "task: [%s] task error ignored: %v\n", t.Name(), err)
+			return nil
 		}
-		return nil
+		return err
 	case cmd.Cmd != "":
 		if !shouldRunOnCurrentPlatform(cmd.Platforms) {
 			e.Logger.VerboseOutf(logger.Yellow, "task: [%s] %s not for current platform - ignored\n", t.Name(), cmd.Cmd)

--- a/taskfile/ast/cmd.go
+++ b/taskfile/ast/cmd.go
@@ -93,6 +93,7 @@ func (c *Cmd) UnmarshalYAML(node *yaml.Node) error {
 			c.Vars = cmdStruct.Vars
 			c.For = cmdStruct.For
 			c.Silent = cmdStruct.Silent
+			c.IgnoreError = cmdStruct.IgnoreError
 			return nil
 		}
 


### PR DESCRIPTION
Support task calls with ignore_error.
* Parse `ignore_error` into the cmd object for task calls.
* Handle the error condition after a task call, ignoring if `error_ignore` was set.

fixes #363

Example task definition
```yaml
version: "3"

tasks:
  bad:
    cmds:
      - exit 1
  default:
    cmds:
      - task: bad
        ignore_error: true
      - echo hello
```



