### PR TITLE
test: add coverage for sh: vars with included Taskfiles

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -942,6 +942,32 @@ func TestReference(t *testing.T) {
 	}
 }
 
+func TestShVarWithIncludes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		call string
+	}{
+		{
+			name: "sh var not clobbered by includes",
+			call: "default",
+		},
+	}
+
+	for _, test := range tests {
+		NewExecutorTest(t,
+			WithName(test.name),
+			WithExecutorOptions(
+				task.WithDir("testdata/var_sh_with_includes"),
+				task.WithSilent(true),
+				task.WithForce(true),
+			),
+			WithTask(cmp.Or(test.call, "default")),
+		)
+	}
+}
+
 func TestVarInheritance(t *testing.T) {
 	enableExperimentForTest(t, &experiments.EnvPrecedence, 1)
 	tests := []struct {

--- a/testdata/var_sh_with_includes/Included.yml
+++ b/testdata/var_sh_with_includes/Included.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+tasks:
+  noop:
+    cmds:
+      - "true"

--- a/testdata/var_sh_with_includes/Taskfile.yml
+++ b/testdata/var_sh_with_includes/Taskfile.yml
@@ -1,0 +1,18 @@
+version: '3'
+
+includes:
+  other:
+    taskfile: ./Included.yml
+    internal: true
+
+vars:
+  DYNAMIC_VAR:
+    sh: echo "hello"
+  DERIVED_VAR: "{{.DYNAMIC_VAR}} world"
+
+tasks:
+  default:
+    cmds:
+      - echo "DYNAMIC_VAR={{.DYNAMIC_VAR}}"
+      - echo "DERIVED_VAR={{.DERIVED_VAR}}"
+    silent: true

--- a/testdata/var_sh_with_includes/testdata/TestShVarWithIncludes-sh_var_not_clobbered_by_includes.golden
+++ b/testdata/var_sh_with_includes/testdata/TestShVarWithIncludes-sh_var_not_clobbered_by_includes.golden
@@ -1,0 +1,2 @@
+DYNAMIC_VAR=hello
+DERIVED_VAR=hello world


### PR DESCRIPTION
## Summary

- Adds `TestShVarWithIncludes` to ensure `sh:` dynamic variables resolve correctly when a Taskfile also has `includes:`
- Guards against regressions like the one fixed in v3.49.1 (see #2720, #2721)
- No code changes — test-only PR to improve coverage

## Context

PR #2721 fixed a regression where global `sh:` variables resolved to empty strings when the Taskfile had `includes:`. That PR was superseded by the revert in #2723, but no test was added to prevent the issue from recurring. This PR adds that missing test coverage.

## Test plan

- [x] `TestShVarWithIncludes` passes on current `main` (post-revert)
- [x] Golden file asserts `DYNAMIC_VAR=hello` and `DERIVED_VAR=hello world`

🤖 Generated with [Claude Code](https://claude.com/claude-code)