### PR TITLE
fix: install fish completions to vendor directory

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,7 +76,7 @@ nfpms:
       - src: completion/bash/task.bash
         dst: /etc/bash_completion.d/task
       - src: completion/fish/task.fish
-        dst: /usr/share/fish/completions/task.fish
+        dst: /usr/share/fish/vendor_completions.d/task.fish
       - src: completion/zsh/_task
         dst: /usr/local/share/zsh/site-functions/_task
 


### PR DESCRIPTION
Fixes #2850.

This updates the Linux package metadata so the Fish completion file is installed to Fish vendor completions:

- `/usr/share/fish/vendor_completions.d/task.fish`

The previous package path used `/usr/share/fish/completions/task.fish`, which is intended for completions shipped with Fish itself.

Validation run:

- `ruby -e 'require "yaml"; YAML.load_file(".goreleaser.yml"); YAML.load_file(".goreleaser-pr.yml"); YAML.load_file(".goreleaser-nightly.yml"); puts "yaml ok"'`
- `ruby -e 'require "yaml"; y=YAML.load_file(".goreleaser.yml"); fish=y.fetch("nfpms").first.fetch("contents").find{|e| e["src"]=="completion/fish/task.fish"}; abort "bad fish dst" unless fish["dst"]=="/usr/share/fish/vendor_completions.d/task.fish"; puts "fish nfpm dst ok"'`
- `git diff --check`

Not run:

- `goreleaser check --config .goreleaser.yml`: `goreleaser` is not installed locally.
- `go test ./...`: local Go is `1.24.3`, while this repo currently requires `1.25.10`; automatic toolchain download timed out in my environment.

AI assistance disclosure: I used AI assistance to draft and verify this patch, then reviewed the diff and validation output before submitting.

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/)
