### PR TITLE
Revert "fix: Call ReplaceVars() to resolve Ref's for imported global vars."

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -114,9 +114,6 @@ func (c *Compiler) getVariables(t *ast.Task, call *Call, evaluateShVars bool) (*
 			return nil, err
 		}
 	}
-	// Resolve any outstanding 'Ref' values in global vars (esp. globals from imported Taskfiles).
-	c.TaskfileVars = templater.ReplaceVars(c.TaskfileVars, &templater.Cache{Vars: result})
-
 	if t != nil {
 		for k, v := range t.IncludeVars.All() {
 			if err := rangeFunc(k, v); err != nil {

--- a/executor_test.go
+++ b/executor_test.go
@@ -927,10 +927,6 @@ func TestReference(t *testing.T) {
 			name: "reference using templating resolver and dynamic var",
 			call: "ref-resolver-sh",
 		},
-		{
-			name: "reference using templating resolver and global var",
-			call: "ref-global",
-		},
 	}
 
 	for _, test := range tests {

--- a/testdata/var_references/Taskfile.yml
+++ b/testdata/var_references/Taskfile.yml
@@ -2,9 +2,6 @@ version: '3'
 
 vars:
   GLOBAL_VAR: [1, 2, 2, 2, 3, 3, 4, 5]
-  GLOBAL_FOO:
-    ref: .GLOBAL_BAR
-  GLOBAL_BAR: bar
 
 tasks:
   default:
@@ -12,7 +9,6 @@ tasks:
     - task: ref-dep
     - task: ref-resolver
     - task: ref-resolver-sh
-    - task: ref-global
 
   ref-cmd:
     vars:
@@ -76,13 +72,3 @@ tasks:
           {{- else}} and {{$child.name -}}
           {{- end -}}
         {{- end -}}"
-
-  ref-global:
-    vars:
-      TASK_FUBAR:
-        ref: .GLOBAL_FOO
-    cmds:
-      - echo "GLOBAL_FOO={{.GLOBAL_FOO}}"
-      - echo "GLOBAL_BAR={{.GLOBAL_BAR}}"
-      - echo "TASK_FUBAR={{.TASK_FUBAR}}"
-    silent: true

--- a/testdata/var_references/testdata/TestReference-reference_using_templating_resolver_and_global_var.golden
+++ b/testdata/var_references/testdata/TestReference-reference_using_templating_resolver_and_global_var.golden
@@ -1,3 +1,0 @@
-GLOBAL_FOO=bar
-GLOBAL_BAR=bar
-TASK_FUBAR=bar


### PR DESCRIPTION
* Reverts go-task/task#2632
* Closes #2720
* Closes #2721
* Closes #2722

This changes caused regressions. We're reverting so it doesn't break existing Taskfiles, and then we can take time to rework that change in a safer way.