### PR TITLE
templater: add joinEnv helper for PATH-like vars

### DIFF
--- a/internal/templater/funcs.go
+++ b/internal/templater/funcs.go
@@ -1,6 +1,7 @@
 package templater
 
 import (
+	stdos "os"
 	"maps"
 	"math/rand/v2"
 	"path/filepath"
@@ -33,6 +34,7 @@ func init() {
 		"splitArgs":    splitArgs,
 		"IsSH":         IsSH, // Deprecated
 		"joinPath":     filepath.Join,
+		"joinEnv":      joinEnv,
 		"relPath":      filepath.Rel,
 		"merge":        merge,
 		"spew":         spew.Sdump,
@@ -87,6 +89,10 @@ func shellQuote(str string) (string, error) {
 
 func splitArgs(s string) ([]string, error) {
 	return shell.Fields(s, nil)
+}
+
+func joinEnv(elems ...string) string {
+	return strings.Join(elems, string(stdos.PathListSeparator))
 }
 
 // Deprecated: now always returns true

--- a/internal/templater/funcs_test.go
+++ b/internal/templater/funcs_test.go
@@ -1,0 +1,31 @@
+package templater
+
+import (
+	stdos "os"
+	"testing"
+)
+
+func TestJoinEnv(t *testing.T) {
+	t.Parallel()
+
+	got := joinEnv("/tmp/tools/bin", "/usr/local/bin", "/usr/bin")
+	want := "/tmp/tools/bin" + string(stdos.PathListSeparator) + "/usr/local/bin" + string(stdos.PathListSeparator) + "/usr/bin"
+	if got != want {
+		t.Fatalf("joinEnv() = %q, want %q", got, want)
+	}
+}
+
+func TestJoinEnvTemplateFunc(t *testing.T) {
+	t.Parallel()
+
+	joinEnvFunc, ok := templateFuncs["joinEnv"].(func(...string) string)
+	if !ok {
+		t.Fatalf("joinEnv template function has unexpected type: %T", templateFuncs["joinEnv"])
+	}
+
+	got := joinEnvFunc("a", "b")
+	want := "a" + string(stdos.PathListSeparator) + "b"
+	if got != want {
+		t.Fatalf("template joinEnv() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add a new `joinEnv` template helper that joins path-like values with the OS-specific path list separator (`:` on POSIX, `;` on Windows)
- expose `joinEnv` in the templater function map so Taskfiles can build cross-platform `PATH` values cleanly
- add unit coverage for both direct helper behavior and template function registration

## Testing
- `git diff --check`
- `go test ./internal/templater` *(not runnable in this environment: required Go toolchain `go1.25` is unavailable via `GOTOOLCHAIN` download)*

## Related
Fixes #2406
