### PR TITLE
Enable ANSI escape code handling on windows consoles.

### DIFF
--- a/cmd/task/console_win.go
+++ b/cmd/task/console_win.go
@@ -14,9 +14,11 @@ func init() {
 	// Ensure that Windows console handles ANSI escape-codes correctly.
 	if runtime.GOOS == "windows" {
 		stdout := windows.Handle(os.Stdout.Fd())
-		var originalMode uint32
-		if err := windows.GetConsoleMode(stdout, &originalMode); err == nil {
-			windows.SetConsoleMode(stdout, originalMode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+		if stdout != 0 {
+			var originalMode uint32
+			if err := windows.GetConsoleMode(stdout, &originalMode); err == nil {
+				windows.SetConsoleMode(stdout, originalMode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Enable ANSI escape code handling on windows consoles.

fixes #2076 


This sets the windows terminal so that it handles ANSI codes (esp color). Under some circumstances (not known) a windows console may be in a mode where it does not process ANSI codes, as a result task output (color=true _or_ false) will show escape sequences:

```
C:\Users\trule\Desktop>task
←[31mtask: No Taskfile found at ""
←[0m
```

This PR pushes the terminal into the correct mode (ENABLE_VIRTUAL_TERMINAL_PROCESSING).

