### PR TITLE
feat(homebrew): migrate from Formula to Cask

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,22 +80,21 @@ nfpms:
       - src: completion/zsh/_task
         dst: /usr/local/share/zsh/site-functions/_task
 
-brews:
+homebrew_casks:
   - name: go-task
     description: A fast, cross-platform build tool inspired by Make, designed for modern workflows.
-    license: MIT
     homepage: https://taskfile.dev
-    directory: Formula
+    binaries:
+      - task
+    completions:
+      bash: completion/bash/task.bash
+      zsh: completion/zsh/_task
+      fish: completion/fish/task.fish
+    directory: Casks
     repository:
       owner: go-task
       name: homebrew-tap
       token: "{{.Env.GH_GORELEASER_TOKEN}}" # So that it runs as the task-bot user
-    test: system "#{bin}/task", "--help"
-    install: |-
-      bin.install "task"
-      bash_completion.install "completion/bash/task.bash" => "task"
-      zsh_completion.install "completion/zsh/_task" => "_task"
-      fish_completion.install "completion/fish/task.fish"
     commit_author:
       name: task-bot
       email: 106601941+task-bot@users.noreply.github.com

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -90,6 +90,15 @@ homebrew_casks:
       bash: completion/bash/task.bash
       zsh: completion/zsh/_task
       fish: completion/fish/task.fish
+    # Binaries are not signed/notarized, so remove the quarantine attribute
+    # set by Homebrew on downloaded cask artifacts to avoid Gatekeeper blocking
+    # them. See https://goreleaser.com/customization/homebrew_casks/
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/task"]
+          end
     directory: Casks
     repository:
       owner: go-task

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,23 +82,21 @@ nfpms:
       - src: completion/nu/task-completions.nu
         dst: /usr/share/nushell/vendor/autoload/task-completions.nu
 
-brews:
+homebrew_casks:
   - name: go-task
     description: A fast, cross-platform build tool inspired by Make, designed for modern workflows.
-    license: MIT
     homepage: https://taskfile.dev
-    directory: Formula
+    binaries:
+      - task
+    completions:
+      bash: completion/bash/task.bash
+      zsh: completion/zsh/_task
+      fish: completion/fish/task.fish
+    directory: Casks
     repository:
       owner: go-task
       name: homebrew-tap
       token: "{{.Env.GH_GORELEASER_TOKEN}}" # So that it runs as the task-bot user
-    test: system "#{bin}/task", "--help"
-    install: |-
-      bin.install "task"
-      bash_completion.install "completion/bash/task.bash" => "task"
-      zsh_completion.install "completion/zsh/_task" => "_task"
-      fish_completion.install "completion/fish/task.fish"
-      (share/"nushell/vendor/autoload").install "completion/nu/task-completions.nu"
     commit_author:
       name: task-bot
       email: 106601941+task-bot@users.noreply.github.com

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -92,6 +92,15 @@ homebrew_casks:
       bash: completion/bash/task.bash
       zsh: completion/zsh/_task
       fish: completion/fish/task.fish
+    # Binaries are not signed/notarized, so remove the quarantine attribute
+    # set by Homebrew on downloaded cask artifacts to avoid Gatekeeper blocking
+    # them. See https://goreleaser.com/customization/homebrew_casks/
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/task"]
+          end
     directory: Casks
     repository:
       owner: go-task

--- a/website/src/docs/installation.md
+++ b/website/src/docs/installation.md
@@ -75,7 +75,7 @@ apk add task
 ### [Homebrew](https://brew.sh) ![macOS](https://img.shields.io/badge/MacOS-000000?logo=apple&logoColor=F0F0F0) ![Linux](https://img.shields.io/badge/Linux-FCC624?logo=linux&logoColor=black) {#homebrew}
 
 Task is available via our official Homebrew tap
-[[source](https://github.com/go-task/homebrew-tap/blob/main/Formula/go-task.rb)]:
+[[source](https://github.com/go-task/homebrew-tap/blob/main/Casks/go-task.rb)]:
 
 ```shell
 brew install go-task/tap/go-task

--- a/website/src/next/docs/installation.md
+++ b/website/src/next/docs/installation.md
@@ -75,7 +75,7 @@ apk add task
 ### [Homebrew](https://brew.sh) ![macOS](https://img.shields.io/badge/MacOS-000000?logo=apple&logoColor=F0F0F0) ![Linux](https://img.shields.io/badge/Linux-FCC624?logo=linux&logoColor=black) {#homebrew}
 
 Task is available via our official Homebrew tap
-[[source](https://github.com/go-task/homebrew-tap/blob/main/Formula/go-task.rb)]:
+[[source](https://github.com/go-task/homebrew-tap/blob/main/Casks/go-task.rb)]:
 
 ```shell
 brew install go-task/tap/go-task


### PR DESCRIPTION
## Summary
Brews is deprecated see : https://goreleaser.com/resources/deprecations/#brews

- Switch GoReleaser config from `brews` to `homebrew_casks` so releases generate a Cask instead of a Formula
- Update documentation links in `installation.md` and `releasing.md` to reference `Casks/go-task.rb`

Companion to https://github.com/go-task/homebrew-tap/pull/5 which prepares the tap for this migration.
