### PR TITLE
Add templating function 'joinPathList'

### DIFF
--- a/internal/templater/funcs.go
+++ b/internal/templater/funcs.go
@@ -33,6 +33,7 @@ func init() {
 		"splitArgs":    splitArgs,
 		"IsSH":         IsSH, // Deprecated
 		"joinPath":     filepath.Join,
+		"joinPathList": joinPathList,
 		"relPath":      filepath.Rel,
 		"absPath":      filepath.Abs,
 		"merge":        merge,
@@ -130,4 +131,8 @@ func mustToYaml(v any) (string, error) {
 		return "", err
 	}
 	return string(output), nil
+}
+
+func joinPathList(paths ...string) string {
+	return strings.Join(paths, string(filepath.ListSeparator))
 }

--- a/internal/templater/templater_test.go
+++ b/internal/templater/templater_test.go
@@ -1,0 +1,68 @@
+package templater
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-task/task/v3/taskfile/ast"
+)
+
+func TestTemplateFuncs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "joinPath",
+			template: `{{ joinPath  .BaseDir "dir" "file.txt" }}`,
+			expected: func() string {
+				switch os := runtime.GOOS; os {
+				case "windows":
+					return "base\\dir\\file.txt"
+				default:
+					return "base/dir/file.txt"
+				}
+			}(),
+		},
+		{
+			name:     "joinPath with single argument",
+			template: `{{ joinPath "dir1" }}`,
+			expected: "dir1",
+		},
+		{
+			name:     "joinPathList",
+			template: `{{ joinPathList .BaseDir "subdir" "file.txt" }}`,
+			expected: func() string {
+				switch os := runtime.GOOS; os {
+				case "windows":
+					return "base;subdir;file.txt"
+				default:
+					return "base:subdir:file.txt"
+				}
+			}(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			vars := ast.NewVars(
+				&ast.VarElement{
+					Key:   "BaseDir",
+					Value: ast.Var{Value: "base"},
+				},
+			)
+			cache := &Cache{Vars: vars}
+			cache.ResetCache()
+			result := Replace(tc.template, cache)
+			require.NoError(t, cache.Err())
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/website/src/docs/reference/templating.md
+++ b/website/src/docs/reference/templating.md
@@ -616,7 +616,8 @@ tasks:
       - echo "{{.WIN_PATH | toSlash}}"                          # Convert to forward slashes
       - echo "{{.WIN_PATH | fromSlash}}"                        # Convert to OS-specific slashes
       - echo "{{joinPath .OUTPUT_DIR .BINARY_NAME}}"            # Join path elements
-      - echo "Relative {{relPath .ROOT_DIR .TASKFILE_DIR}}"    # Get relative path
+      - echo "{{joinPathList .PATH_1 .PATH_2 .PATH_3}}"         # Join a list of path elements using the OS List Separator
+      - echo "Relative {{relPath .ROOT_DIR .TASKFILE_DIR}}"     # Get relative path
       - echo '{{absPath "../sibling"}}'                         # Resolve to an absolute path
 ```
 


### PR DESCRIPTION
This PR implements a simple `joinPathList` templating function which uses the `filepath.ListSeparator` value (from same namespace as existing functions).

It does not add a special variables as that can be done with environment variables (.dotenv files). 
Also it does not add the `joinUrl` templating function because its too similar to existing `urlJoin` and `urlPath`. The existing `joinPath` should cover this anyway.


Fixes #2406 
Alternative to #2408
