### PR TITLE
docs: fix `dir` headline level

### DIFF
--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -637,7 +637,7 @@ tasks:
       - go build -ldflags="-s -w" ./...
 ```
 
-### `dir`
+#### `dir`
 
 - **Type**: `string`
 - **Description**: The directory in which this task should run


### PR DESCRIPTION
The other commands in this section are on headline level 4, which probably is also the expected one for `dir`.

Results in weird indentation in the docs menu:

<img width="303" height="675" alt="image" src="https://github.com/user-attachments/assets/c24fff9c-2cce-4503-8653-6828733cf64d" />


<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->
