### PR TITLE
feat: expose .CLI_ASSUME_YES templating variable

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -182,6 +182,7 @@ func run() error {
 	globals.Set("CLI_SILENT", ast.Var{Value: flags.Silent})
 	globals.Set("CLI_VERBOSE", ast.Var{Value: flags.Verbose})
 	globals.Set("CLI_OFFLINE", ast.Var{Value: flags.Offline})
+	globals.Set("CLI_ASSUME_YES", ast.Var{Value: flags.AssumeYes})
 	e.Taskfile.Vars.ReverseMerge(globals, nil)
 	if !flags.Watch {
 		e.InterceptInterruptSignals()

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -13,7 +12,6 @@ import (
 	"github.com/go-task/task/v3"
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/experiments"
-	"github.com/go-task/task/v3/internal/env"
 	"github.com/go-task/task/v3/internal/sort"
 	"github.com/go-task/task/v3/taskfile/ast"
 	"github.com/go-task/task/v3/taskrc"
@@ -165,13 +163,6 @@ func init() {
 		pflag.DurationVar(&CacheExpiryDuration, "expiry", getConfig(config, func() *time.Duration { return config.Remote.CacheExpiry }, 0), "Expiry duration for cached remote Taskfiles.")
 	}
 	pflag.Parse()
-
-	// If the "--yes" flag was not explicitly set in the CLI arguments, check the "TASK_ASSUME_YES" environment variable to override the option.
-	if !pflag.Lookup("yes").Changed {
-		if v, err := strconv.ParseBool(env.GetTaskEnv("ASSUME_YES")); err == nil {
-			AssumeYes = v
-		}
-	}
 }
 
 func Validate() error {

--- a/website/src/docs/reference/templating.md
+++ b/website/src/docs/reference/templating.md
@@ -172,6 +172,11 @@ tasks:
 - **Type**: `bool`
 - **Description**: Whether `--offline` flag was set
 
+#### `CLI_ASSUME_YES`
+
+- **Type**: `bool`
+- **Description**: Whether `--yes` flag was set
+
 ### Task
 
 #### `TASK`


### PR DESCRIPTION
This PR exposes the state of the `--yes` (or `-y`) CLI flag as a global templating variable named `.CLI_ASSUME_YES`.

This allows users to conditionally execute logic in their Taskfiles based on whether the user has confirmed prompts via the CLI flag.

see: #2479

**Example:**

```yaml
tasks:
  example:
    cmds:
      - >
        {{if .CLI_ASSUME_YES}}
        echo "Assume yes is true"
        {{else}}
        echo "Assume yes is false"
        {{end}}
```

**Changes:**

- Added `.CLI_ASSUME_YES` to the global variables in `cmd/task/task.go`
- Documented the new variable in `website/src/docs/reference/templating.md`
