### PR TITLE
feat(includes): add `only` field to limit which tasks are included

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -1467,6 +1467,36 @@ func TestIncludesWithExclude(t *testing.T) {
 	assert.Equal(t, "foo\n", buff.String())
 }
 
+func TestIncludesWithOnly(t *testing.T) {
+	t.Parallel()
+
+	var buff bytes.Buffer
+	e := task.NewExecutor(
+		task.WithDir("testdata/includes_with_only"),
+		task.WithSilent(true),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
+	require.NoError(t, e.Setup())
+
+	err := e.Run(t.Context(), &task.Call{Task: "included:foo"})
+	require.NoError(t, err)
+	assert.Equal(t, "foo\n", buff.String())
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "included:bar"})
+	require.Error(t, err)
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "bar"})
+	require.NoError(t, err)
+	assert.Equal(t, "bar\n", buff.String())
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "foo"})
+	require.Error(t, err)
+}
+
 func TestIncludedTaskfileVarMerging(t *testing.T) {
 	t.Parallel()
 

--- a/taskfile/ast/include.go
+++ b/taskfile/ast/include.go
@@ -21,6 +21,7 @@ type (
 		Internal       bool
 		Aliases        []string
 		Excludes       []string
+		Only           []string
 		AdvancedImport bool
 		Vars           *Vars
 		Flatten        bool
@@ -165,6 +166,7 @@ func (include *Include) UnmarshalYAML(node *yaml.Node) error {
 			Flatten  bool
 			Aliases  []string
 			Excludes []string
+			Only     []string
 			Vars     *Vars
 			Checksum string
 		}
@@ -177,6 +179,7 @@ func (include *Include) UnmarshalYAML(node *yaml.Node) error {
 		include.Internal = includedTaskfile.Internal
 		include.Aliases = includedTaskfile.Aliases
 		include.Excludes = includedTaskfile.Excludes
+		include.Only = includedTaskfile.Only
 		include.AdvancedImport = true
 		include.Vars = includedTaskfile.Vars
 		include.Flatten = includedTaskfile.Flatten
@@ -200,6 +203,7 @@ func (include *Include) DeepCopy() *Include {
 		Optional:       include.Optional,
 		Internal:       include.Internal,
 		Excludes:       deepcopy.Slice(include.Excludes),
+		Only:           deepcopy.Slice(include.Only),
 		AdvancedImport: include.AdvancedImport,
 		Vars:           include.Vars.DeepCopy(),
 		Flatten:        include.Flatten,

--- a/taskfile/ast/tasks.go
+++ b/taskfile/ast/tasks.go
@@ -135,6 +135,11 @@ func (t1 *Tasks) Merge(t2 *Tasks, include *Include, includedTaskfileVars *Vars) 
 			continue
 		}
 
+		// if an only list is set and the task is not in it, skip it
+		if len(include.Only) > 0 && !slices.Contains(include.Only, name) {
+			continue
+		}
+
 		if !include.Flatten {
 			// Add namespaces to task dependencies
 			for _, dep := range task.Deps {

--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -332,6 +332,7 @@ func (r *Reader) include(ctx context.Context, node Node) error {
 				Aliases:        include.Aliases,
 				AdvancedImport: include.AdvancedImport,
 				Excludes:       include.Excludes,
+				Only:           include.Only,
 				Vars:           include.Vars,
 				Checksum:       include.Checksum,
 			}

--- a/testdata/includes_with_only/Taskfile.yml
+++ b/testdata/includes_with_only/Taskfile.yml
@@ -1,0 +1,17 @@
+version: '3'
+
+includes:
+  included:
+    taskfile: ./included/Taskfile.yml
+    only:
+      - foo
+  included_flatten:
+    taskfile: ./included/Taskfile.yml
+    flatten: true
+    only:
+      - bar
+
+tasks:
+  default:
+    cmds:
+      - echo "default"

--- a/testdata/includes_with_only/included/Taskfile.yml
+++ b/testdata/includes_with_only/included/Taskfile.yml
@@ -1,0 +1,5 @@
+version: '3'
+
+tasks:
+  foo: echo foo
+  bar: echo bar

--- a/website/src/docs/guide.md
+++ b/website/src/docs/guide.md
@@ -441,6 +441,45 @@ tasks:
 
 It's compatible with the `flatten` option.
 
+### Include only specific tasks
+
+You can include only specific tasks by using the `only` option. This is the
+opposite of `excludes` — only the listed tasks will be included and all others
+will be ignored.
+
+::: code-group
+
+```yaml [Taskfile.yml]
+version: '3'
+
+includes:
+  included:
+    taskfile: ./Included.yml
+    only: [foo]
+```
+
+```yaml [Included.yml]
+version: '3'
+
+tasks:
+  foo: echo "Foo"
+  bar: echo "Bar"
+```
+
+:::
+
+`task included:bar` will throw an error because only `foo` is included but
+`task included:foo` will work and display `Foo`.
+
+::: info
+
+When `only` is set, `excludes` is redundant — any task not in the `only` list
+is already excluded.
+
+:::
+
+It's compatible with the `flatten` option.
+
 ### Vars of included Taskfiles
 
 You can also specify variables when including a Taskfile. This may be useful for

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -74,6 +74,7 @@ includes:
     internal: false
     aliases: [api]
     excludes: [internal-task]
+    only: [public-task]
     vars:
       SERVICE_NAME: backend
     checksum: abc123...
@@ -304,6 +305,20 @@ includes:
   shared:
     taskfile: ./shared.yml
     excludes: [internal-setup, debug-only]
+```
+
+### `only`
+
+- **Type**: `[]string`
+- **Description**: Tasks to include. If set, only these tasks will be included
+  and all others will be ignored. Opposite of `excludes`. When `only` is set,
+  `excludes` is redundant.
+
+```yaml
+includes:
+  shared:
+    taskfile: ./shared.yml
+    only: [build, test]
 ```
 
 ### `vars`

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -733,6 +733,13 @@
                         "type": "string"
                       }
                     },
+                    "only": {
+                      "description": "A list of tasks to include. If set, only these tasks will be included and all others will be ignored.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
                     "vars": {
                       "description": "A set of variables to apply to the included Taskfile.",
                       "$ref": "#/definitions/vars"


### PR DESCRIPTION
<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->
### What changed
- Added `only` field to `includes` as the inverse of `excludes`:
  ``` yml
  includes:
    shared:
      taskfile: shared.yml
      only: [foo, baa]
  ```
- Added tests
- Updated guide.md, schema.md and schema.json

### Use cases
- include specific task from a "third party" or even a remote taskfile
- avoid having to keep updating `excludes` whenever tasks are added to included taskfile
- most useful when `internal: false` and the included tasks are part of the "public API"

### Disclosure
- [x] AI was used during implementation
- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/)
