### PR TITLE
fix: pin yaml package to v3 for now

### DIFF
--- a/errors/error_taskfile_decode.go
+++ b/errors/error_taskfile_decode.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 )
 
 type (
@@ -50,10 +50,10 @@ func (err *TaskfileDecodeError) Error() string {
 			if len(te.Errors) > 1 {
 				fmt.Fprintln(buf, color.RedString("errs:"))
 				for _, message := range te.Errors {
-					fmt.Fprintln(buf, color.RedString("- %s", message.Err.Error()))
+					fmt.Fprintln(buf, color.RedString("- %s", message))
 				}
 			} else {
-				fmt.Fprintln(buf, color.RedString("err:  %s", te.Errors[0].Err.Error()))
+				fmt.Fprintln(buf, color.RedString("err:  %s", te.Errors[0]))
 			}
 		} else {
 			// Otherwise print the error message normally

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/zeebo/xxh3 v1.0.2
-	go.yaml.in/yaml/v4 v4.0.0-rc.3
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.19.0
 	golang.org/x/term v0.39.0
 	mvdan.cc/sh/moreinterp v0.0.0-20260120230322-19def062a997

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ go.opentelemetry.io/otel/sdk/metric v1.39.0 h1:cXMVVFVgsIf2YL6QkRF4Urbr/aMInf+2W
 go.opentelemetry.io/otel/sdk/metric v1.39.0/go.mod h1:xq9HEVH7qeX69/JnwEfp6fVq5wosJsY1mt4lLfYdVew=
 go.opentelemetry.io/otel/trace v1.39.0 h1:2d2vfpEDmCJ5zVYz7ijaJdOF59xLomrvj7bjt6/qCJI=
 go.opentelemetry.io/otel/trace v1.39.0/go.mod h1:88w4/PnZSazkGzz/w84VHpQafiU4EtqqlVdxWy+rNOA=
-go.yaml.in/yaml/v4 v4.0.0-rc.3 h1:3h1fjsh1CTAPjW7q/EMe+C8shx5d8ctzZTrLcs/j8Go=
-go.yaml.in/yaml/v4 v4.0.0-rc.3/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.46.0 h1:cKRW/pmt1pKAfetfu+RCEvjvZkA9RimPbh7bhFjGVBU=
 golang.org/x/crypto v0.46.0/go.mod h1:Evb/oLKmMraqjZ2iQTwDwvCtJkczlDuTmdJXoZVzqU0=
 golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 h1:nDVHiLt8aIbd/VzvPWN6kSOPE7+F/fNFDSXLVYkE/Iw=

--- a/internal/templater/funcs.go
+++ b/internal/templater/funcs.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/uuid"
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 	"mvdan.cc/sh/v3/shell"
 	"mvdan.cc/sh/v3/syntax"
 

--- a/taskfile/ast/cmd.go
+++ b/taskfile/ast/cmd.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/deepcopy"

--- a/taskfile/ast/defer.go
+++ b/taskfile/ast/defer.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 )

--- a/taskfile/ast/dep.go
+++ b/taskfile/ast/dep.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 )

--- a/taskfile/ast/for.go
+++ b/taskfile/ast/for.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/deepcopy"

--- a/taskfile/ast/glob.go
+++ b/taskfile/ast/glob.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 )

--- a/taskfile/ast/include.go
+++ b/taskfile/ast/include.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/elliotchance/orderedmap/v3"
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/deepcopy"

--- a/taskfile/ast/matrix.go
+++ b/taskfile/ast/matrix.go
@@ -4,7 +4,7 @@ import (
 	"iter"
 
 	"github.com/elliotchance/orderedmap/v3"
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/deepcopy"

--- a/taskfile/ast/output.go
+++ b/taskfile/ast/output.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 )

--- a/taskfile/ast/platforms.go
+++ b/taskfile/ast/platforms.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/goext"

--- a/taskfile/ast/precondition.go
+++ b/taskfile/ast/precondition.go
@@ -3,7 +3,7 @@ package ast
 import (
 	"fmt"
 
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 )

--- a/taskfile/ast/precondition_test.go
+++ b/taskfile/ast/precondition_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/taskfile/ast"
 )

--- a/taskfile/ast/prompt.go
+++ b/taskfile/ast/prompt.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 )

--- a/taskfile/ast/requires.go
+++ b/taskfile/ast/requires.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/deepcopy"

--- a/taskfile/ast/task.go
+++ b/taskfile/ast/task.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/deepcopy"

--- a/taskfile/ast/taskfile.go
+++ b/taskfile/ast/taskfile.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 )

--- a/taskfile/ast/taskfile_test.go
+++ b/taskfile/ast/taskfile_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/taskfile/ast"
 )

--- a/taskfile/ast/tasks.go
+++ b/taskfile/ast/tasks.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	"github.com/elliotchance/orderedmap/v3"
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/filepathext"

--- a/taskfile/ast/var.go
+++ b/taskfile/ast/var.go
@@ -1,7 +1,7 @@
 package ast
 
 import (
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 )

--- a/taskfile/ast/vars.go
+++ b/taskfile/ast/vars.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/elliotchance/orderedmap/v3"
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/deepcopy"

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/dominikbraun/graph"
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/go-task/task/v3/errors"

--- a/taskrc/reader.go
+++ b/taskrc/reader.go
@@ -3,7 +3,7 @@ package taskrc
 import (
 	"os"
 
-	"go.yaml.in/yaml/v4"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/taskrc/ast"
 )


### PR DESCRIPTION
According to one of the maintainers, `go.yaml.in/yaml/v4` is still alpha and they called it "rc" by mistake.

In fact, our dependency update PRs are failing because they're still pushing breaking changes to v4.

* https://github.com/go-testfixtures/testfixtures/pull/362#issuecomment-3836643022
* https://github.com/go-task/task/pull/2661