### PR TITLE
fix: copy watch when merging tasks during import

### DIFF
--- a/taskfile/ast/task.go
+++ b/taskfile/ast/task.go
@@ -242,6 +242,7 @@ func (t *Task) DeepCopy() *Task {
 		Requires:             t.Requires.DeepCopy(),
 		Namespace:            t.Namespace,
 		FullName:             t.FullName,
+		Watch:                t.Watch,
 		Failfast:             t.Failfast,
 	}
 	return c


### PR DESCRIPTION
When importing a taskfile/task, a tasks `watch` setting was not copied during the merge, and was thus lost. This PR adds that field to the DeepCopy().


Fixes #1763 
Fixes #2674  (helps with)