### PR TITLE
fix: validate include 'taskfile' field, suggest 'vars:' if missing

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -1064,6 +1064,25 @@ func TestIncludeCycle(t *testing.T) {
 	assert.Contains(t, err.Error(), "task: include cycle detected between")
 }
 
+func TestIncludesMissingTaskfile(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/includes_missing_taskfile"
+
+	var buff bytes.Buffer
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSilent(true),
+	)
+
+	err := e.Setup()
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "include cycle detected", "should not report a cycle error for a missing taskfile field")
+	assert.Contains(t, err.Error(), "missing the required \"taskfile\" field")
+}
+
 func TestIncludesIncorrect(t *testing.T) {
 	t.Parallel()
 

--- a/taskfile/ast/include.go
+++ b/taskfile/ast/include.go
@@ -1,6 +1,7 @@
 package ast
 
 import (
+	"fmt"
 	"iter"
 	"sync"
 
@@ -131,6 +132,26 @@ func (includes *Includes) UnmarshalYAML(node *yaml.Node) error {
 			var v Include
 			if err := valueNode.Decode(&v); err != nil {
 				return errors.NewTaskfileDecodeError(err, node)
+			}
+
+			// Validate that the include has a Taskfile path specified.
+			// If it doesn't, suggest the user may have meant to use 'vars:' instead
+			// of 'includes:' — a common copy-paste mistake that otherwise produces
+			// a misleading "include cycle detected" error downstream.
+			if v.Taskfile == "" {
+				rawKeys := []string{}
+				for j := 0; j < len(valueNode.Content); j += 2 {
+					rawKeys = append(rawKeys, valueNode.Content[j].Value)
+				}
+				keysStr := ""
+				if len(rawKeys) > 0 {
+					keysStr = fmt.Sprintf(" (unexpected keys: %v)", rawKeys)
+				}
+				err := fmt.Errorf(
+					"include \"%s\" is missing the required \"taskfile\" field%s; did you mean to use \"vars:\" instead?",
+					keyNode.Value, keysStr,
+				)
+				return errors.NewTaskfileDecodeError(err, valueNode)
 			}
 
 			// Set the include namespace

--- a/testdata/includes_missing_taskfile/Taskfile.yml
+++ b/testdata/includes_missing_taskfile/Taskfile.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+includes:
+  common: ./TaskfileCommon.yml
+
+tasks:
+  test:
+    cmds:
+      - task: common:test

--- a/testdata/includes_missing_taskfile/TaskfileCommon.yml
+++ b/testdata/includes_missing_taskfile/TaskfileCommon.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+includes:
+  GOBIN:
+    sh: echo $(go env GOPATH)/bin
+
+tasks:
+  test:
+    cmds:
+      - "{{.GOBIN}}/richgo test ./..."


### PR DESCRIPTION
## Problem

When a user accidentally writes `includes:` with variable-like content instead of `vars:` — a common typo like this:

```yaml
# Taskfile.yml
version: '3'

includes:
  GOBIN:
    sh: echo $(go env GOPATH)/bin

tasks:
  test:
    cmds:
      - "{{.GOBIN}}/richgo test ./..."
```

...the current behavior is to silently accept the malformed include entry (since any YAML mapping passes the `yaml.MappingNode` check in `Includes.UnmarshalYAML`), and later report a misleading **"include cycle detected between A <--> A"** error, because the empty `Taskfile` path resolves to the same file.

This is confusing and unhelpful — the real problem isn't a cycle, it's that the user put variables under `includes:` instead of `vars:`.

## Solution

Added validation in `taskfile/ast/include.go` to check that each include entry has a non-empty `Taskfile` field after decoding. If it doesn't:

1. Returns a clear error: `include "GOBIN" is missing the required "taskfile" field; did you mean to use "vars:" instead?`
2. Lists unexpected keys found (e.g., `sh`) so the user understands what went wrong
3. Provides actionable guidance (use `vars:` instead)

## Changes

- `taskfile/ast/include.go`: Added validation in `Includes.UnmarshalYAML` after decoding each include value, checking for empty `Taskfile` and producing a helpful error message
- `testdata/includes_missing_taskfile/`: Test fixtures reproducing the exact scenario from issue #1881
- `task_test.go`: New test `TestIncludesMissingTaskfile` verifying the new error message is shown instead of the misleading cycle error

## Testing

- All existing include-related tests pass (`TestIncludes`, `TestIncludeCycle`, `TestIncludesIncorrect`, etc.)
- New test specifically validates:
  - Error contains "missing the required \"taskfile\" field"
  - Error does NOT contain "include cycle detected"