### PR TITLE
Support dotenv in included taskfiles.

### DIFF
--- a/taskfile/ast/taskfile.go
+++ b/taskfile/ast/taskfile.go
@@ -2,21 +2,21 @@ package ast
 
 import (
 	"fmt"
+	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"go.yaml.in/yaml/v4"
 
 	"github.com/go-task/task/v3/errors"
+	"github.com/go-task/task/v3/internal/filepathext"
 )
 
 // NamespaceSeparator contains the character that separates namespaces
 const NamespaceSeparator = ":"
 
 var V3 = semver.MustParse("3")
-
-// ErrIncludedTaskfilesCantHaveDotenvs is returned when a included Taskfile contains dotenvs
-var ErrIncludedTaskfilesCantHaveDotenvs = errors.New("task: Included Taskfiles can't have dotenv declarations. Please, move the dotenv declaration to the main Taskfile")
 
 // Taskfile is the abstract syntax tree for a Taskfile
 type Taskfile struct {
@@ -41,8 +41,11 @@ func (t1 *Taskfile) Merge(t2 *Taskfile, include *Include) error {
 	if !t1.Version.Equal(t2.Version) {
 		return fmt.Errorf(`task: Taskfiles versions should match. First is "%s" but second is "%s"`, t1.Version, t2.Version)
 	}
-	if len(t2.Dotenv) > 0 {
-		return ErrIncludedTaskfilesCantHaveDotenvs
+	for _, dotenvfile := range t2.Dotenv {
+		fp := filepathext.SmartJoin(filepath.Dir(t2.Location), dotenvfile)
+		if !slices.Contains(t1.Dotenv, fp) {
+			t1.Dotenv = append([]string{fp}, t1.Dotenv...)
+		}
 	}
 	if t2.Output.IsSet() {
 		t1.Output = t2.Output

--- a/testdata/dotenv/included_envs/Taskfile.yaml
+++ b/testdata/dotenv/included_envs/Taskfile.yaml
@@ -1,0 +1,15 @@
+version: '3'
+
+silent: true
+
+dotenv:
+  - dotenv.txt
+
+includes:
+  foo: ./inc/Taskfile.yaml
+
+tasks:
+  default:
+    cmds:
+      - echo "var FOO = {{.FOO}}"
+      - echo "env FOO = $FOO"

--- a/testdata/dotenv/included_envs/inc/Taskfile.yaml
+++ b/testdata/dotenv/included_envs/inc/Taskfile.yaml
@@ -1,0 +1,10 @@
+version: '3'
+
+dotenv:
+  - dotenv.txt
+
+tasks:
+  default:
+    cmds:
+      - echo "FOO = {{.FOO}}"
+      - echo "FOO = $FOO"

--- a/testdata/dotenv/included_envs/testdata/TestDotenvIncludeDotenvs-included_dotenv_has_priority.golden
+++ b/testdata/dotenv/included_envs/testdata/TestDotenvIncludeDotenvs-included_dotenv_has_priority.golden
@@ -1,0 +1,2 @@
+var FOO = bar
+env FOO = bar


### PR DESCRIPTION
Support dotenvs defined in included taskfiles.

Not sure why this is not supported. Its seems to work, with the usual limitation for global vars (non-deterministic behaviour).

fixed #1075 