### PR TITLE
fix(completion): zsh completion supports aliases

### DIFF
--- a/completion/zsh/_task
+++ b/completion/zsh/_task
@@ -59,6 +59,28 @@ function __task_list() {
         else
             scripts+=( "$task" )
         fi
+
+        # Add aliases as separate completion entries
+        if [[ "$item" =~ '\(aliases: ([^)]+)\)' ]]; then
+            local aliases_str="${match[1]}"
+            local -a alias_names
+
+            # Split aliases by ", " and handle edge cases
+            alias_names=("${(@s:, :)aliases_str}")
+
+            for alias_name in "${alias_names[@]}"; do
+                # Trim whitespace and skip empty entries
+                alias_name="${alias_name## }"
+                alias_name="${alias_name%% }"
+                [[ -z "$alias_name" ]] && continue
+
+                if [[ "$show_desc" == "true" ]]; then
+                    scripts+=( "${alias_name//:/\\:}:alias for ${task}" )
+                else
+                    scripts+=( "$alias_name" )
+                fi
+            done
+        fi
     done
 
     if [[ "$show_desc" == "true" ]]; then


### PR DESCRIPTION
I'd noticed that alias would not autocomplete on MacOS with zsh, so taking inspiration from it being [fixed in fish](https://github.com/go-task/task/issues/2604), I thought I'd fix the zsh issue.  I had a good search for any previous discussion on this, but didn't turn anything up, so apologies if I've missed this somewhere.

Claude & Co-Pilot did a lot of the heavy lifting here, but I've reviewed the code any believe it all to be good and proper.

# The Fix

The ZSH completion script not parses the `(aliases: ...)` parenthetical from `task --list-all` output and add each alias as a separate completion entry, so typing an alias prefix and pressing Tab now completes correctly. When verbose mode is on, aliases are shown with an "alias for <task>" description.

# Tests

As this is a shell script I've not written tests, however Co-Pilot provided the following script to validate the logic, in cause it's useful, or you want this integrtaing into this PR as a test file somehow (please advise how)…

```shell
#!/bin/zsh

# Simulate task output
output="task: Available tasks for this project:
* build:            Build the project	(aliases: b, compile)
* deploy:           Deploy to production	(aliases: d, push)
* test:             Run tests	(aliases: t, check)"

echo "Testing alias completion regex patterns...\n"

# Test cases
test_items=(
    "build:            Build the project	(aliases: b, compile)"
    "deploy:           Deploy to production	(aliases: d, push)"
    "test:             Run tests	(aliases: t, check)"
    "single:           Single alias task	(aliases: s)"
    "nospace:          No space after comma	(aliases: foo,bar,baz)"
)

for item in "${test_items[@]}"; do
    echo "Testing: $item"

    if [[ "$item" =~ '\(aliases: ([^)]+)\)' ]]; then
        echo "  ✓ Regex matched"
        local aliases_str="${match[1]}"
        echo "  Captured aliases string: '$aliases_str'"

        # Test splitting
        local -a alias_names
        alias_names=("${(@s:, :)aliases_str}")
        echo "  Split into ${#alias_names[@]} alias(es):"

        for alias_name in "${alias_names[@]}"; do
            # Trim whitespace
            alias_name="${alias_name## }"
            alias_name="${alias_name%% }"

            if [[ -z "$alias_name" ]]; then
                echo "    - (empty - skipped)"
            else
                echo "    - '$alias_name'"
            fi
        done
    else
        echo "  ✗ Regex did not match"
    fi
    echo ""
done

```

<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/)
