### PR TITLE
ci: add security action with `govulncheck` + enable `gosec` linter

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,19 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{matrix.platform}}
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go ${{matrix.go-version}}
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,9 @@ linters:
     - tparallel
     - usetesting
   settings:
+    gosec:
+      excludes:
+        - G306
     depguard:
       rules:
         main:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ formatters:
 linters:
   enable:
     - depguard
+    - gosec
     - mirror
     - misspell
     - noctx

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -117,7 +117,7 @@ func changelog(version *semver.Version) error {
 	changelog = changelogReleaseRegex.ReplaceAllString(changelog, fmt.Sprintf("## v%s - %s", version, date))
 
 	// Write the changelog to the source file
-	if err := os.WriteFile(changelogSource, []byte(changelog), 0o644); err != nil {
+	if err := os.WriteFile(changelogSource, []byte(changelog), 0o644); err != nil { //nolint:gosec
 		return err
 	}
 
@@ -129,7 +129,7 @@ func changelog(version *semver.Version) error {
 	changelogWithFrontmatter := fmt.Sprintf("---\n%s\n---\n\n%s", frontmatter, changelogWithVPre)
 
 	// Write the changelog to the target file
-	return os.WriteFile(changelogTarget, []byte(changelogWithFrontmatter), 0o644)
+	return os.WriteFile(changelogTarget, []byte(changelogWithFrontmatter), 0o644) //nolint:gosec
 }
 
 func setVersionFile(fileName string, version *semver.Version) error {

--- a/internal/term/term.go
+++ b/internal/term/term.go
@@ -7,5 +7,5 @@ import (
 )
 
 func IsTerminal() bool {
-	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd())) //nolint:gosec
 }

--- a/task_test.go
+++ b/task_test.go
@@ -1022,7 +1022,7 @@ func TestIncludesRemote(t *testing.T) {
 
 					for k, taskCall := range taskCalls {
 						t.Run(taskCall.Task, func(t *testing.T) {
-							expectedContent := fmt.Sprint(rand.Int64())
+							expectedContent := fmt.Sprint(rand.Int64()) //nolint:gosec
 							t.Setenv("CONTENT", expectedContent)
 
 							outputFile := fmt.Sprintf("%d.%d.txt", i, k)

--- a/taskfile/node_http.go
+++ b/taskfile/node_http.go
@@ -38,7 +38,7 @@ func buildHTTPClient(insecure bool, caCert, cert, certKey string) (*http.Client,
 	}
 
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: insecure,
+		InsecureSkipVerify: insecure, //nolint:gosec
 	}
 
 	// Load custom CA certificate if provided

--- a/taskrc/reader.go
+++ b/taskrc/reader.go
@@ -65,7 +65,7 @@ func (r *Reader) Read(node *Node) (*ast.TaskRC, error) {
 	}
 
 	// Read the file
-	b, err := os.ReadFile(node.entrypoint)
+	b, err := os.ReadFile(node.entrypoint) //nolint:gosec
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Some explanation:

* [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) is a native Go tool that checks if we're using any vulnarable dependencies, including modules from `go.mod` and also Go itself. When it fails, we need to update that specific dependency or [the minimal Go version](https://github.com/go-task/task/blob/8fa9dc04aca4a372bd4c5a7ba84a2bc3e7eab82a/go.mod#L3) to the latest patch.
* [gosec](https://github.com/securego/gosec) is a tool that checks for security issues on our Go code. We're running it via `golangci-lint`. When not relevant, can be ignored with `//nolint:gosec`.