### PR TITLE
fix: refresh for-loop commands after deps

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -894,6 +894,47 @@ func TestForCmds(t *testing.T) {
 	}
 }
 
+func TestForCmdsRecompileAfterDeps(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Taskfile.yml"), []byte(`
+version: '3'
+
+tasks:
+  create-deps:
+    cmds:
+      - mkdir -p generated
+      - printf 'a\n' > generated/a.dep
+      - printf 'b\n' > generated/b.dep
+      - printf 'c\n' > generated/c.dep
+
+  use-deps:
+    deps:
+      - create-deps
+    sources:
+      - generated/*.dep
+    cmds:
+      - for: sources
+        cmd: cat "{{.ITEM}}"
+`), 0o644))
+
+	var buffer SyncBuffer
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithSilent(true),
+		task.WithStdout(&buffer),
+		task.WithStderr(&buffer),
+	)
+	require.NoError(t, e.Setup())
+	require.NoError(t, e.Run(t.Context(), &task.Call{
+		Task: "use-deps",
+		Vars: ast.NewVars(),
+	}))
+
+	require.Equal(t, "a\nb\nc\n", string(PPSortedLines(t, buffer.buf.Bytes())))
+}
+
 func TestForDeps(t *testing.T) {
 	t.Parallel()
 

--- a/task.go
+++ b/task.go
@@ -209,6 +209,18 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 		if err := e.runDeps(ctx, t); err != nil {
 			return err
 		}
+		if len(t.Deps) > 0 {
+			// Dependencies can materialize files that `for: sources` / `for: generates`
+			// loops expand over, so refresh the compiled command list after deps run.
+			origTask, err := e.GetTask(call)
+			if err != nil {
+				return err
+			}
+			cache := &templater.Cache{Vars: t.Vars}
+			if err := compileCmds(origTask, t, t.Vars, cache); err != nil {
+				return err
+			}
+		}
 
 		skipFingerprinting := e.ForceAll || (!call.Indirect && e.Force)
 		if !skipFingerprinting {

--- a/variables.go
+++ b/variables.go
@@ -212,54 +212,8 @@ func (e *Executor) compiledTask(call *Call, evaluateShVars bool) (*ast.Task, err
 		cache.ResetCache()
 	}
 
-	if len(origTask.Cmds) > 0 {
-		new.Cmds = make([]*ast.Cmd, 0, len(origTask.Cmds))
-		for _, cmd := range origTask.Cmds {
-			if cmd == nil {
-				continue
-			}
-			if cmd.For != nil {
-				list, keys, err := itemsFromFor(cmd.For, new.Dir, new.Sources, new.Generates, vars, origTask.Location, cache)
-				if err != nil {
-					return nil, err
-				}
-				// Name the iterator variable
-				var as string
-				if cmd.For.As != "" {
-					as = cmd.For.As
-				} else {
-					as = "ITEM"
-				}
-				// Create a new command for each item in the list
-				for i, loopValue := range list {
-					extra := map[string]any{
-						as: loopValue,
-					}
-					if len(keys) > 0 {
-						extra["KEY"] = keys[i]
-					}
-					newCmd := cmd.DeepCopy()
-					newCmd.Cmd = templater.ReplaceWithExtra(cmd.Cmd, cache, extra)
-					newCmd.Task = templater.ReplaceWithExtra(cmd.Task, cache, extra)
-					newCmd.If = templater.ReplaceWithExtra(cmd.If, cache, extra)
-					newCmd.Vars = templater.ReplaceVarsWithExtra(cmd.Vars, cache, extra)
-					new.Cmds = append(new.Cmds, newCmd)
-				}
-				continue
-			}
-			// Defer commands are replaced in a lazy manner because
-			// we need to include EXIT_CODE.
-			if cmd.Defer {
-				new.Cmds = append(new.Cmds, cmd.DeepCopy())
-				continue
-			}
-			newCmd := cmd.DeepCopy()
-			newCmd.Cmd = templater.Replace(cmd.Cmd, cache)
-			newCmd.Task = templater.Replace(cmd.Task, cache)
-			newCmd.If = templater.Replace(cmd.If, cache)
-			newCmd.Vars = templater.ReplaceVars(cmd.Vars, cache)
-			new.Cmds = append(new.Cmds, newCmd)
-		}
+	if err := compileCmds(origTask, &new, vars, cache); err != nil {
+		return nil, err
 	}
 	if len(origTask.Deps) > 0 {
 		new.Deps = make([]*ast.Dep, 0, len(origTask.Deps))
@@ -332,6 +286,63 @@ func asAnySlice[T any](slice []T) []any {
 		ret[i] = v
 	}
 	return ret
+}
+
+func compileCmds(origTask *ast.Task, new *ast.Task, vars *ast.Vars, cache *templater.Cache) error {
+	if len(origTask.Cmds) == 0 {
+		new.Cmds = nil
+		return nil
+	}
+
+	new.Cmds = make([]*ast.Cmd, 0, len(origTask.Cmds))
+	for _, cmd := range origTask.Cmds {
+		if cmd == nil {
+			continue
+		}
+		if cmd.For != nil {
+			list, keys, err := itemsFromFor(cmd.For, new.Dir, new.Sources, new.Generates, vars, origTask.Location, cache)
+			if err != nil {
+				return err
+			}
+			// Name the iterator variable
+			var as string
+			if cmd.For.As != "" {
+				as = cmd.For.As
+			} else {
+				as = "ITEM"
+			}
+			// Create a new command for each item in the list
+			for i, loopValue := range list {
+				extra := map[string]any{
+					as: loopValue,
+				}
+				if len(keys) > 0 {
+					extra["KEY"] = keys[i]
+				}
+				newCmd := cmd.DeepCopy()
+				newCmd.Cmd = templater.ReplaceWithExtra(cmd.Cmd, cache, extra)
+				newCmd.Task = templater.ReplaceWithExtra(cmd.Task, cache, extra)
+				newCmd.If = templater.ReplaceWithExtra(cmd.If, cache, extra)
+				newCmd.Vars = templater.ReplaceVarsWithExtra(cmd.Vars, cache, extra)
+				new.Cmds = append(new.Cmds, newCmd)
+			}
+			continue
+		}
+		// Defer commands are replaced in a lazy manner because
+		// we need to include EXIT_CODE.
+		if cmd.Defer {
+			new.Cmds = append(new.Cmds, cmd.DeepCopy())
+			continue
+		}
+		newCmd := cmd.DeepCopy()
+		newCmd.Cmd = templater.Replace(cmd.Cmd, cache)
+		newCmd.Task = templater.Replace(cmd.Task, cache)
+		newCmd.If = templater.Replace(cmd.If, cache)
+		newCmd.Vars = templater.ReplaceVars(cmd.Vars, cache)
+		new.Cmds = append(new.Cmds, newCmd)
+	}
+
+	return nil
 }
 
 func itemsFromFor(


### PR DESCRIPTION
Fixes #1494

When a task uses `for: sources` and the matching files are created by a dependency, the first run can skip the task because the command list is compiled before the deps materialize those sources.

The issue in #1494 looks like a fingerprint ordering bug at first, but the stale piece is actually the compiled `cmds` list. `deps` already run before fingerprinting; the missing step is refreshing commands that loop over `sources` or `generates` after those deps finish.

This patch keeps the fix scoped to that command-refresh step. It rebuilds the compiled command list after deps complete, so `for: sources` / `for: generates` loops see newly created files without re-running dynamic `sh:` vars.

## Reproduction

```yaml
version: '3'

tasks:
  create_deps:
    cmds:
      - touch a.dep b.dep c.dep

  use_deps:
    deps:
      - create_deps
    sources:
      - '*.dep'
    cmds:
      - for: sources
        cmd: echo {{.ITEM}}
```

Before this change, a clean run only executed `create_deps`, and `use_deps` could then be treated as up to date because its compiled command list was still empty.

After this change, the same first run executes the expanded `use_deps` commands and prints all three generated files.

## Testing

- `go test ./... -run '^TestForCmdsRecompileAfterDeps$'`
- `go test ./...`
- `go run ./cmd/task -d /tmp/task1494-repro use_deps`
