### PR TITLE
Fix Taskfile not found error handling

### DIFF
--- a/errors/errors_taskfile.go
+++ b/errors/errors_taskfile.go
@@ -11,18 +11,14 @@ import (
 // TaskfileNotFoundError is returned when no appropriate Taskfile is found when
 // searching the filesystem.
 type TaskfileNotFoundError struct {
-	URI     string
-	Walk    bool
-	AskInit bool
+	URI  string
+	Walk bool
 }
 
 func (err TaskfileNotFoundError) Error() string {
 	var walkText string
 	if err.Walk {
 		walkText = " (or any of the parent directories)."
-	}
-	if err.AskInit {
-		walkText += " Run `task --init` to create a new Taskfile."
 	}
 	return fmt.Sprintf(`task: No Taskfile found at %q%s`, err.URI, walkText)
 }

--- a/internal/fsext/fs.go
+++ b/internal/fsext/fs.go
@@ -49,6 +49,24 @@ func ResolveDir(entrypoint, resolvedEntrypoint, dir string) (string, error) {
 	return filepath.Dir(resolvedEntrypoint), nil
 }
 
+// GetSearchPath returns the absolute path to search for the entrypoint. If the
+// entrypoint is set, it returns the absolute path to the entrypoint. If the dir
+// is set, it returns the absolute path to the dir. If both are empty, it returns
+// the current working directory.
+func GetSearchPath(entrypoint, dir string) (string, error) {
+	if entrypoint != "" {
+		return filepath.Abs(entrypoint)
+	}
+	if dir != "" {
+		return filepath.Abs(dir)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return wd, nil
+}
+
 // Search looks for files with the given possible filenames using the given
 // entrypoint and directory. If the entrypoint is set, it checks if the
 // entrypoint matches a file or if it matches a directory containing one of the

--- a/internal/fsext/fs_test.go
+++ b/internal/fsext/fs_test.go
@@ -59,6 +59,78 @@ func TestDefaultDir(t *testing.T) {
 	}
 }
 
+func TestGetSearchPath(t *testing.T) {
+	t.Parallel()
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name         string
+		entrypoint   string
+		dir          string
+		expectedPath string
+	}{
+		{
+			name:         "return absolute entrypoint if only absolute entrypoint is set",
+			entrypoint:   "/dir/to/Taskfile.yml",
+			dir:          "",
+			expectedPath: "/dir/to/Taskfile.yml",
+		},
+		{
+			name:         "return absolute path of entrypoint if only relative entrypoint is set",
+			entrypoint:   "./dir/to/Taskfile.yml",
+			dir:          "",
+			expectedPath: filepath.Join(wd, "dir", "to", "Taskfile.yml"),
+		},
+		{
+			name:         "return absolute dir if only absolute dir is set",
+			entrypoint:   "",
+			dir:          "/dir/to",
+			expectedPath: "/dir/to",
+		},
+		{
+			name:         "return absolute path of dir if only relative dir is set",
+			entrypoint:   "",
+			dir:          "./dir/to",
+			expectedPath: filepath.Join(wd, "dir", "to"),
+		},
+		{
+			name:         "return absolute entrypoint if both absolute entrypoint and dir are set",
+			entrypoint:   "/dir/to/another/Taskfile.yml",
+			dir:          "/dir/to",
+			expectedPath: "/dir/to/another/Taskfile.yml",
+		},
+		{
+			name:         "return absolute path of entrypoint if both relative entrypoint and dir are set",
+			entrypoint:   "./dir/to/another/Taskfile.yml",
+			dir:          "./dir/to",
+			expectedPath: filepath.Join(wd, "dir", "to", "another", "Taskfile.yml"),
+		},
+		{
+			name:         "return absolute path of entrypoint if relative entrypoint and absolute dir are set",
+			entrypoint:   "./dir/to/another/Taskfile.yml",
+			dir:          "/dir/to",
+			expectedPath: filepath.Join(wd, "dir", "to", "another", "Taskfile.yml"),
+		},
+		{
+			name:         "return working directory if both are empty",
+			entrypoint:   "",
+			dir:          "",
+			expectedPath: wd,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path, err := GetSearchPath(tt.entrypoint, tt.dir)
+			require.NoError(t, err)
+			require.Equal(t, tt.expectedPath, path)
+		})
+	}
+}
+
 func TestSearch(t *testing.T) {
 	t.Parallel()
 

--- a/taskfile/node_file.go
+++ b/taskfile/node_file.go
@@ -20,10 +20,17 @@ type FileNode struct {
 func NewFileNode(entrypoint, dir string, opts ...NodeOption) (*FileNode, error) {
 	// Find the entrypoint file
 	resolvedEntrypoint, err := fsext.Search(entrypoint, dir, DefaultTaskfiles)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, errors.TaskfileNotFoundError{URI: entrypoint, Walk: false}
+	if errors.Is(err, os.ErrNotExist) {
+		path, err := fsext.GetSearchPath(entrypoint, dir)
+		if err != nil {
+			return nil, err
 		}
+		return nil, errors.TaskfileNotFoundError{
+			URI:  path,
+			Walk: entrypoint == "",
+		}
+	}
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes #2581

When running `task` in a directory without a Taskfile, the error message was showing an empty path (`task: No Taskfile found at ""`) and missing the helpful `--init` suggestion. This was caused by conflicting error handling where `NewFileNode()` was already wrapping `os.ErrNotExist` as `TaskfileNotFoundError`, but `getRootNode()` was checking for `os.IsNotExist(err)` which failed on the wrapped error.

## Solution

1. **Moved `--init` suggestion logic from error type to caller**: Removed the `AskInit` field from `TaskfileNotFoundError` and moved the suggestion logic to `getRootNode()` in `setup.go`. This separates the concern of "what happened" (file not found) from "what to suggest to the user" (run --init), and ensures the suggestion only appears when appropriate (i.e., when running plain `task` without `-t` or `-d` flags, since `--init` ignores those flags).

2. **Fixed URI construction**: Added `fsext.GetSearchPath()` helper to properly determine the absolute path being searched. This ensures `TaskfileNotFoundError.URI` always contains a meaningful path instead of an empty string.

3. **Simplified error handling**: Changed `getRootNode()` to use `errors.As()` to properly detect `TaskfileNotFoundError` and wrap it with the `--init` suggestion when appropriate, instead of trying to re-wrap `os.ErrNotExist`.

## Result

- `--init` suggestion appears only when running `task` without flags
- Proper "parent directories" message when doing recursive search
- Error messages now show absolute paths
