### PR TITLE
fix: restore escaped brace command args

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.42.0
 	mvdan.cc/sh/moreinterp v0.0.0-20260120230322-19def062a997
-	mvdan.cc/sh/v3 v3.13.1
+	mvdan.cc/sh/v3 v3.13.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -315,5 +315,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 mvdan.cc/sh/moreinterp v0.0.0-20260120230322-19def062a997 h1:3bbJwtPFh98dJ6lxRdR3eLHTH1CmR3BcU6TriIMiXjE=
 mvdan.cc/sh/moreinterp v0.0.0-20260120230322-19def062a997/go.mod h1:Qy/zdaMDxq9sT72Gi43K3gsV+TtTohyDO3f1cyBVwuo=
-mvdan.cc/sh/v3 v3.13.1 h1:DP3TfgZhDkT7lerUdnp6PTGKyxxzz6T+cOlY/xEvfWk=
-mvdan.cc/sh/v3 v3.13.1/go.mod h1:lXJ8SexMvEVcHCoDvAGLZgFJ9Wsm2sulmoNEXGhYZD0=
+mvdan.cc/sh/v3 v3.13.0 h1:dSfq/MVsY4w0Vsi6Lbs0IcQquMVqLdKLESAOZjuHdLg=
+mvdan.cc/sh/v3 v3.13.0/go.mod h1:KV1GByGPc/Ho0X1E6Uz9euhsIQEj4hwyKnodLlFLoDM=

--- a/internal/execext/exec_test.go
+++ b/internal/execext/exec_test.go
@@ -1,0 +1,24 @@
+package execext_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-task/task/v3/internal/execext"
+)
+
+func TestRunCommandEscapedBraces(t *testing.T) {
+	t.Parallel()
+
+	var stdout bytes.Buffer
+	err := execext.RunCommand(context.Background(), &execext.RunCommandOptions{
+		Command: `printf '<%s>\n' \{\{iriname\}\}`,
+		Stdout:  &stdout,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "<{{iriname}}>\n", stdout.String())
+}


### PR DESCRIPTION
## Summary

- Pin `mvdan.cc/sh/v3` back to `v3.13.0` to restore shell-compatible handling of escaped braces in command arguments.
- Add a regression test for `\{\{iriname\}\}` being passed to the command as literal `{{iriname}}`.

Fixes #2812

## Testing

- `go test ./internal/execext -count=1`
- `go test ./... -run TestRunCommandEscapedBraces -count=1`
- `go test ./... -count=1`
- Manual Taskfile repro with `go run ./cmd/task --dir /tmp/oss-pr-pipeline/repro-2812 export`

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/)
