### PR TITLE
feat(templater): add absPath template function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v3.50.0 - 2026-04-13
 
 - Added `enum.ref` support in `requires`: enum constraints can now reference
   variables or template pipelines (e.g., `ref: .ALLOWED_ENVS`) instead of
@@ -10,8 +10,6 @@
   `$GO_TASK_PROGNAME` for experiments cache (#2730, #2727 by @SergioChan).
 - Fixed watch mode ignoring SIGHUP signal, causing the watcher to exit instead
   of restarting (#2764, #2642).
-- Added `absPath` template function that resolves a path to absolute form
-  (wraps `filepath.Abs`), cleaning `..` and `.` components (#2681).
 - Fixed a long time bug where the task wouldn't re-run as it should when using
   `method: timestamp` and the files listed on `generates:` were deleted.
   This makes `method: timestamp` behaves the same as `method: checksum`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   `$GO_TASK_PROGNAME` for experiments cache (#2730, #2727 by @SergioChan).
 - Fixed watch mode ignoring SIGHUP signal, causing the watcher to exit instead
   of restarting (#2764, #2642).
+- Added `absPath` template function that resolves a path to absolute form
+  (wraps `filepath.Abs`), cleaning `..` and `.` components (#2681).
 - Fixed a long time bug where the task wouldn't re-run as it should when using
   `method: timestamp` and the files listed on `generates:` were deleted.
   This makes `method: timestamp` behaves the same as `method: checksum`

--- a/internal/templater/funcs.go
+++ b/internal/templater/funcs.go
@@ -34,6 +34,7 @@ func init() {
 		"IsSH":         IsSH, // Deprecated
 		"joinPath":     filepath.Join,
 		"relPath":      filepath.Rel,
+		"absPath":      filepath.Abs,
 		"merge":        merge,
 		"spew":         spew.Sdump,
 		"fromYaml":     fromYaml,

--- a/task_test.go
+++ b/task_test.go
@@ -2601,6 +2601,23 @@ func TestSplitArgs(t *testing.T) {
 	assert.Equal(t, "3\n", buff.String())
 }
 
+func TestAbsPath(t *testing.T) {
+	t.Parallel()
+
+	var buff bytes.Buffer
+	e := task.NewExecutor(
+		task.WithDir("testdata/abs_path"),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSilent(true),
+	)
+	require.NoError(t, e.Setup())
+
+	err := e.Run(t.Context(), &task.Call{Task: "default"})
+	require.NoError(t, err)
+	assert.Equal(t, "bar\n", buff.String())
+}
+
 func TestSingleCmdDep(t *testing.T) {
 	t.Parallel()
 

--- a/task_test.go
+++ b/task_test.go
@@ -2615,7 +2615,11 @@ func TestAbsPath(t *testing.T) {
 
 	err := e.Run(t.Context(), &task.Call{Task: "default"})
 	require.NoError(t, err)
-	assert.Equal(t, "bar\n", buff.String())
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	expected := filepath.Join(cwd, "bar") + "\n"
+	assert.Equal(t, expected, buff.String())
 }
 
 func TestSingleCmdDep(t *testing.T) {

--- a/testdata/abs_path/Taskfile.yml
+++ b/testdata/abs_path/Taskfile.yml
@@ -3,4 +3,4 @@ version: '3'
 tasks:
   default:
     cmds:
-      - cmd: echo '{{absPath "foo/../bar" | base}}'
+      - cmd: echo '{{absPath "foo/../bar" | osBase}}'

--- a/testdata/abs_path/Taskfile.yml
+++ b/testdata/abs_path/Taskfile.yml
@@ -3,4 +3,4 @@ version: '3'
 tasks:
   default:
     cmds:
-      - cmd: echo '{{absPath "foo/../bar" | osBase}}'
+      - cmd: echo '{{absPath "foo/../bar"}}'

--- a/testdata/abs_path/Taskfile.yml
+++ b/testdata/abs_path/Taskfile.yml
@@ -1,0 +1,6 @@
+version: '3'
+
+tasks:
+  default:
+    cmds:
+      - cmd: echo '{{absPath "foo/../bar" | base}}'

--- a/website/src/docs/reference/templating.md
+++ b/website/src/docs/reference/templating.md
@@ -617,6 +617,7 @@ tasks:
       - echo "{{.WIN_PATH | fromSlash}}"                        # Convert to OS-specific slashes
       - echo "{{joinPath .OUTPUT_DIR .BINARY_NAME}}"            # Join path elements
       - echo "Relative {{relPath .ROOT_DIR .TASKFILE_DIR}}"    # Get relative path
+      - echo '{{absPath "../sibling"}}'                         # Resolve to an absolute path
 ```
 
 ### Data Structure Functions


### PR DESCRIPTION
adds absPath as a thin wrapper over filepath.Abs so Taskfiles can resolve paths with .. or . components without shelling out. slots in next to joinPath and relPath in internal/templater/funcs.go, same one-liner style.

originally discussed in #2681. i first tried adding osAbs in slim-sprig (go-task/slim-sprig#23), but per @trulede's suggestion in https://github.com/go-task/task/issues/2681#issuecomment-4238152667 that repo is inactive, so moving the change here instead.

the integration test under testdata/abs_path verifies `{{absPath "foo/../bar" | base}}` resolves to "bar". also added a one-line example to the Path Functions section of the templating reference docs, and a CHANGELOG entry.

symlink resolution (filepath.EvalSymlinks) was also mentioned in the issue but keeping scope to just absPath for now, happy to follow up with a second PR if wanted.

Fixes #2681