### PR TITLE
fix: print prefix when task is up-to-date and output-style is prefixed

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -717,6 +717,27 @@ func TestLabel(t *testing.T) {
 	)
 }
 
+func TestPrefix(t *testing.T) {
+	t.Parallel()
+
+	NewExecutorTest(t,
+		WithName("up to date"),
+		WithExecutorOptions(
+			task.WithDir("testdata/prefix_uptodate"),
+			task.WithOutputStyle(ast.Output{Name: "prefixed"}),
+		),
+		WithTask("foo"),
+	)
+
+	NewExecutorTest(t,
+		WithName("up to dat with no output style"),
+		WithExecutorOptions(
+			task.WithDir("testdata/prefix_uptodate"),
+		),
+		WithTask("foo"),
+	)
+}
+
 func TestPromptInSummary(t *testing.T) {
 	t.Parallel()
 

--- a/task.go
+++ b/task.go
@@ -186,7 +186,11 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 
 			if upToDate && preCondMet {
 				if e.Verbose || (!call.Silent && !t.Silent && !e.Taskfile.Silent && !e.Silent) {
-					e.Logger.Errf(logger.Magenta, "task: Task %q is up to date\n", t.Name())
+					name := t.Name()
+					if e.OutputStyle.Name == "prefixed" {
+						name = t.Prefix
+					}
+					e.Logger.Errf(logger.Magenta, "task: Task %q is up to date\n", name)
 				}
 				return nil
 			}

--- a/testdata/prefix_uptodate/Taskfile.yml
+++ b/testdata/prefix_uptodate/Taskfile.yml
@@ -1,0 +1,7 @@
+version: '3'
+
+tasks:
+  foo:
+    prefix: "foobar"
+    status:
+      - echo "I'm ok"

--- a/testdata/prefix_uptodate/testdata/TestPrefix-up_to_dat_with_no_output_style.golden
+++ b/testdata/prefix_uptodate/testdata/TestPrefix-up_to_dat_with_no_output_style.golden
@@ -1,0 +1,1 @@
+task: Task "foo" is up to date

--- a/testdata/prefix_uptodate/testdata/TestPrefix-up_to_date.golden
+++ b/testdata/prefix_uptodate/testdata/TestPrefix-up_to_date.golden
@@ -1,0 +1,1 @@
+task: Task "foobar" is up to date


### PR DESCRIPTION
When output style is prefixed, use the prefix in the up-to-date message. Prefix will be either the task name (default), or the 'prefix' field in the task definition (if specified).

fixes #1566  