### PR TITLE
fix: use errors.As to detect TaskfileNotFoundError in getRootNode

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -60,7 +60,8 @@ func (e *Executor) getRootNode() (taskfile.Node, error) {
 		taskfile.WithCert(e.Cert),
 		taskfile.WithCertKey(e.CertKey),
 	)
-	if os.IsNotExist(err) {
+	var taskfileNotFoundErr errors.TaskfileNotFoundError
+	if errors.As(err, &taskfileNotFoundErr) {
 		return nil, errors.TaskfileNotFoundError{
 			URI:     fsext.DefaultDir(e.Entrypoint, e.Dir),
 			Walk:    true,


### PR DESCRIPTION
## Summary
  - Fix regression where `task` shows `No Taskfile found at ""` instead of the full error message with path and `--init` suggestion

  ## Problem
  When running `task` in a directory without a Taskfile, `NewFileNode()` in `node_file.go` wraps `os.ErrNotExist` into a `TaskfileNotFoundError` before returning. In `getRootNode()` (`setup.go`), the
  error check uses `os.IsNotExist(err)`, which fails to match the already-wrapped error. As a result, the enriched error (with the correct path, `Walk: true`, and `AskInit: true`) is never constructed,
  and the incomplete `TaskfileNotFoundError` from `NewFileNode()` is returned as-is.

  ## Fix
  Replace `os.IsNotExist(err)` with `errors.As(err, &taskfileNotFoundErr)` so that the wrapped `TaskfileNotFoundError` is properly detected.

  **Before:** `task: No Taskfile found at ""`
  **After:** `task: No Taskfile found at "/path/to/dir" (or any of the parent directories). Run `task --init` to create a new Taskfile.`

  Closes #2581
