### PR TITLE
perf: optimize timestamp fingerprinting for large glob patterns

### DIFF
--- a/internal/fingerprint/glob.go
+++ b/internal/fingerprint/glob.go
@@ -1,8 +1,13 @@
 package fingerprint
 
 import (
+	"errors"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"sort"
+	"strings"
+	"time"
 
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
@@ -55,4 +60,167 @@ func collectKeys(m map[string]bool) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// errStop is a sentinel error used to short-circuit filepath.WalkDir.
+var errStop = errors.New("stop walk")
+
+// walkGlobFiles walks files matching the given globs and calls visit for each
+// matched file's FileInfo. If visit returns errStop, walking stops immediately
+// (this is not treated as an error). For negated globs, it falls back to the
+// standard Globs approach since negation requires full enumeration.
+// Returns (fallback=true, nil) when negated globs are present so the caller
+// can handle the fallback.
+func walkGlobFiles(dir string, globs []*ast.Glob, visit func(path string, info fs.FileInfo) error) (negated bool, err error) {
+	for _, g := range globs {
+		if g.Negate {
+			return true, nil
+		}
+	}
+
+	for _, g := range globs {
+		pattern := filepathext.SmartJoin(dir, g.Glob)
+		base, _ := splitGlobPattern(pattern)
+
+		walkErr := filepath.WalkDir(base, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			if !matchesPattern(path, base, pattern) {
+				return nil
+			}
+			info, infoErr := d.Info()
+			if infoErr != nil {
+				return nil
+			}
+			return visit(path, info)
+		})
+		if walkErr != nil && !errors.Is(walkErr, errStop) {
+			continue
+		}
+		if errors.Is(walkErr, errStop) {
+			return false, nil
+		}
+	}
+	return false, nil
+}
+
+// matchesPattern checks whether a file path matches a glob pattern.
+// It tries filepath.Match first, then falls back to matchesGlobStar
+// for ** patterns that filepath.Match doesn't support.
+func matchesPattern(path, base, pattern string) bool {
+	_, globSuffix := splitGlobPattern(pattern)
+
+	// Try matching the full path against the suffix.
+	if matched, err := filepath.Match(globSuffix, path); err == nil && matched {
+		return true
+	}
+
+	// Try matching the relative path from base.
+	if rel, err := filepath.Rel(base, path); err == nil {
+		if matched, err := filepath.Match(globSuffix, rel); err == nil && matched {
+			return true
+		}
+	}
+
+	// Fall back to ** matching against the full pattern.
+	return matchesGlobStar(path, pattern)
+}
+
+// anyGlobNewerThan checks if any file matching the given globs has a modification
+// time newer than referenceTime. It walks each glob's base directory and checks
+// timestamps inline, short-circuiting as soon as a newer file is found.
+func anyGlobNewerThan(dir string, globs []*ast.Glob, referenceTime time.Time) (bool, error) {
+	found := false
+	negated, err := walkGlobFiles(dir, globs, func(_ string, info fs.FileInfo) error {
+		if info.ModTime().After(referenceTime) {
+			found = true
+			return errStop
+		}
+		return nil
+	})
+	if negated {
+		sources, err := Globs(dir, globs)
+		if err != nil {
+			return false, err
+		}
+		return anyFileNewerThan(sources, referenceTime)
+	}
+	return found, err
+}
+
+// GlobsMaxTime returns the maximum modification time among all files matching
+// the given globs. It walks directories directly to avoid the expensive full
+// glob expansion via execext.ExpandFields.
+func GlobsMaxTime(dir string, globs []*ast.Glob) (time.Time, error) {
+	var maxT time.Time
+	negated, err := walkGlobFiles(dir, globs, func(_ string, info fs.FileInfo) error {
+		if info.ModTime().After(maxT) {
+			maxT = info.ModTime()
+		}
+		return nil
+	})
+	if negated {
+		sources, err := Globs(dir, globs)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return getMaxTime(sources...)
+	}
+	return maxT, err
+}
+
+// splitGlobPattern splits a glob pattern into a concrete base directory
+// and the remaining glob suffix. For example:
+//
+//	"/home/user/project/gqlgen/**/*.gql" → ("/home/user/project/gqlgen", "**/*.gql")
+//	"./src/**/*.gql" → ("./src", "**/*.gql")
+func splitGlobPattern(pattern string) (base, suffix string) {
+	dir := pattern
+	for {
+		if dir == "." || dir == "/" {
+			return dir, pattern
+		}
+		base := filepath.Base(dir)
+		if strings.ContainsAny(base, "*?[{") {
+			dir = filepath.Dir(dir)
+			continue
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		if !strings.ContainsAny(parent, "*?[{") {
+			return dir, strings.TrimPrefix(strings.TrimPrefix(pattern, dir), string(filepath.Separator))
+		}
+		dir = parent
+	}
+	return ".", pattern
+}
+
+// matchesGlobStar checks if a file path matches a pattern containing **.
+// It handles the common cases of "base/**/*.ext" and "base/**".
+func matchesGlobStar(filePath, pattern string) bool {
+	if idx := strings.Index(pattern, "/**/"); idx >= 0 {
+		base := pattern[:idx]
+		suffix := pattern[idx+4:] // after "/**/"
+
+		if !strings.HasPrefix(filePath, base+"/") && filePath != base {
+			return false
+		}
+
+		if !strings.ContainsAny(suffix, "*?[{") {
+			return filepath.Base(filePath) == suffix
+		}
+
+		matched, err := filepath.Match(suffix, filepath.Base(filePath))
+		return err == nil && matched
+	}
+
+	if strings.HasSuffix(pattern, "/**") {
+		base := strings.TrimSuffix(pattern, "/**")
+		return strings.HasPrefix(filePath, base+"/")
+	}
+
+	return false
 }

--- a/internal/fingerprint/glob_test.go
+++ b/internal/fingerprint/glob_test.go
@@ -1,0 +1,243 @@
+package fingerprint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-task/task/v3/taskfile/ast"
+)
+
+func TestSplitGlobPattern(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		pattern        string
+		expectedBase   string
+		expectedSuffix string
+	}{
+		{
+			name:           "double star with extension",
+			pattern:        "/home/user/project/gqlgen/**/*.gql",
+			expectedBase:   "/home/user/project/gqlgen",
+			expectedSuffix: "**/*.gql",
+		},
+		{
+			name:           "double star only",
+			pattern:        "/home/user/project/**",
+			expectedBase:   "/home/user/project",
+			expectedSuffix: "**",
+		},
+		{
+			name:           "single star",
+			pattern:        "/home/user/project/*.go",
+			expectedBase:   "/home/user/project",
+			expectedSuffix: "*.go",
+		},
+		{
+			name:           "no glob characters",
+			pattern:        "/home/user/project/file.go",
+			expectedBase:   "/home/user/project/file.go",
+			expectedSuffix: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			base, suffix := splitGlobPattern(tt.pattern)
+			assert.Equal(t, tt.expectedBase, base)
+			assert.Equal(t, tt.expectedSuffix, suffix)
+		})
+	}
+}
+
+func TestMatchesGlobStar(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		filePath string
+		pattern  string
+		expected bool
+	}{
+		{
+			name:     "matches double star with extension",
+			filePath: "/project/src/deep/nested/file.gql",
+			pattern:  "/project/src/**/*.gql",
+			expected: true,
+		},
+		{
+			name:     "does not match wrong extension",
+			filePath: "/project/src/deep/file.go",
+			pattern:  "/project/src/**/*.gql",
+			expected: false,
+		},
+		{
+			name:     "does not match outside base",
+			filePath: "/other/src/file.gql",
+			pattern:  "/project/src/**/*.gql",
+			expected: false,
+		},
+		{
+			name:     "matches double star catch-all",
+			filePath: "/project/src/any/file.txt",
+			pattern:  "/project/src/**",
+			expected: true,
+		},
+		{
+			name:     "does not match catch-all outside base",
+			filePath: "/other/file.txt",
+			pattern:  "/project/src/**",
+			expected: false,
+		},
+		{
+			name:     "no double star returns false",
+			filePath: "/project/file.go",
+			pattern:  "/project/*.go",
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, matchesGlobStar(tt.filePath, tt.pattern))
+		})
+	}
+}
+
+// setupTestDir creates a temp directory with test files and returns the path
+// and a cleanup function.
+func setupTestDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Create directory structure
+	for _, sub := range []string{"src/a", "src/b/nested", "other"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, sub), 0o755))
+	}
+
+	// Create files
+	files := []string{
+		"src/a/one.gql",
+		"src/a/two.go",
+		"src/b/nested/three.gql",
+		"src/b/four.gql",
+		"other/five.gql",
+	}
+	for _, f := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, f), []byte("test"), 0o644))
+	}
+
+	return dir
+}
+
+func TestAnyGlobNewerThan(t *testing.T) {
+	t.Parallel()
+
+	dir := setupTestDir(t)
+	past := time.Now().Add(-1 * time.Hour)
+	future := time.Now().Add(1 * time.Hour)
+
+	tests := []struct {
+		name          string
+		globs         []*ast.Glob
+		referenceTime time.Time
+		expected      bool
+	}{
+		{
+			name:          "files newer than past time",
+			globs:         []*ast.Glob{{Glob: "src/**/*.gql"}},
+			referenceTime: past,
+			expected:      true,
+		},
+		{
+			name:          "no files newer than future time",
+			globs:         []*ast.Glob{{Glob: "src/**/*.gql"}},
+			referenceTime: future,
+			expected:      false,
+		},
+		{
+			name:          "no matching files",
+			globs:         []*ast.Glob{{Glob: "src/**/*.xyz"}},
+			referenceTime: past,
+			expected:      false,
+		},
+		{
+			name: "multiple globs",
+			globs: []*ast.Glob{
+				{Glob: "src/**/*.gql"},
+				{Glob: "other/**/*.gql"},
+			},
+			referenceTime: past,
+			expected:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := anyGlobNewerThan(dir, tt.globs, tt.referenceTime)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGlobsMaxTime(t *testing.T) {
+	t.Parallel()
+
+	dir := setupTestDir(t)
+
+	// Touch one file to have a known max time
+	knownTime := time.Now().Add(1 * time.Hour).Truncate(time.Second)
+	require.NoError(t, os.Chtimes(
+		filepath.Join(dir, "src/b/nested/three.gql"),
+		knownTime, knownTime,
+	))
+
+	tests := []struct {
+		name     string
+		globs    []*ast.Glob
+		expected time.Time
+	}{
+		{
+			name:     "finds max time among matching files",
+			globs:    []*ast.Glob{{Glob: "src/**/*.gql"}},
+			expected: knownTime,
+		},
+		{
+			name:     "no matching files returns zero time",
+			globs:    []*ast.Glob{{Glob: "src/**/*.xyz"}},
+			expected: time.Time{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := GlobsMaxTime(dir, tt.globs)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestAnyGlobNewerThanWithNegation(t *testing.T) {
+	t.Parallel()
+
+	dir := setupTestDir(t)
+	past := time.Now().Add(-1 * time.Hour)
+
+	// Negated globs should fall back to Globs+anyFileNewerThan
+	globs := []*ast.Glob{
+		{Glob: "src/**/*.gql"},
+		{Glob: "src/b/**/*.gql", Negate: true},
+	}
+	result, err := anyGlobNewerThan(dir, globs, past)
+	require.NoError(t, err)
+	// src/a/one.gql should still match (not negated)
+	assert.True(t, result)
+}

--- a/internal/fingerprint/sources_timestamp.go
+++ b/internal/fingerprint/sources_timestamp.go
@@ -28,10 +28,6 @@ func (checker *TimestampChecker) IsUpToDate(t *ast.Task) (bool, error) {
 		return false, nil
 	}
 
-	sources, err := Globs(t.Dir, t.Sources)
-	if err != nil {
-		return false, nil
-	}
 	generates, err := Globs(t.Dir, t.Generates)
 	if err != nil {
 		return false, nil
@@ -68,8 +64,8 @@ func (checker *TimestampChecker) IsUpToDate(t *ast.Task) (bool, error) {
 		return false, nil
 	}
 
-	// Check if any of the source files is newer than the max time of the generates.
-	shouldUpdate, err := anyFileNewerThan(sources, generateMaxTime)
+	// Check if any source file is newer than the max time of the generates.
+	shouldUpdate, err := anyGlobNewerThan(t.Dir, t.Sources, generateMaxTime)
 	if err != nil {
 		return false, nil
 	}
@@ -90,12 +86,7 @@ func (checker *TimestampChecker) Kind() string {
 
 // Value implements the Checker Interface
 func (checker *TimestampChecker) Value(t *ast.Task) (any, error) {
-	sources, err := Globs(t.Dir, t.Sources)
-	if err != nil {
-		return time.Now(), err
-	}
-
-	sourcesMaxTime, err := getMaxTime(sources...)
+	sourcesMaxTime, err := GlobsMaxTime(t.Dir, t.Sources)
 	if err != nil {
 		return time.Now(), err
 	}

--- a/variables.go
+++ b/variables.go
@@ -181,7 +181,7 @@ func (e *Executor) compiledTask(call *Call, evaluateShVars bool) (*ast.Task, err
 		}
 	}
 
-	if len(origTask.Sources) > 0 && origTask.Method != "none" {
+	if evaluateShVars && len(origTask.Sources) > 0 && origTask.Method != "none" {
 		var checker fingerprint.SourcesCheckable
 
 		if origTask.Method == "timestamp" {


### PR DESCRIPTION
## Summary

Fixes #2746

Optimizes `method: timestamp` fingerprinting for tasks with large glob patterns (e.g. `**/*.gql` matching thousands of files). Achieves a **3x speedup** (6.6s → 2.2s) on a real-world monorepo.

### Changes

- **`walkGlobFiles` helper** (`glob.go`): Shared function that uses `filepath.WalkDir` to walk directories and match files inline, avoiding the expensive full glob expansion via `execext.ExpandFields`. Both `anyGlobNewerThan` and `GlobsMaxTime` reuse this helper.
- **`anyGlobNewerThan`** (`glob.go`): Checks if any source file is newer than a reference time by walking directories directly, short-circuiting on the first match.
- **`GlobsMaxTime`** (`glob.go`): Computes the maximum modification time among matching files without building a full file list.
- **`Value()` uses `GlobsMaxTime`** (`sources_timestamp.go`): Replaces `Globs()` + `getMaxTime()` with the walk-based approach.
- **`IsUpToDate` uses `anyGlobNewerThan`** (`sources_timestamp.go`): Replaces `Globs()` + `anyFileNewerThan()` with the walk-based approach.
- **Gate `Value()` behind `evaluateShVars`** (`variables.go`): `FastCompiledTask` no longer triggers `Value()`, eliminating a redundant ~2.7s glob expansion per task invocation.

All new functions fall back to the standard `Globs()` approach when negated globs are present, preserving backward compatibility.

### Benchmark

Tested on a monorepo with `**/*.gql` patterns matching ~5000 files:

| Approach | Time |
|----------|------|
| Before (current main) | ~6.6s |
| After (this PR) | ~2.2s |

### Test plan

- [x] All existing fingerprint tests pass
- [x] New unit tests for `splitGlobPattern`, `matchesGlobStar`, `anyGlobNewerThan`, `GlobsMaxTime`, and negated glob fallback
- [x] Manual testing: task correctly detects stale sources and skips up-to-date tasks
- [x] `go vet` clean