### PR TITLE
feat: add permissions to actions

### DIFF
--- a/.github/workflows/issue-awaiting-response.yml
+++ b/.github/workflows/issue-awaiting-response.yml
@@ -4,13 +4,16 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+
 jobs:
   issue-awaiting-response:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{secrets.GH_PAT}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const issue = await github.rest.issues.get({
               owner: context.repo.owner,

--- a/.github/workflows/issue-closed.yml
+++ b/.github/workflows/issue-closed.yml
@@ -4,13 +4,16 @@ on:
   issues:
     types: [closed]
 
+permissions:
+  issues: write
+
 jobs:
   issue-closed:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{secrets.GH_PAT}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const labels = await github.paginate(
               github.rest.issues.listLabelsOnIssue, {

--- a/.github/workflows/issue-experiment.yml
+++ b/.github/workflows/issue-experiment.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [field_added]
 
+permissions:
+  issues: write
+
 jobs:
   issue-experiment-proposal:
     if: github.event.issue_field.id == '6591' && github.event.issue_field_value.option.name == 'proposal'
@@ -11,7 +14,7 @@ jobs:
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{secrets.GH_PAT}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -25,7 +28,7 @@ jobs:
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{secrets.GH_PAT}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -39,7 +42,7 @@ jobs:
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{secrets.GH_PAT}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -53,7 +56,7 @@ jobs:
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{secrets.GH_PAT}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -67,7 +70,7 @@ jobs:
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{secrets.GH_PAT}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -87,7 +90,7 @@ jobs:
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{secrets.GH_PAT}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,
@@ -107,7 +110,7 @@ jobs:
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{secrets.GH_PAT}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/.github/workflows/issue-needs-triage.yml
+++ b/.github/workflows/issue-needs-triage.yml
@@ -4,13 +4,16 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  issues: write
+
 jobs:
   issue-needs-triage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{secrets.GH_PAT}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const labels = await github.paginate(
               github.rest.issues.listLabelsOnIssue, {

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,11 +19,11 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.x'
+          go-version: "1.26.x"
           cache: true
       - uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
-          version: '~> v2'
+          version: "~> v2"
           args: release --snapshot --clean --config .goreleaser-pr.yml
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -52,12 +52,12 @@ jobs:
       - uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find-comment
         with:
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{secrets.GITHUB_TOKEN}}
           issue-number: ${{ github.event.pull_request.number }}
-          body-includes: '📦 Build artifacts ready!'
+          body-includes: "📦 Build artifacts ready!"
       - uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
-          token: ${{ secrets.GH_PAT || github.token }}
+          token: ${{secrets.GITHUB_TOKEN}}
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: 0 0 * * *
+
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -25,6 +29,6 @@ jobs:
           version: latest
           args: release --clean --nightly -f .goreleaser-nightly.yml
         env:
-          GITHUB_TOKEN: ${{secrets.GH_PAT}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           GORELEASER_KEY: ${{secrets.GORELEASER_KEY}}
           CLOUDSMITH_TOKEN: ${{secrets.CLOUDSMITH_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,11 @@ name: goreleaser
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 permissions:
-  id-token: write  # Required for OIDC
-  contents: read
+  id-token: write # Required for OIDC
+  contents: write
 
 jobs:
   goreleaser:
@@ -25,8 +25,8 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Update npm
         run: npm install -g npm@latest
@@ -37,8 +37,8 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
-          package_json_file: 'website/package.json'
-          run_install: 'true'
+          package_json_file: "website/package.json"
+          run_install: "true"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
@@ -47,7 +47,7 @@ jobs:
           version: latest
           args: release --clean --draft
         env:
-          GITHUB_TOKEN: ${{secrets.GH_PAT}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           GORELEASER_KEY: ${{secrets.GORELEASER_KEY}}
           CLOUDSMITH_TOKEN: ${{secrets.CLOUDSMITH_TOKEN}}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Uses `${{secrets.GITHUB_TOKEN}}` instead of the PAT and adds the `permissions` block to every workflow per best practice.

My formatter also insisted on making YAML quotes consistent. Can remove this if unwanted.