### PR TITLE
docs: correct stdin Taskfile command example

### DIFF
--- a/website/src/docs/guide.md
+++ b/website/src/docs/guide.md
@@ -99,7 +99,7 @@ from stdin, you must specify the `-t/--taskfile` flag with the special `-`
 value. You may then pipe into Task as you would any other program:
 
 ```shell
-task -t - <(cat ./Taskfile.yml)
+task -t - < ./Taskfile.yml
 # OR
 cat ./Taskfile.yml | task -t -
 ```


### PR DESCRIPTION
## Summary
- fix the `Reading a Taskfile from stdin` guide example that used `task -t - <(cat ./Taskfile.yml)`
- replace it with `task -t - < ./Taskfile.yml`, which correctly passes stdin to Task when using `-t -`
- keep the existing piped example (`cat ./Taskfile.yml | task -t -`) unchanged

## Testing
- verified the docs snippet now contains the corrected stdin redirection command:
  - `rg -n "task -t - < ./Taskfile.yml|cat ./Taskfile.yml \| task -t -" website/src/docs/guide.md`
- note: `task` CLI is not installed in this runner, so executable command validation was not run locally

## Related
Fixes #2610
