### PR TITLE
fix: CLI variables should take priority over Taskfile defaults

### DIFF
--- a/cmd/task/task.go
+++ b/cmd/task/task.go
@@ -172,18 +172,23 @@ func run() error {
 		calls = append(calls, &task.Call{Task: "default"})
 	}
 
+	// Merge CLI variables first (e.g. FOO=bar) so they take priority over Taskfile defaults
+	e.Taskfile.Vars.Merge(globals, nil)
+
+	// Then ReverseMerge special variables so they're available for templating
 	cliArgsPostDashQuoted, err := args.ToQuotedString(cliArgsPostDash)
 	if err != nil {
 		return err
 	}
-	globals.Set("CLI_ARGS", ast.Var{Value: cliArgsPostDashQuoted})
-	globals.Set("CLI_ARGS_LIST", ast.Var{Value: cliArgsPostDash})
-	globals.Set("CLI_FORCE", ast.Var{Value: flags.Force || flags.ForceAll})
-	globals.Set("CLI_SILENT", ast.Var{Value: flags.Silent})
-	globals.Set("CLI_VERBOSE", ast.Var{Value: flags.Verbose})
-	globals.Set("CLI_OFFLINE", ast.Var{Value: flags.Offline})
-	globals.Set("CLI_ASSUME_YES", ast.Var{Value: flags.AssumeYes})
-	e.Taskfile.Vars.ReverseMerge(globals, nil)
+	specialVars := ast.NewVars()
+	specialVars.Set("CLI_ARGS", ast.Var{Value: cliArgsPostDashQuoted})
+	specialVars.Set("CLI_ARGS_LIST", ast.Var{Value: cliArgsPostDash})
+	specialVars.Set("CLI_FORCE", ast.Var{Value: flags.Force || flags.ForceAll})
+	specialVars.Set("CLI_SILENT", ast.Var{Value: flags.Silent})
+	specialVars.Set("CLI_VERBOSE", ast.Var{Value: flags.Verbose})
+	specialVars.Set("CLI_OFFLINE", ast.Var{Value: flags.Offline})
+	specialVars.Set("CLI_ASSUME_YES", ast.Var{Value: flags.AssumeYes})
+	e.Taskfile.Vars.ReverseMerge(specialVars, nil)
 	if !flags.Watch {
 		e.InterceptInterruptSignals()
 	}

--- a/executor_test.go
+++ b/executor_test.go
@@ -263,6 +263,23 @@ func TestVars(t *testing.T) {
 			task.WithSilent(true),
 		),
 	)
+	NewExecutorTest(t,
+		WithName("cli-var-priority-default"),
+		WithExecutorOptions(
+			task.WithDir("testdata/vars"),
+			task.WithSilent(true),
+		),
+		WithTask("cli-var-priority"),
+	)
+	NewExecutorTest(t,
+		WithName("cli-var-priority-override"),
+		WithExecutorOptions(
+			task.WithDir("testdata/vars"),
+			task.WithSilent(true),
+		),
+		WithTask("cli-var-priority"),
+		WithVar("CLI_VAR", "from_cli"),
+	)
 }
 
 func TestRequires(t *testing.T) {

--- a/testdata/vars/Taskfile.yml
+++ b/testdata/vars/Taskfile.yml
@@ -49,3 +49,10 @@ tasks:
       - echo "{{.MESSAGE}}"
 
   from-dot-env: echo '{{.DOT_ENV_VAR}}'
+
+  # Test that CLI variables take priority over Taskfile defaults
+  cli-var-priority:
+    vars:
+      CLI_VAR: '{{.CLI_VAR | default "default_value"}}'
+    cmds:
+      - echo '{{.CLI_VAR}}'

--- a/testdata/vars/testdata/TestVars-cli-var-priority-default.golden
+++ b/testdata/vars/testdata/TestVars-cli-var-priority-default.golden
@@ -1,0 +1,1 @@
+default_value

--- a/testdata/vars/testdata/TestVars-cli-var-priority-override.golden
+++ b/testdata/vars/testdata/TestVars-cli-var-priority-override.golden
@@ -1,0 +1,1 @@
+from_cli


### PR DESCRIPTION
fixes https://github.com/go-task/task/issues/2588

When using `task FOO=bar` with a Taskfile containing `FOO: '{{.FOO | default "foo"}}'`, the CLI value was being overwritten by the Taskfile default.

The ReverseMerge function was incorrectly allowing Taskfile variables to overwrite CLI globals. Now it skips variables that already exist in the CLI globals, ensuring user-provided values take priority while still making CLI globals available for templating.

Fixes regression introduced in #2403.
