### PR TITLE
build(deps): declare ourself as a 'go tool' for ourself

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,3 +134,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+tool github.com/go-task/task/v3/cmd/task


### PR DESCRIPTION
In go.mod declare ourself as a [tool](https://go.dev/doc/modules/managing-dependencies#tools) for our own consumption.

```console
$ go get -tool ./cmd/task
```

Task developers can now run tasks via `go tool task`, independently of the `task` installed in `$PATH`.

This is a first step before further experiments of integrations such as #2784.

## Meta
- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/)
