### PR TITLE
feat: use GH_PAT for goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,6 +89,7 @@ brews:
     repository:
       owner: go-task
       name: homebrew-tap
+      token: "{{secrets.GH_GORELEASER_TOKEN}}" # So that it runs as the task-bot user
     test: system "#{bin}/task", "--help"
     install: |-
       bin.install "task"
@@ -130,6 +131,7 @@ winget:
       owner: go-task
       name: winget-pkgs
       branch: 'task-{{.Version}}'
+      token: "{{secrets.GH_GORELEASER_TOKEN}}" # So that it runs as the task-bot user
       pull_request:
         enabled: true
         draft: false
@@ -140,7 +142,6 @@ winget:
           branch: master
         body: |
           /cc @andreynering @pd93 @vmaerten
-
 
 npms:
   - name: "@go-task/cli"


### PR DESCRIPTION
Need to recreate `GH_PAT` before merging.