### PR TITLE
docs: use dependent in gentle force docs

### DIFF
--- a/website/src/docs/experiments/gentle-force.md
+++ b/website/src/docs/experiments/gentle-force.md
@@ -34,15 +34,15 @@ information.
 The `--force` flag currently forces _all_ tasks to run regardless of the status
 checks. This can be useful, but we have found that most of the time users only
 expect the direct task they are calling to be forced and _not_ all of its
-dependant tasks.
+dependent tasks.
 
 This experiment changes the `--force` flag to only force the directly called
-task. All dependant tasks will have their statuses checked as normal and will
+task. All dependent tasks will have their statuses checked as normal and will
 only run if Task considers them to be out of date. A new `--force-all` flag will
 also be added to maintain the current behavior for users that need this
 functionality.
 
-If you want to migrate, but continue to force all dependant tasks to run, you
+If you want to migrate, but continue to force all dependent tasks to run, you
 should replace all uses of the `--force` flag with `--force-all`. Alternatively,
 if you want to adopt the new behavior, you can continue to use the `--force`
 flag as you do now!


### PR DESCRIPTION
## Summary
- use "dependent" consistently in the gentle force experiment docs

## Related issue
- N/A (trivial docs wording fix)

## Guideline alignment
- Contribution guide: https://taskfile.dev/contributing/
- PR template: https://github.com/go-task/task/blob/main/.github/pull_request_template.md

## Validation
- Not run (docs-only change)
