### PR TITLE
fix: preserve dotenv variable declaration order for deterministic expansion

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -1706,6 +1706,26 @@ func TestDotenvHasLocalVarInPath(t *testing.T) {
 	})
 }
 
+func TestDotenvNestedVarsExpandDeterministically(t *testing.T) {
+	t.Parallel()
+
+	// Nested $VAR references in a dotenv file must always resolve to the same
+	// value. Previously, the use of an unordered map in godotenv caused
+	// non-deterministic expansion of chained variables.
+	tt := fileContentTest{
+		Dir:       "testdata/dotenv/nested_vars",
+		Target:    "default",
+		TrimSpace: true,
+		Files: map[string]string{
+			"output.txt": "/home/user/nested/deeper/file.txt",
+		},
+	}
+	t.Run("", func(t *testing.T) {
+		t.Parallel()
+		tt.Run(t)
+	})
+}
+
 func TestDotenvHasEnvVarInPath(t *testing.T) { // nolint:paralleltest // cannot run in parallel
 	t.Setenv("ENV_VAR", "testing")
 

--- a/taskfile/dotenv.go
+++ b/taskfile/dotenv.go
@@ -1,8 +1,11 @@
 package taskfile
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/joho/godotenv"
 
@@ -10,6 +13,57 @@ import (
 	"github.com/go-task/task/v3/internal/templater"
 	"github.com/go-task/task/v3/taskfile/ast"
 )
+
+// ReadEnvFile reads a dotenv file and returns an ordered Vars map.
+// Unlike godotenv.Read, this preserves the declaration order of variables as
+// they appear in the file, ensuring that nested {{.VAR}} template references
+// expand deterministically.
+func ReadEnvFile(path string) (*ast.Vars, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading env file %s: %w", path, err)
+	}
+
+	// godotenv.Parse handles $VAR expansion and all quoting rules. It reads
+	// line by line internally, so $VAR references resolve in file order. The
+	// returned map loses that order, which is why we re-scan for key names.
+	envMap, err := godotenv.Parse(bytes.NewReader(content))
+	if err != nil {
+		return nil, fmt.Errorf("error reading env file %s: %w", path, err)
+	}
+
+	vars := ast.NewVars()
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimLeft(scanner.Text(), " \t")
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Handle "export KEY=VALUE" syntax
+		line = strings.TrimPrefix(line, "export")
+		line = strings.TrimLeft(line, " \t")
+		// Extract key name (everything before the first '=')
+		idx := strings.IndexByte(line, '=')
+		if idx <= 0 {
+			continue
+		}
+		key := strings.TrimRight(line[:idx], " \t")
+		if key == "" {
+			continue
+		}
+		value, ok := envMap[key]
+		if !ok {
+			continue
+		}
+		if _, exists := vars.Get(key); !exists {
+			vars.Set(key, ast.Var{Value: value})
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading env file %s: %w", path, err)
+	}
+	return vars, nil
+}
 
 func Dotenv(vars *ast.Vars, tf *ast.Taskfile, dir string) (*ast.Vars, error) {
 	env := ast.NewVars()
@@ -26,13 +80,13 @@ func Dotenv(vars *ast.Vars, tf *ast.Taskfile, dir string) (*ast.Vars, error) {
 			continue
 		}
 
-		envs, err := godotenv.Read(dotEnvPath)
+		fileVars, err := ReadEnvFile(dotEnvPath)
 		if err != nil {
-			return nil, fmt.Errorf("error reading env file %s: %w", dotEnvPath, err)
+			return nil, err
 		}
-		for key, value := range envs {
-			if _, ok := env.Get(key); !ok {
-				env.Set(key, ast.Var{Value: value})
+		for k, v := range fileVars.All() {
+			if _, ok := env.Get(k); !ok {
+				env.Set(k, v)
 			}
 		}
 	}

--- a/testdata/dotenv/nested_vars/.env
+++ b/testdata/dotenv/nested_vars/.env
@@ -1,0 +1,4 @@
+BASE_DIR=/home/user
+MID_DIR=$BASE_DIR/nested
+FINAL_DIR=$MID_DIR/deeper
+FULL_PATH=$FINAL_DIR/file.txt

--- a/testdata/dotenv/nested_vars/Taskfile.yml
+++ b/testdata/dotenv/nested_vars/Taskfile.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+dotenv: ['.env']
+
+tasks:
+  default:
+    cmds:
+      - echo "$FULL_PATH" > output.txt

--- a/variables.go
+++ b/variables.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/joho/godotenv"
-
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/deepcopy"
 	"github.com/go-task/task/v3/internal/env"
@@ -16,6 +14,7 @@ import (
 	"github.com/go-task/task/v3/internal/filepathext"
 	"github.com/go-task/task/v3/internal/fingerprint"
 	"github.com/go-task/task/v3/internal/templater"
+	"github.com/go-task/task/v3/taskfile"
 	"github.com/go-task/task/v3/taskfile/ast"
 )
 
@@ -150,13 +149,13 @@ func (e *Executor) compiledTask(call *Call, evaluateShVars bool) (*ast.Task, err
 			if _, err := os.Stat(dotEnvPath); os.IsNotExist(err) {
 				continue
 			}
-			envs, err := godotenv.Read(dotEnvPath)
+			fileVars, err := taskfile.ReadEnvFile(dotEnvPath)
 			if err != nil {
 				return nil, err
 			}
-			for key, value := range envs {
-				if _, ok := dotenvEnvs.Get(key); !ok {
-					dotenvEnvs.Set(key, ast.Var{Value: value})
+			for k, v := range fileVars.All() {
+				if _, ok := dotenvEnvs.Get(k); !ok {
+					dotenvEnvs.Set(k, v)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes #1847

`godotenv.Read` returns `map[string]string` which is unordered in Go. Both `taskfile/dotenv.go` and `variables.go` iterated over this map to populate `ast.Vars`, losing the original declaration order from the `.env` file. This caused non-deterministic expansion of chained `$VAR` references across multiple runs.

**Example** (from the issue): with a `.env` file like:
```
BASE_DIR=/home/user
MID_DIR=$BASE_DIR/nested
FINAL_DIR=$MID_DIR/deeper
FULL_PATH=$FINAL_DIR/file.txt
```
`FULL_PATH` could expand to `/home/user/nested/deeper/file.txt` on one run and `/nested/deeper/file.txt` on another.

## Fix

Add `ReadEnvFile(path string) (*ast.Vars, error)` in `taskfile/dotenv.go` that:
1. Reads the file content once with `os.ReadFile`
2. Passes it to `godotenv.Parse` to get expanded values (godotenv handles `$VAR` expansion internally in file order)
3. Re-scans the same bytes with `bufio.Scanner` to recover the original key declaration order
4. Inserts into `ast.Vars` in that order

Both `Dotenv()` and `compiledTask()` now call `ReadEnvFile` instead of `godotenv.Read` directly, removing the duplicated logic.

## Test plan

- [ ] New test `TestDotenvNestedVarsExpandDeterministically` verifies that chained `$VAR` references in a dotenv file always expand to the correct value
- [ ] All existing dotenv tests pass
- [ ] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)