### PR TITLE
Ensure that errors from interop are of type interp.ExitStatus.

### DIFF
--- a/internal/execext/coreutils.go
+++ b/internal/execext/coreutils.go
@@ -7,14 +7,14 @@ import (
 	"github.com/go-task/task/v3/internal/env"
 )
 
-var useGoCoreUtils bool
+var UseGoCoreUtils bool
 
 func init() {
 	// If TASK_CORE_UTILS is set to either true or false, respect that.
 	// By default, enable on Windows only.
 	if v, err := strconv.ParseBool(env.GetTaskEnv("CORE_UTILS")); err == nil {
-		useGoCoreUtils = v
+		UseGoCoreUtils = v
 	} else {
-		useGoCoreUtils = runtime.GOOS == "windows"
+		UseGoCoreUtils = runtime.GOOS == "windows"
 	}
 }

--- a/internal/execext/exec.go
+++ b/internal/execext/exec.go
@@ -144,7 +144,7 @@ func ExpandFields(s string) ([]string, error) {
 }
 
 func execHandlers() (handlers []func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc) {
-	if useGoCoreUtils {
+	if UseGoCoreUtils {
 		handlers = append(handlers, coreutils.ExecHandler)
 	}
 	return handlers

--- a/task.go
+++ b/task.go
@@ -359,7 +359,7 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 			var exitCode interp.ExitStatus
 			if !errors.As(err, &exitCode) {
 				// Convert the err to an interp.ExitStatus.
-				e.Logger.VerboseErrf(logger.Yellow, "task: [%s] command error: %v\n", t.Name(), err)
+				e.Logger.Errf(logger.Default, "%v\n", err)
 				err = interp.ExitStatus(1)
 			}
 			if cmd.IgnoreError {

--- a/task.go
+++ b/task.go
@@ -358,8 +358,10 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 		if err != nil {
 			var exitCode interp.ExitStatus
 			if !errors.As(err, &exitCode) {
-				// Convert the err to an interp.ExitStatus.
-				e.Logger.Errf(logger.Default, "%v\n", err)
+				if execext.UseGoCoreUtils {
+					// Convert the err from CoreUtil to an interp.ExitStatus.
+					e.Logger.Errf(logger.Default, "%v\n", err)
+				}
 				err = interp.ExitStatus(1)
 			}
 			if cmd.IgnoreError {


### PR DESCRIPTION
When commands from coreutils fail, the error type is not the expected interop.ExitStatus. The handling of those errors, especially in relation to ignore-error, depends on that error type.

Solution presented here first prints the error (otherwise you have no feedback as to why the command fails), and then replaces the err object with a new interop.ExitStatus error. Location is also chosen because logging is available (for the original error).

Output formatting of the error is similar (in format) to the errors from defaul interop.

```
# Windows
.\task.exe -t .\ISSUES\2466 -v
task: "default" started
task: [default] cp -f foo fuvar/bar
CreateFile \\wsl.localhost\Ubuntu\home\trule\git\task\ISSUES\2466\foo: The system cannot find the file specified.
task: [default] command error ignored: exit status 1
task: "default" finished

# Linux
$ task -t ./ISSUES/2466/ -v
task: "default" started
task: [default] cp -f foo fuvar/bar
cp: cannot stat 'foo': No such file or directory
task: [default] command error ignored: exit status 1
task: "default" finished
```

Fixes #2466 
