### PR TITLE
fix: improve error message when searching for Taskfile.

### DIFF
--- a/errors/errors_taskfile.go
+++ b/errors/errors_taskfile.go
@@ -11,14 +11,17 @@ import (
 // TaskfileNotFoundError is returned when no appropriate Taskfile is found when
 // searching the filesystem.
 type TaskfileNotFoundError struct {
-	URI     string
-	Walk    bool
-	AskInit bool
+	URI         string
+	Walk        bool
+	AskInit     bool
+	OwnerChange bool
 }
 
 func (err TaskfileNotFoundError) Error() string {
 	var walkText string
-	if err.Walk {
+	if err.OwnerChange {
+		walkText = " (or any of the parent directories until ownership changed)."
+	} else if err.Walk {
 		walkText = " (or any of the parent directories)."
 	}
 	if err.AskInit {

--- a/setup.go
+++ b/setup.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-task/task/v3/internal/env"
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
-	"github.com/go-task/task/v3/internal/fsext"
 	"github.com/go-task/task/v3/internal/logger"
 	"github.com/go-task/task/v3/internal/output"
 	"github.com/go-task/task/v3/internal/version"
@@ -60,12 +59,10 @@ func (e *Executor) getRootNode() (taskfile.Node, error) {
 		taskfile.WithCert(e.Cert),
 		taskfile.WithCertKey(e.CertKey),
 	)
-	if os.IsNotExist(err) {
-		return nil, errors.TaskfileNotFoundError{
-			URI:     fsext.DefaultDir(e.Entrypoint, e.Dir),
-			Walk:    true,
-			AskInit: true,
-		}
+	var taskNotFoundError errors.TaskfileNotFoundError
+	if errors.As(err, &taskNotFoundError) {
+		taskNotFoundError.AskInit = true
+		return nil, taskNotFoundError
 	}
 	if err != nil {
 		return nil, err

--- a/taskfile/node_file.go
+++ b/taskfile/node_file.go
@@ -22,7 +22,13 @@ func NewFileNode(entrypoint, dir string, opts ...NodeOption) (*FileNode, error) 
 	resolvedEntrypoint, err := fsext.Search(entrypoint, dir, DefaultTaskfiles)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, errors.TaskfileNotFoundError{URI: entrypoint, Walk: false}
+			if entrypoint == "" {
+				return nil, errors.TaskfileNotFoundError{URI: entrypoint, Walk: true}
+			} else {
+				return nil, errors.TaskfileNotFoundError{URI: entrypoint, Walk: false}
+			}
+		} else if errors.Is(err, os.ErrPermission) {
+			return nil, errors.TaskfileNotFoundError{URI: entrypoint, Walk: true, OwnerChange: true}
 		}
 		return nil, err
 	}

--- a/taskrc/taskrc.go
+++ b/taskrc/taskrc.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/fsext"
 	"github.com/go-task/task/v3/taskrc/ast"
 )
@@ -62,6 +63,9 @@ func GetConfig(dir string) (*ast.TaskRC, error) {
 		return config, err
 	}
 	entrypoints, err := fsext.SearchAll("", absDir, defaultTaskRCs)
+	if errors.Is(err, os.ErrPermission) {
+		err = nil
+	}
 	if err != nil {
 		return config, err
 	}


### PR DESCRIPTION
When searching for a Taskfile, and the directory ownership changes, provide a message indicating that.

In implementing this change, I noticed that the handling of TaskfileNotFoundError in setup.go would never be hit (bug) and also that the code in fs.go was a little odd - in so much that detecting this condition required returning valid paths _and_ an err, which in many cases the caller would ignore anyway. But I think its OK, just a bit odd.

```
~/git$ task --list-all
task: No Taskfile found at "" (or any of the parent directories until ownership changed). Run `task --init` to create a new Taskfile.

```
Fixes #1683 