### PR TITLE
chore(ci): add on-demand PR build workflow

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,69 @@
+name: PR Build
+
+on:
+  pull_request_target:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build:
+    if: contains(github.event.pull_request.labels.*.name, 'needs-build')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.x'
+          cache: true
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --snapshot --clean --config .goreleaser-pr.yml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: task_linux_amd64
+          path: dist/task_linux_amd64.tar.gz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: task_linux_arm64
+          path: dist/task_linux_arm64.tar.gz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: task_darwin_amd64
+          path: dist/task_darwin_amd64.tar.gz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: task_darwin_arm64
+          path: dist/task_darwin_arm64.tar.gz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: task_windows_amd64
+          path: dist/task_windows_amd64.zip
+      - uses: actions/upload-artifact@v4
+        with:
+          name: checksums
+          path: dist/task_checksums.txt
+      - uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          token: ${{ secrets.GH_PAT || github.token }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: '📦 Build artifacts ready!'
+      - uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GH_PAT || github.token }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ## 📦 Build artifacts ready!
+
+            Download binaries from [this workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+            Available platforms: Linux, macOS, Windows (amd64, arm64)
+          edit-mode: replace

--- a/.goreleaser-pr.yml
+++ b/.goreleaser-pr.yml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+builds:
+  - binary: task
+    main: ./cmd/task
+    goos: [windows, darwin, linux]
+    goarch: [amd64, arm64]
+    env:
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w"
+
+archives:
+  - name_template: '{{.Binary}}_{{.Os}}_{{.Arch}}'
+    files:
+      - README.md
+      - LICENSE
+      - completion/**/*
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+snapshot:
+  version_template: 'pr-{{ .ShortCommit }}'
+
+checksum:
+  name_template: 'task_checksums.txt'


### PR DESCRIPTION
  # Summary

  Similar to our nightly builds, but for PRs!

  Currently, testing a PR requires having Go installed locally to build from source. This makes it harder for users to help test fixes or new features before they're merged.

  This adds a workflow that builds binaries on-demand when a maintainer adds the `needs-build` label to a PR. Binaries are uploaded as artifacts and a comment is posted with the download link.

This will uses our `task-bot`.

This [PR](https://github.com/go-task/task/pull/2570) could benefits this feature

> [!NOTE]
> The label is `needs-build` but it can be modified. We can also use somesthing like a comment but it's harder to detect 

## Example: 

<img width="844" height="231" alt="image" src="https://github.com/user-attachments/assets/47dd41ee-11d8-4ea6-b787-ea9bb1a78abe" />
