### PR TITLE
fix: ensure no ansi sequences are printed for `--color=false`

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -43,6 +43,12 @@ type (
 	PrintFunc func(io.Writer, string, ...any)
 )
 
+func None() PrintFunc {
+	c := color.New()
+	c.DisableColor()
+	return c.FprintfFunc()
+}
+
 func Default() PrintFunc {
 	return color.New(attrsReset...).FprintfFunc()
 }
@@ -149,7 +155,7 @@ func (l *Logger) FOutf(w io.Writer, color Color, s string, args ...any) {
 		s, args = "%s", []any{s}
 	}
 	if !l.Color {
-		color = Default
+		color = None
 	}
 	print := color()
 	print(w, s, args...)
@@ -168,7 +174,7 @@ func (l *Logger) Errf(color Color, s string, args ...any) {
 		s, args = "%s", []any{s}
 	}
 	if !l.Color {
-		color = Default
+		color = None
 	}
 	print := color()
 	print(l.Stderr, s, args...)


### PR DESCRIPTION
When cli arg `--color` is set to false the Task logging will still print ANSI codes (the reset code). This is _probably_ not the intended behaviour!?! Most often this is observed in situations where ANSI codes are not interpreted by a terminal emulation (i.e. logging, some UI situations (#2560).

For further clarity:
* FORCE_COLOR will turn color on
* NO_COLOR will turn color off via the fatih/color module
* `--color=false` will turn color off, overpowering FORCE_COLOR. 

This PR is introducing `None` as a log color, which explicitly calls `DisableColor()` in/on a Color object from fatih/color, and its set when CLI option `--color` is false.

Helps to fix #2560
