### PR TITLE
Fix the handling of CLI option dir.

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -22,6 +22,7 @@ type Compiler struct {
 	Dir            string
 	Entrypoint     string
 	UserWorkingDir string
+	RootDir        string
 
 	TaskfileEnv  *ast.Vars
 	TaskfileVars *ast.Vars
@@ -203,8 +204,8 @@ func (c *Compiler) ResetCache() {
 func (c *Compiler) getSpecialVars(t *ast.Task, call *Call) (map[string]string, error) {
 	allVars := map[string]string{
 		"TASK_EXE":         filepath.ToSlash(os.Args[0]),
-		"ROOT_TASKFILE":    filepathext.SmartJoin(c.Dir, c.Entrypoint),
-		"ROOT_DIR":         c.Dir,
+		"ROOT_TASKFILE":    filepathext.SmartJoin(c.RootDir, c.Entrypoint),
+		"ROOT_DIR":         c.RootDir,
 		"USER_WORKING_DIR": c.UserWorkingDir,
 		"TASK_VERSION":     version.GetVersion(),
 	}

--- a/executor.go
+++ b/executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -69,6 +70,7 @@ type (
 		OutputStyle        ast.Output
 		TaskSorter         sort.Sorter
 		UserWorkingDir     string
+		RootDir            string
 		EnableVersionCheck bool
 
 		fuzzyModel     *fuzzy.Model
@@ -102,6 +104,7 @@ func NewExecutor(opts ...ExecutorOption) *Executor {
 		OutputStyle:          ast.Output{},
 		TaskSorter:           sort.AlphaNumericWithRootTasksFirst,
 		UserWorkingDir:       "",
+		RootDir:              "",
 		fuzzyModel:           nil,
 		concurrencySemaphore: nil,
 		taskCallCount:        map[string]*int32{},
@@ -132,7 +135,15 @@ type dirOption struct {
 }
 
 func (o *dirOption) ApplyToExecutor(e *Executor) {
-	e.Dir = o.dir
+	if len(o.dir) > 0 {
+		if filepath.IsAbs(o.dir) {
+			e.Dir = o.dir
+		} else {
+			if d, err := filepath.Abs(o.dir); err == nil {
+				e.Dir = d
+			}
+		}
+	}
 }
 
 // WithEntrypoint sets the entrypoint (main Taskfile) of the [Executor]. By

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -275,6 +275,13 @@ func (o *flagsOption) ApplyToExecutor(e *task.Executor) {
 		if err == nil {
 			dir = home
 		}
+	} else {
+		if len(dir) > 0 {
+			// Use the cli provided directory.
+			if d, err := filepath.Abs(dir); err == nil {
+				dir = d
+			}
+		}
 	}
 
 	e.Options(

--- a/setup.go
+++ b/setup.go
@@ -67,7 +67,11 @@ func (e *Executor) getRootNode() (taskfile.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	e.Dir = node.Dir()
+	e.RootDir = node.Dir()
+	if len(e.Dir) == 0 {
+		// Only set the executor dir if it was not already set.
+		e.Dir = node.Dir()
+	}
 	e.Entrypoint = node.Location()
 	return node, err
 }
@@ -216,11 +220,11 @@ func (e *Executor) setupCompiler() error {
 			return err
 		}
 	}
-
 	e.Compiler = &Compiler{
 		Dir:            e.Dir,
 		Entrypoint:     e.Entrypoint,
 		UserWorkingDir: e.UserWorkingDir,
+		RootDir:        e.RootDir,
 		TaskfileEnv:    e.Taskfile.Env,
 		TaskfileVars:   e.Taskfile.Vars,
 		Logger:         e.Logger,

--- a/testdata/special_vars/subdir/testdata/TestSpecialVars-testdata-special_vars-subdir-print-task-dir.golden
+++ b/testdata/special_vars/subdir/testdata/TestSpecialVars-testdata-special_vars-subdir-print-task-dir.golden
@@ -1,1 +1,1 @@
-{{.TEST_DIR}}/testdata/special_vars/foo
+{{.TEST_DIR}}/testdata/special_vars/subdir/foo


### PR DESCRIPTION
Values for `--dir` provided at the CLI are chomped in the call to getRootNode(). This means that the working dir for task is not actually set according to the user intention.

Grounding notes:

USER_WORKING_DIR = Directory task is called from. Fixed (does not change).
TASKFILE_DIR = Directory of the current taskfile (when running a task).
TASK_DIR = The working directory of a task.

* defaults to c.Dir (which shadows e.Dir)
* task.dir modifies -> join(c.Dir, task.Dir)
* cli `--dir` modifies c.Dir (and thus may impact on previous line)

ROOT_DIR = Directory of the root taskfile. Fixed (does not change).

This PR fixes the chomping and _ensures_ that a user (or test) provided `--dir` is used as the basis for determining a tasks working dir. If a task specifies a `task.dir`, that will be resolved relative to the provided `--dir`.

As a result of _that_ change the RootDIr needs to be explicitly set, rather than inferred from c.Dir (which itself is set from e.Dir).

Observation: prior to this PR the `dir` cli option had no effect. 

Note: one test needed modification because it was running in the ROOT_DIR rather than in the provided `dir`. This seems to have been a mistake in the test.

fixes #2102 



Further observation: previous PR's have caused regressions. I do believe this change will be more resiliant.
https://github.com/go-task/task/commit/68d50957615acc7c6b30c0eab36be06792d3e843
