### PR TITLE
Perf: speed up `task --list` on projects with many includes

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -54,30 +54,45 @@ func (c *Compiler) getVariables(t *ast.Task, call *Call, evaluateShVars bool) (*
 		result.Set(k, ast.Var{Value: v})
 	}
 
+	// Share a single Cache across every rangeFunc invocation below. The
+	// previous implementation allocated a fresh Cache per variable, which
+	// caused Replace -> ToCacheMap to rebuild the full cacheMap on every
+	// call. SyncVarSet keeps the cacheMap in sync after each result.Set so
+	// subsequent Replace calls on the same cache can reuse it.
+	sharedCache := &templater.Cache{Vars: result}
+
 	getRangeFunc := func(dir string) func(k string, v ast.Var) error {
 		return func(k string, v ast.Var) error {
-			cache := &templater.Cache{Vars: result}
+			// Each variable is processed independently, so clear any sticky
+			// error from a previous template before evaluating this one.
+			sharedCache.ResetErr()
 			// Replace values
-			newVar := templater.ReplaceVar(v, cache)
+			newVar := templater.ReplaceVar(v, sharedCache)
 			// If the variable should not be evaluated, but is nil, set it to an empty string
 			// This stops empty interface errors when using the templater to replace values later
 			// Preserve the Sh field so it can be displayed in summary
 			if !evaluateShVars && newVar.Value == nil {
-				result.Set(k, ast.Var{Value: "", Sh: newVar.Sh})
+				out := ast.Var{Value: "", Sh: newVar.Sh}
+				result.Set(k, out)
+				sharedCache.SyncVarSet(k, out)
 				return nil
 			}
 			// If the variable should not be evaluated and it is set, we can set it and return
 			if !evaluateShVars {
-				result.Set(k, ast.Var{Value: newVar.Value, Sh: newVar.Sh})
+				out := ast.Var{Value: newVar.Value, Sh: newVar.Sh}
+				result.Set(k, out)
+				sharedCache.SyncVarSet(k, out)
 				return nil
 			}
 			// Now we can check for errors since we've handled all the cases when we don't want to evaluate
-			if err := cache.Err(); err != nil {
+			if err := sharedCache.Err(); err != nil {
 				return err
 			}
 			// If the variable is already set, we can set it and return
 			if newVar.Value != nil || newVar.Sh == nil {
-				result.Set(k, ast.Var{Value: newVar.Value})
+				out := ast.Var{Value: newVar.Value}
+				result.Set(k, out)
+				sharedCache.SyncVarSet(k, out)
 				return nil
 			}
 			// If the variable is dynamic, we need to resolve it first
@@ -85,7 +100,9 @@ func (c *Compiler) getVariables(t *ast.Task, call *Call, evaluateShVars bool) (*
 			if err != nil {
 				return err
 			}
-			result.Set(k, ast.Var{Value: static})
+			out := ast.Var{Value: static}
+			result.Set(k, out)
+			sharedCache.SyncVarSet(k, out)
 			return nil
 		}
 	}
@@ -95,11 +112,11 @@ func (c *Compiler) getVariables(t *ast.Task, call *Call, evaluateShVars bool) (*
 	if t != nil {
 		// NOTE(@andreynering): We're manually joining these paths here because
 		// this is the raw task, not the compiled one.
-		cache := &templater.Cache{Vars: result}
-		dir := templater.Replace(t.Dir, cache)
-		if err := cache.Err(); err != nil {
+		dir := templater.Replace(t.Dir, sharedCache)
+		if err := sharedCache.Err(); err != nil {
 			return nil, err
 		}
+		sharedCache.ResetErr()
 		dir = filepathext.SmartJoin(c.Dir, dir)
 		taskRangeFunc = getRangeFunc(dir)
 	}

--- a/internal/templater/templater.go
+++ b/internal/templater/templater.go
@@ -82,6 +82,13 @@ func ReplaceWithExtra[T any](v T, cache *Cache, extra map[string]any) T {
 
 	// Traverse the value and parse any template variables
 	copy, err := deepcopy.TraverseStringsFunc(v, func(v string) (string, error) {
+		// Skip the template engine entirely if the string has no actions.
+		// Go templates only fire on `{{`; pure literals can short-circuit.
+		// This is a large win when iterating many merged taskfile env vars
+		// whose values are static strings.
+		if !strings.Contains(v, "{{") {
+			return v, nil
+		}
 		tpl, err := template.New("").Funcs(templateFuncs).Parse(v)
 		if err != nil {
 			return v, err

--- a/internal/templater/templater.go
+++ b/internal/templater/templater.go
@@ -31,6 +31,38 @@ func (r *Cache) Err() error {
 	return r.err
 }
 
+// ResetErr clears the sticky error flag so a single Cache can be reused for
+// a sequence of independent template operations. Without this, the first
+// failed Replace would short-circuit every subsequent call on the same
+// Cache.
+func (r *Cache) ResetErr() {
+	r.err = nil
+}
+
+// SyncVarSet updates the internal cacheMap after the caller mutates Vars via
+// [ast.Vars.Set]. This lets a single Cache be reused across many Replace
+// calls (each interleaved with a Vars.Set) without rebuilding the entire
+// cacheMap from scratch via [ast.Vars.ToCacheMap]. The mirroring rules match
+// [ast.Vars.ToCacheMap]: dynamic-only entries are excluded, Live takes
+// precedence over Value.
+//
+// No-op if cacheMap has not yet been initialized — the lazy init in Replace
+// will pick up the value on first use.
+func (r *Cache) SyncVarSet(key string, v ast.Var) {
+	if r.cacheMap == nil {
+		return
+	}
+	if v.Sh != nil && *v.Sh != "" {
+		delete(r.cacheMap, key)
+		return
+	}
+	if v.Live != nil {
+		r.cacheMap[key] = v.Live
+	} else {
+		r.cacheMap[key] = v.Value
+	}
+}
+
 func ResolveRef(ref string, cache *Cache) any {
 	// If there is already an error, do nothing
 	if cache.err != nil {

--- a/internal/templater/templater.go
+++ b/internal/templater/templater.go
@@ -5,12 +5,50 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"sync"
 
 	"github.com/go-task/template"
 
 	"github.com/go-task/task/v3/internal/deepcopy"
 	"github.com/go-task/task/v3/taskfile/ast"
 )
+
+// dataMapPool reuses map[string]any backing memory across [ReplaceWithExtra]
+// calls. When a template might mutate the dot via sprig's set/unset, we
+// clone cache.cacheMap into a fresh map so those mutations cannot leak back
+// into cache.cacheMap. The maps are short-lived and identically shaped, so a
+// pool drops the per-call allocation without changing semantics.
+var dataMapPool = sync.Pool{
+	New: func() any {
+		m := make(map[string]any, 64)
+		return &m
+	},
+}
+
+func acquireDataMap() *map[string]any {
+	return dataMapPool.Get().(*map[string]any)
+}
+
+func releaseDataMap(m *map[string]any) {
+	clear(*m)
+	dataMapPool.Put(m)
+}
+
+// templateMayMutateDot reports whether a template source string might mutate
+// its dot (root data map). The only functions registered in templateFuncs
+// that mutate the dict passed to them are sprig's `set` and `unset`. Other
+// sprig mutators (push/append/prepend on slices) operate on slice values
+// retrieved from the dict — they do not modify the dict itself, and the
+// original code's shallow [maps.Clone] never protected against those either.
+//
+// This is a conservative substring check: false positives are fine (they
+// just force an unnecessary clone), false negatives would leak mutations.
+// "set" appearing inside a literal string ({{"set"}}) or inside an unrelated
+// identifier (settings, subset) is treated as potentially mutating, which is
+// safe. Checking for "set" alone also catches "unset".
+func templateMayMutateDot(s string) bool {
+	return strings.Contains(s, "set")
+}
 
 // Cache is a help struct that allow us to call "replaceX" funcs multiple
 // times, without having to check for error each time. The first error that
@@ -105,11 +143,46 @@ func ReplaceWithExtra[T any](v T, cache *Cache, extra map[string]any) T {
 		cache.cacheMap = cache.Vars.ToCacheMap()
 	}
 
-	// Create a copy of the cache map to avoid editing the original
-	// If there is extra data, merge it with the cache map
-	data := maps.Clone(cache.cacheMap)
-	if extra != nil {
-		maps.Copy(data, extra)
+	// Decide whether the template can read directly from cache.cacheMap or
+	// whether we must clone it. Cloning is required when there is `extra`
+	// data to merge in, or when any template traversed below might mutate
+	// the dict via sprig's set/unset. For all other cases the clone is pure
+	// overhead — tpl.Execute only reads from the data map.
+	//
+	// nil values (nil interface, nil *string) cannot run any template at
+	// all, so they don't need a cloned data map. Strings are checked for
+	// "set" anywhere. For other concrete types we conservatively clone.
+	mayMutate := false
+	switch {
+	case extra != nil:
+		mayMutate = true
+	case any(v) == nil:
+		// nil interface — TraverseStringsFunc has no strings to visit.
+		mayMutate = false
+	default:
+		switch tv := any(v).(type) {
+		case string:
+			mayMutate = templateMayMutateDot(tv)
+		case *string:
+			// nil pointer — no template runs.
+			mayMutate = tv != nil && templateMayMutateDot(*tv)
+		default:
+			// []string, map, struct, etc. — don't risk it.
+			mayMutate = true
+		}
+	}
+
+	var data map[string]any
+	if mayMutate {
+		dataPtr := acquireDataMap()
+		defer releaseDataMap(dataPtr)
+		data = *dataPtr
+		maps.Copy(data, cache.cacheMap)
+		if extra != nil {
+			maps.Copy(data, extra)
+		}
+	} else {
+		data = cache.cacheMap
 	}
 
 	// Traverse the value and parse any template variables

--- a/internal/templater/templater.go
+++ b/internal/templater/templater.go
@@ -50,6 +50,39 @@ func templateMayMutateDot(s string) bool {
 	return strings.Contains(s, "set")
 }
 
+// parsedTemplateCache memoizes parsed [template.Template] objects keyed by
+// their source string. Each call to template.New("").Funcs(templateFuncs)
+// copies the ~170-entry FuncMap into a fresh Template (sprig + go-task
+// builtins) — that copy is the single largest allocator on the hot path of
+// listing tasks in a project with many includes, because the same merged
+// TaskfileEnv values are processed once per task.
+//
+// Caching the parsed Template is safe: once parsed, a Template may be
+// executed concurrently from multiple goroutines (Go docs guarantee this),
+// and Execute reads from but does not mutate the Template. The cache key is
+// the unparsed source — sufficient because templateFuncs is a package-level
+// singleton.
+//
+// We cache errors as well so that a malformed template surfaces the same
+// error on every call instead of being re-parsed each time.
+var parsedTemplateCache sync.Map // map[string]parsedTemplateEntry
+
+type parsedTemplateEntry struct {
+	tpl *template.Template
+	err error
+}
+
+func cachedParse(text string) (*template.Template, error) {
+	if v, ok := parsedTemplateCache.Load(text); ok {
+		entry := v.(parsedTemplateEntry)
+		return entry.tpl, entry.err
+	}
+	tpl, err := template.New("").Funcs(templateFuncs).Parse(text)
+	actual, _ := parsedTemplateCache.LoadOrStore(text, parsedTemplateEntry{tpl: tpl, err: err})
+	entry := actual.(parsedTemplateEntry)
+	return entry.tpl, entry.err
+}
+
 // Cache is a help struct that allow us to call "replaceX" funcs multiple
 // times, without having to check for error each time. The first error that
 // happen will be assigned to r.err, and consecutive calls to funcs will just
@@ -115,7 +148,7 @@ func ResolveRef(ref string, cache *Cache) any {
 	if ref == "." {
 		return cache.cacheMap
 	}
-	t, err := template.New("resolver").Funcs(templateFuncs).Parse(fmt.Sprintf("{{%s}}", ref))
+	t, err := cachedParse(fmt.Sprintf("{{%s}}", ref))
 	if err != nil {
 		cache.err = err
 		return nil
@@ -194,7 +227,7 @@ func ReplaceWithExtra[T any](v T, cache *Cache, extra map[string]any) T {
 		if !strings.Contains(v, "{{") {
 			return v, nil
 		}
-		tpl, err := template.New("").Funcs(templateFuncs).Parse(v)
+		tpl, err := cachedParse(v)
 		if err != nil {
 			return v, err
 		}


### PR DESCRIPTION
I work in an org with a fairly large monorepo and we use `task` heavily as our cross-language entry point. The taskfile setup looks like this:

- **379** taskfiles checked in
- **199** of them transitively loaded from the root (25 top-level includes, recursive from there)
- **2,662** tasks visible to `task --list` (3,547 total before filtering internals)
- **328** merged `env:` entries and **13** merged `vars:` at taskfile scope

`task --list` here takes about **13.7 seconds**.

Four commits, applied in order of biggest gain first. Each is scoped to a single change and should be readable on its own — they accumulate, but they're largely independent and can be cherry-picked individually if any one of them seems too risky:

1. **Skip the template engine for strings without `{{`** (13.7s → 5.0s). 
     Most env values are static literals; running them through `template.Parse + Execute` is pure overhead.
2. **Share one Cache across the whole `getVariables` rangeFunc loop** (5.0s → 3.1s).
     The previous code allocated a fresh `templater.Cache` per variable, so `cacheMap` got rebuilt from scratch for every entry.
3. **Share `cacheMap` directly when the template can't mutate it; pool clones for the cases that can** (3.1s → 0.44s).
     The shallow `maps.Clone` was there to defend against sprig's `set`/`unset` writing back into `cacheMap`. A cheap substring check on the template tells us when that's possible — for everything else (and for nil values, which can't run a template at all) we just hand `tpl.Execute` the cacheMap directly. When we do need to clone, the clone goes through a `sync.Pool`.
4. **Cache parsed templates by source string** (0.44s → 0.25s). 
    `template.New("").Funcs(templateFuncs).Parse(text)` copies the ~170-entry sprig FuncMap into a fresh template every time. With many tasks processing the same merged env/vars, the same source strings get parsed over and over. Parsed templates are documented as safe for concurrent `Execute`, so memoizing them in a `sync.Map` is straightforward.

End-to-end: **13.7s → 0.25s, ~55× faster** on the repo above on an 11-core M3 Pro macbook with 18GB RAM.

## Correctness

This is best effort. I've validated:
- All upstream tests pass on Go 1.25.x and 1.26.x.
- `task --list` output is byte-identical to v3.50.0 on our repo.
- Templates that mutate `.` via sprig's `set`/`unset` produce the same output as the system `task` binary in targeted reproductions.

The risk areas, in case I missed something:
- The COW decision in commit 3 uses a substring check (`"set"` anywhere in the template) to decide whether to clone. False positives are fine — they just clone when not strictly necessary. False negatives would silently leak template-side mutations back into `cacheMap`. I went through the templater's func map and the only top-level dict mutators I found were sprig's `set` and `unset` (`unset` is also caught by the substring scan for `"set"`). Push/append/prepend mutate slice values, which the original shallow clone never protected against either. If there are mutators I missed — especially any that get added later — this could regress.
- The shared `Cache` in commit 2 is per-`getVariables`-call, not across goroutines. Each task compilation still gets its own cache. But it does mean that if a template mutates `cacheMap` (i.e. clone path didn't run because the substring check missed), pollution would persist across subsequent variables in the same compilation. The combination of the always-present clone in commit 1 and the COW logic in commit 3 should prevent this in practice — but it's worth flagging.

So: tests pass, behavior matches on our workspace, but I can't 100% guarantee no edge case in some other repo's taskfiles.

## On the four-commit structure

The contributing guide prefers a single commit. I deliberately split this into four because each one is a self-contained change with its own measurable win and its own correctness argument. If any single commit turns out to be unsafe in some repo I haven't thought of, you can revert just that one without losing the others. Happy to squash before merge if you'd rather have a single commit.

## On the doc comments

The comments I added on the new functions are wordy — I left "why" in there explicitly because I wanted the trade-offs visible. Happy to trim, reword, or drop them entirely.

Also open to feedback on the substring approach in commit 3. A more rigorous version would parse the template AST and look for FuncCall nodes matching `set`/`unset`. That felt like over-engineering for a static set of two function names, but if you'd prefer that approach I can add it.

## AI disclosure

Per the contributing guide: I used Claude as a profiling/research tool while digging into where the time was actually going and validating correctness against the upstream test suite. The code went through several rounds of review and adjustment by me before landing here.

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/)
