### PR TITLE
Postpone glob template substitution for sources/generates.

### DIFF
--- a/variables.go
+++ b/variables.go
@@ -96,8 +96,15 @@ func (e *Executor) compiledTask(call *Call, evaluateShVars bool) (*ast.Task, err
 			fullName = strings.Replace(fullName, "*", match, 1)
 		}
 	}
-
 	cache := &templater.Cache{Vars: vars}
+	globber := func(globs []*ast.Glob) []*ast.Glob {
+		// Delays globbing until dynamic variables are available.
+		if evaluateShVars {
+			return templater.ReplaceGlobs(globs, cache)
+		} else {
+			return origTask.Sources
+		}
+	}
 	new := ast.Task{
 		Task:                 origTask.Task,
 		Label:                templater.Replace(origTask.Label, cache),
@@ -105,8 +112,8 @@ func (e *Executor) compiledTask(call *Call, evaluateShVars bool) (*ast.Task, err
 		Prompt:               templater.Replace(origTask.Prompt, cache),
 		Summary:              templater.Replace(origTask.Summary, cache),
 		Aliases:              origTask.Aliases,
-		Sources:              templater.ReplaceGlobs(origTask.Sources, cache),
-		Generates:            templater.ReplaceGlobs(origTask.Generates, cache),
+		Sources:              globber(origTask.Sources),
+		Generates:            globber(origTask.Generates),
 		Dir:                  templater.Replace(origTask.Dir, cache),
 		Set:                  origTask.Set,
 		Shopt:                origTask.Shopt,


### PR DESCRIPTION
The sources/generates globs are resolved by the templater after dynamic variables are evaluated. This is done in response to issue #2400 and seems to resolve the reported issue.

It seems reasonable, however consideration should be given (if the change could have side effects?).


fixes #2400 