### PR TITLE
fix(fish): honor GO_TASK_PROGNAME for experiments cache

### DIFF
--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -5,7 +5,7 @@ set -g __task_experiments_cache ""
 set -g __task_experiments_cache_time 0
 
 # Helper function to get experiments with 1-second cache
-function __task_get_experiments
+function __task_get_experiments --inherit-variable GO_TASK_PROGNAME
     set -l now (date +%s)
     set -l ttl 1  # Cache for 1 second only
 


### PR DESCRIPTION
## Summary
- use `$GO_TASK_PROGNAME` instead of hardcoded `task` when refreshing fish completion experiment cache
- fixes fish completion warnings on distros where the binary name is `go-task`
- keeps completion behavior unchanged for default `task` installs

## Testing
- `git diff --check`
- `go test ./...` *(not runnable in this environment: required Go toolchain `go1.25` is unavailable via `GOTOOLCHAIN` download)*

## Related
- Fixes #2727
