### PR TITLE
fix(env): resolve nested dotenv template expansion deterministically

### DIFF
--- a/variables.go
+++ b/variables.go
@@ -161,10 +161,11 @@ func (e *Executor) compiledTask(call *Call, evaluateShVars bool) (*ast.Task, err
 			}
 		}
 	}
+	dotenvEnvs = resolveDotenvVars(dotenvEnvs, cache)
 
 	new.Env = ast.NewVars()
 	new.Env.Merge(templater.ReplaceVars(e.Taskfile.Env, cache), nil)
-	new.Env.Merge(templater.ReplaceVars(dotenvEnvs, cache), nil)
+	new.Env.Merge(dotenvEnvs, nil)
 	new.Env.Merge(templater.ReplaceVars(origTask.Env, cache), nil)
 	if evaluateShVars {
 		for k, v := range new.Env.All() {
@@ -463,4 +464,24 @@ func product(matrix *ast.Matrix) []map[string]any {
 	}
 
 	return result
+}
+
+func resolveDotenvVars(dotenvEnvs *ast.Vars, cache *templater.Cache) *ast.Vars {
+	if dotenvEnvs == nil || dotenvEnvs.Len() == 0 {
+		return dotenvEnvs
+	}
+
+	resolved := dotenvEnvs
+	for range dotenvEnvs.Len() {
+		next := templater.ReplaceVarsWithExtra(resolved, cache, resolved.ToCacheMap())
+		if next == nil {
+			return resolved
+		}
+		if fmt.Sprint(next.All()) == fmt.Sprint(resolved.All()) {
+			return next
+		}
+		resolved = next
+	}
+
+	return resolved
 }

--- a/variables_dotenv_test.go
+++ b/variables_dotenv_test.go
@@ -1,0 +1,37 @@
+package task
+
+import (
+	"testing"
+
+	"github.com/go-task/task/v3/internal/templater"
+	"github.com/go-task/task/v3/taskfile/ast"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveDotenvVarsNestedTemplates(t *testing.T) {
+	t.Parallel()
+
+	base := ast.NewVars()
+	base.Set("BASE_DIR", ast.Var{Value: "/home/user"})
+
+	cache := &templater.Cache{Vars: base}
+
+	dotenv := ast.NewVars()
+	dotenv.Set("MID_DIR", ast.Var{Value: "{{.BASE_DIR}}/nested"})
+	dotenv.Set("FINAL_DIR", ast.Var{Value: "{{.MID_DIR}}/deeper"})
+	dotenv.Set("FULL_PATH", ast.Var{Value: "{{.FINAL_DIR}}/file.txt"})
+
+	resolved := resolveDotenvVars(dotenv, cache)
+
+	mid, ok := resolved.Get("MID_DIR")
+	require.True(t, ok)
+	require.Equal(t, "/home/user/nested", mid.Value)
+
+	finalDir, ok := resolved.Get("FINAL_DIR")
+	require.True(t, ok)
+	require.Equal(t, "/home/user/nested/deeper", finalDir.Value)
+
+	fullPath, ok := resolved.Get("FULL_PATH")
+	require.True(t, ok)
+	require.Equal(t, "/home/user/nested/deeper/file.txt", fullPath.Value)
+}


### PR DESCRIPTION
## Summary
- resolve dotenv values with iterative template expansion so nested `{{.VAR}}` chains are evaluated consistently
- keep dotenv precedence behavior unchanged (first file wins), while making resolution order deterministic
- add a regression test for nested dotenv template chains (`MID_DIR -> FINAL_DIR -> FULL_PATH`)

## Testing
- Not run locally: this environment has Go 1.22.2 and cannot download the required Go 1.25 toolchain (`go.mod` requires `go >= 1.25`)
- Added targeted regression test: `TestResolveDotenvVarsNestedTemplates` in `variables_dotenv_test.go`

## Related
Fixes #1847