### PR TITLE
Correct import directory resolution for nested imports.

### DIFF
--- a/taskfile/node_file.go
+++ b/taskfile/node_file.go
@@ -18,7 +18,7 @@ type FileNode struct {
 }
 
 func NewFileNode(entrypoint, dir string, opts ...NodeOption) (*FileNode, error) {
-	// Find the entrypoint file
+	// Find the entrypoint file.
 	resolvedEntrypoint, err := fsext.Search(entrypoint, dir, DefaultTaskfiles)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -27,7 +27,7 @@ func NewFileNode(entrypoint, dir string, opts ...NodeOption) (*FileNode, error) 
 		return nil, err
 	}
 
-	// Resolve the directory
+	// Resolve the directory.
 	resolvedDir, err := fsext.ResolveDir(entrypoint, resolvedEntrypoint, dir)
 	if err != nil {
 		return nil, err
@@ -53,38 +53,29 @@ func (node *FileNode) Read() ([]byte, error) {
 }
 
 func (node *FileNode) ResolveEntrypoint(entrypoint string) (string, error) {
-	// If the file is remote, we don't need to resolve the path
+	// Resolve to entrypoint without adjustment.
 	if isRemoteEntrypoint(entrypoint) {
 		return entrypoint, nil
 	}
-
-	path, err := execext.ExpandLiteral(entrypoint)
+	// Resolve relative to this nodes Taskfile location, or absolute.
+	entrypoint, err := execext.ExpandLiteral(entrypoint)
 	if err != nil {
 		return "", err
 	}
-
-	if filepathext.IsAbs(path) {
-		return path, nil
-	}
-
-	// NOTE: Uses the directory of the entrypoint (Taskfile), not the current working directory
-	// This means that files are included relative to one another
-	entrypointDir := filepath.Dir(node.entrypoint)
-	return filepathext.SmartJoin(entrypointDir, path), nil
+	dir := filepath.Dir(node.Location())
+	return filepathext.SmartJoin(dir, entrypoint), nil
 }
 
 func (node *FileNode) ResolveDir(dir string) (string, error) {
-	path, err := execext.ExpandLiteral(dir)
-	if err != nil {
-		return "", err
+	if len(dir) == 0 {
+		// Resolve to the current node.Dir().
+		return node.Dir(), nil
+	} else {
+		// Resolve include.Dir, relative to this node.Dir(), or absolute.
+		dir, err := execext.ExpandLiteral(dir)
+		if err != nil {
+			return "", err
+		}
+		return filepathext.SmartJoin(node.Dir(), dir), nil
 	}
-
-	if filepathext.IsAbs(path) {
-		return path, nil
-	}
-
-	// NOTE: Uses the directory of the entrypoint (Taskfile), not the current working directory
-	// This means that files are included relative to one another
-	entrypointDir := filepath.Dir(node.entrypoint)
-	return filepathext.SmartJoin(entrypointDir, path), nil
 }

--- a/taskfile/node_git.go
+++ b/taskfile/node_git.go
@@ -200,19 +200,17 @@ func (node *GitNode) ResolveEntrypoint(entrypoint string) (string, error) {
 }
 
 func (node *GitNode) ResolveDir(dir string) (string, error) {
-	path, err := execext.ExpandLiteral(dir)
-	if err != nil {
-		return "", err
+	if len(dir) == 0 {
+		// Resolve to the current node.Dir().
+		return node.Dir(), nil
+	} else {
+		// Resolve include.Dir, relative to this node.Dir(), or absolute.
+		dir, err := execext.ExpandLiteral(dir)
+		if err != nil {
+			return "", err
+		}
+		return filepathext.SmartJoin(node.Dir(), dir), nil
 	}
-
-	if filepathext.IsAbs(path) {
-		return path, nil
-	}
-
-	// NOTE: Uses the directory of the entrypoint (Taskfile), not the current working directory
-	// This means that files are included relative to one another
-	entrypointDir := filepath.Dir(node.Dir())
-	return filepathext.SmartJoin(entrypointDir, path), nil
 }
 
 func (node *GitNode) CacheKey() string {

--- a/taskfile/node_http.go
+++ b/taskfile/node_http.go
@@ -91,23 +91,17 @@ func (node *HTTPNode) ResolveEntrypoint(entrypoint string) (string, error) {
 }
 
 func (node *HTTPNode) ResolveDir(dir string) (string, error) {
-	path, err := execext.ExpandLiteral(dir)
-	if err != nil {
-		return "", err
+	if len(dir) == 0 {
+		// Resolve to the current node.Dir().
+		return node.Dir(), nil
+	} else {
+		// Resolve include.Dir, relative to this node.Dir(), or absolute.
+		dir, err := execext.ExpandLiteral(dir)
+		if err != nil {
+			return "", err
+		}
+		return filepathext.SmartJoin(node.Dir(), dir), nil
 	}
-
-	if filepathext.IsAbs(path) {
-		return path, nil
-	}
-
-	// NOTE: Uses the directory of the entrypoint (Taskfile), not the current working directory
-	// This means that files are included relative to one another
-	parent := node.Dir()
-	if node.Parent() != nil {
-		parent = node.Parent().Dir()
-	}
-
-	return filepathext.SmartJoin(parent, path), nil
 }
 
 func (node *HTTPNode) CacheKey() string {

--- a/taskfile/node_stdin.go
+++ b/taskfile/node_stdin.go
@@ -41,32 +41,28 @@ func (node *StdinNode) Read() ([]byte, error) {
 }
 
 func (node *StdinNode) ResolveEntrypoint(entrypoint string) (string, error) {
-	// If the file is remote, we don't need to resolve the path
+	// Resolve to entrypoint without adjustment.
 	if isRemoteEntrypoint(entrypoint) {
 		return entrypoint, nil
 	}
-
-	path, err := execext.ExpandLiteral(entrypoint)
+	// Resolve relative to this node.Dir() (i.e. the root node), or absolute.
+	entrypoint, err := execext.ExpandLiteral(entrypoint)
 	if err != nil {
 		return "", err
 	}
-
-	if filepathext.IsAbs(path) {
-		return path, nil
-	}
-
-	return filepathext.SmartJoin(node.Dir(), path), nil
+	return filepathext.SmartJoin(node.Dir(), entrypoint), nil
 }
 
 func (node *StdinNode) ResolveDir(dir string) (string, error) {
-	path, err := execext.ExpandLiteral(dir)
-	if err != nil {
-		return "", err
+	if len(dir) == 0 {
+		// Resolve to the current node.Dir().
+		return node.Dir(), nil
+	} else {
+		// Resolve include.Dir, relative to this node.Dir(), or absolute.
+		dir, err := execext.ExpandLiteral(dir)
+		if err != nil {
+			return "", err
+		}
+		return filepathext.SmartJoin(node.Dir(), dir), nil
 	}
-
-	if filepathext.IsAbs(path) {
-		return path, nil
-	}
-
-	return filepathext.SmartJoin(node.Dir(), path), nil
 }


### PR DESCRIPTION
The importing mechanism was/is determining the import directory based on the path of the importing taskfile. This means that the directory of an imported taskfile is not following the expectation of users, and effectively becomes unpredictable as imports are nested.

```
A imports foo/B imports foo/bar/C (in each case, import dir not specified)
A TASK_DIR = ./
B TASK_DIR = ./
C TASK_DIR = ./foo  *** the logic behind this is cloudy ...
```

The logic seems to be that, C was imported from B, and therefore C should run in the folder of B (./foo above). However, if B is running in the folder of A (./) then having C run in the folder of B, even though B is running in the folder of A, seems to be wrong. C should run in the folder of B, if B runs in the folder of A, then C should _also_ run in the folder of A.

This PR changes that behaviour, so that it matches the user documentation, and imports taskfiles based on the resolved directory of the importing taskfile. As a result, imports are relative to one another, based on their resolved directories.

Essentially; if taskfile A imports taskfile B then it expects taskfile B to have the same working dir as A, unless the importing mechanism is configured by A (via import dir), in which case taskfile B would have that configured working dir.

fixes #903 
fixes #2620 