### PR TITLE
templater: expose wildcard MATCH in include vars

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -115,6 +115,13 @@ func (c *Compiler) getVariables(t *ast.Task, call *Call, evaluateShVars bool) (*
 		}
 	}
 	if t != nil {
+		if call != nil {
+			for k, v := range call.Vars.All() {
+				if err := rangeFunc(k, v); err != nil {
+					return nil, err
+				}
+			}
+		}
 		for k, v := range t.IncludeVars.All() {
 			if err := rangeFunc(k, v); err != nil {
 				return nil, err

--- a/task_test.go
+++ b/task_test.go
@@ -2096,6 +2096,21 @@ func TestIncludeWithVarsInInclude(t *testing.T) {
 	require.NoError(t, e.Setup())
 }
 
+func TestWildcardIncludeVarsCanUseMatch(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/includes_wildcard_include_vars"
+	var buff bytes.Buffer
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
+	require.NoError(t, e.Setup())
+	require.NoError(t, e.Run(t.Context(), &task.Call{Task: "default"}))
+	assert.Contains(t, buff.String(), "ENV=prod")
+}
+
 func TestIncludedVarsMultiLevel(t *testing.T) {
 	t.Parallel()
 

--- a/testdata/includes_wildcard_include_vars/Taskfile.stack.yml
+++ b/testdata/includes_wildcard_include_vars/Taskfile.stack.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+tasks:
+  show:
+    cmds:
+      - echo "ENV={{.ENV}}"

--- a/testdata/includes_wildcard_include_vars/Taskfile.yml
+++ b/testdata/includes_wildcard_include_vars/Taskfile.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+includes:
+  'stack:*':
+    taskfile: ./Taskfile.stack.yml
+    vars:
+      ENV: '{{index .MATCH 0}}'
+
+tasks:
+  default:
+    cmds:
+      - task stack:prod:show


### PR DESCRIPTION
## Summary
- seed call-time vars before include var templating so wildcard `MATCH` is available while evaluating `includes.*.vars`
- preserve existing variable resolution flow; change is scoped to include-var evaluation order
- add a regression fixture and test covering `ENV: '{{index .MATCH 0}}'` in wildcard includes

## Testing
- `go test ./... -run TestWildcardIncludeVarsCanUseMatch -count=1` *(fails locally: repo requires Go 1.25 toolchain, host has Go 1.22.2 and cannot download go1.25 in this environment)*
- Manual verification via regression test logic: before change include vars evaluation hit `index of untyped nil`; after change the test asserts output contains `ENV=prod`

## Related
- Fixes #2732
