### PR TITLE
fix: always run a watch task regardless of run setting.

### DIFF
--- a/task.go
+++ b/task.go
@@ -366,7 +366,7 @@ func (e *Executor) startExecution(ctx context.Context, t *ast.Task, execute func
 		return err
 	}
 
-	if h == "" {
+	if h == "" || t.Watch {
 		return execute(ctx)
 	}
 


### PR DESCRIPTION
A task will not run (once or when_changed) if its hash is "known". Therefore, a watch task where `run` is configured, will never start.

In this PR, the check of task hash is extended to consider if watch is configured/requested.

fixes #1388 


<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->
