### PR TITLE
fix: handle nil Vars in ToCacheMap

### DIFF
--- a/taskfile/ast/vars.go
+++ b/taskfile/ast/vars.go
@@ -98,6 +98,9 @@ func (vars *Vars) Values() iter.Seq[Var] {
 // ToCacheMap converts Vars to an unordered map containing only the static
 // variables
 func (vars *Vars) ToCacheMap() (m map[string]any) {
+	if vars == nil || vars.om == nil {
+		return nil
+	}
 	defer vars.mutex.RUnlock()
 	vars.mutex.RLock()
 	m = make(map[string]any, vars.Len())

--- a/taskfile/ast/vars_test.go
+++ b/taskfile/ast/vars_test.go
@@ -1,0 +1,55 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVars_ToCacheMap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil receiver returns nil", func(t *testing.T) {
+		t.Parallel()
+		var vars *Vars
+		assert.Nil(t, vars.ToCacheMap())
+	})
+
+	t.Run("empty vars returns empty map", func(t *testing.T) {
+		t.Parallel()
+		vars := NewVars()
+		m := vars.ToCacheMap()
+		assert.NotNil(t, m)
+		assert.Empty(t, m)
+	})
+
+	t.Run("static values are included", func(t *testing.T) {
+		t.Parallel()
+		vars := NewVars(
+			&VarElement{Key: "FOO", Value: Var{Value: "bar"}},
+			&VarElement{Key: "NUM", Value: Var{Value: 42}},
+		)
+		m := vars.ToCacheMap()
+		assert.Equal(t, map[string]any{"FOO": "bar", "NUM": 42}, m)
+	})
+
+	t.Run("live values take precedence over static values", func(t *testing.T) {
+		t.Parallel()
+		vars := NewVars(
+			&VarElement{Key: "FOO", Value: Var{Value: "bar", Live: "live-bar"}},
+		)
+		m := vars.ToCacheMap()
+		assert.Equal(t, map[string]any{"FOO": "live-bar"}, m)
+	})
+
+	t.Run("dynamic variables are excluded", func(t *testing.T) {
+		t.Parallel()
+		sh := "echo hello"
+		vars := NewVars(
+			&VarElement{Key: "STATIC", Value: Var{Value: "ok"}},
+			&VarElement{Key: "DYNAMIC", Value: Var{Sh: &sh}},
+		)
+		m := vars.ToCacheMap()
+		assert.Equal(t, map[string]any{"STATIC": "ok"}, m)
+	})
+}


### PR DESCRIPTION
This makes ToCacheMap safe to call on a nil Vars receiver and adds focused coverage for nil, empty, static, live, and dynamic variables.

The behavior for populated Vars is unchanged.

Verification:
- go test ./taskfile/ast