### PR TITLE
fix(compiler): create task.dir before running dynamic (sh:) vars

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -166,6 +166,22 @@ func (c *Compiler) HandleDynamicVar(v ast.Var, dir string, e []string) (string, 
 		dir = v.Dir
 	}
 
+	// The task's `dir:` is documented as "Directory which this task should
+	// run. Defaults to the current working directory. If the directory does
+	// not exist, Task creates it." Dynamic variables (`sh:`) compile before
+	// the task's `mkdir` runs, so without this guard the shell executes
+	// with Dir pointing at a non-existent path and aborts with a cryptic
+	// chdir error. Create the directory here with the same 0o755 perms the
+	// main task mkdir uses, so `sh:` variables behave like task commands.
+	// See https://github.com/go-task/task/issues/1001.
+	if dir != "" {
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return "", fmt.Errorf(`task: cannot make directory %q for dynamic variable: %w`, dir, err)
+			}
+		}
+	}
+
 	var stdout bytes.Buffer
 	opts := &execext.RunCommandOptions{
 		Command: *v.Sh,


### PR DESCRIPTION
Fixes #1001.

## Problem

A tasks `dir:` is documented as being created on demand:

> **dir** &mdash; Directory which this task should run. Defaults to the current working directory. If the directory does not exist, Task creates it.

but dynamic variables (`sh:`) are compiled **before** the tasks `mkdir` step runs. So this Taskfile:

```yaml
test-dir:
  dir: does-not-exist
  cmds:
    - echo {{.TEST}}
  vars:
    TEST:
      sh: cat ../exist.txt
```

aborts with a cryptic `chdir` error:

```
task: Command "cat ../exist.txt" failed: chdir /…/does-not-exist: no such file or directory
```

even though running the same command inside `cmds:` works fine, because `mkdir` runs before `runCommand` for normal commands but *after* variable compilation.

## Fix

`Compiler.HandleDynamicVar` now creates `dir` with `0o755` (the same permissions `Executor.mkdir` uses at `task.go:311`) before calling `execext.RunCommand`. Dynamic variables and cmds now see the same filesystem state, and the documented `dir:` semantics hold for both.

```go
if dir != "" {
    if _, err := os.Stat(dir); os.IsNotExist(err) {
        if err := os.MkdirAll(dir, 0o755); err != nil {
            return "", fmt.Errorf(...)
        }
    }
}
```

No behaviour change when the directory already exists; no behaviour change for tasks without `sh:` vars.

Signed off per DCO.