### PR TITLE
feat: support namespace include excludes

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -1465,6 +1465,28 @@ func TestIncludesWithExclude(t *testing.T) {
 	err = e.Run(t.Context(), &task.Call{Task: "foo"})
 	require.NoError(t, err)
 	assert.Equal(t, "foo\n", buff.String())
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "included_namespace:flight-recorder:start"})
+	require.Error(t, err)
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "included_namespace:flight-recorder:dump"})
+	require.Error(t, err)
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "included_namespace:flight-recorder-extra:start"})
+	require.NoError(t, err)
+	assert.Equal(t, "flight-recorder-extra start\n", buff.String())
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "included_namespace_glob:flight-recorder:start"})
+	require.Error(t, err)
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "included_namespace_glob:flight-recorder-extra:start"})
+	require.NoError(t, err)
+	assert.Equal(t, "flight-recorder-extra start\n", buff.String())
 }
 
 func TestIncludedTaskfileVarMerging(t *testing.T) {

--- a/taskfile/ast/tasks.go
+++ b/taskfile/ast/tasks.go
@@ -131,7 +131,7 @@ func (t1 *Tasks) Merge(t2 *Tasks, include *Include, includedTaskfileVars *Vars) 
 		taskName := name
 
 		// if the task is in the exclude list, don't add it to the merged taskfile
-		if slices.Contains(include.Excludes, name) {
+		if isTaskExcluded(name, include.Excludes) {
 			continue
 		}
 
@@ -248,4 +248,21 @@ func taskNameWithNamespace(taskName string, namespace string) string {
 		return after
 	}
 	return fmt.Sprintf("%s%s%s", namespace, NamespaceSeparator, taskName)
+}
+
+func isTaskExcluded(taskName string, excludes []string) bool {
+	for _, exclude := range excludes {
+		if taskName == exclude {
+			return true
+		}
+
+		namespace, ok := strings.CutSuffix(exclude, NamespaceSeparator+"*")
+		if !ok {
+			namespace = exclude
+		}
+		if strings.HasPrefix(taskName, namespace+NamespaceSeparator) {
+			return true
+		}
+	}
+	return false
 }

--- a/testdata/includes_with_excludes/Taskfile.yml
+++ b/testdata/includes_with_excludes/Taskfile.yml
@@ -10,6 +10,14 @@ includes:
     flatten: true
     excludes:
       - bar
+  included_namespace:
+    taskfile: ./included/Taskfile.yml
+    excludes:
+      - flight-recorder
+  included_namespace_glob:
+    taskfile: ./included/Taskfile.yml
+    excludes:
+      - flight-recorder:*
 
 tasks:
   default:

--- a/testdata/includes_with_excludes/included/Taskfile.yml
+++ b/testdata/includes_with_excludes/included/Taskfile.yml
@@ -3,3 +3,6 @@ version: '3'
 tasks:
   foo: echo foo
   bar: echo bar
+  "flight-recorder:start": echo flight-recorder start
+  "flight-recorder:dump": echo flight-recorder dump
+  "flight-recorder-extra:start": echo flight-recorder-extra start

--- a/website/src/docs/guide.md
+++ b/website/src/docs/guide.md
@@ -413,7 +413,7 @@ You can do this by using the
 ### Exclude tasks from being included
 
 You can exclude tasks from being included by using the `excludes` option. This
-option takes the list of tasks to be excluded from this include.
+option takes the list of tasks or namespaces to be excluded from this include.
 
 ::: code-group
 
@@ -423,7 +423,7 @@ version: '3'
 includes:
   included:
     taskfile: ./Included.yml
-    excludes: [foo]
+    excludes: [foo, flight-recorder]
 ```
 
 ```yaml [Included.yml]
@@ -432,12 +432,17 @@ version: '3'
 tasks:
   foo: echo "Foo"
   bar: echo "Bar"
+  flight-recorder:start: echo "Start flight recorder"
+  flight-recorder:dump: echo "Dump flight recorder"
 ```
 
 :::
 
-`task included:foo` will throw an error because the `foo` task is excluded but
-`task included:bar` will work and display `Bar`.
+`task included:foo` will throw an error because the `foo` task is excluded,
+but `task included:bar` will work and display `Bar`.
+`task included:flight-recorder:start` will throw an error because the
+`flight-recorder` namespace is excluded. You can also use
+`flight-recorder:*` to exclude the namespace explicitly.
 
 It's compatible with the `flatten` option.
 

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -297,13 +297,13 @@ includes:
 ### `excludes`
 
 - **Type**: `[]string`
-- **Description**: Tasks to exclude from inclusion
+- **Description**: Tasks or namespaces to exclude from inclusion
 
 ```yaml
 includes:
   shared:
     taskfile: ./shared.yml
-    excludes: [internal-setup, debug-only]
+    excludes: [internal-setup, debug-only, flight-recorder:*]
 ```
 
 ### `vars`

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -727,7 +727,7 @@
                       }
                     },
                     "excludes": {
-                      "description": "A list of tasks to be excluded from inclusion.",
+                      "description": "A list of tasks or namespaces to be excluded from inclusion.",
                       "type": "array",
                       "items": {
                         "type": "string"


### PR DESCRIPTION
## What

- allow include `excludes` entries to match entire task namespaces, in addition to exact task names
- support both `namespace` and `namespace:*` forms
- update include exclude tests, docs, and JSON schema description

Fixes #2300

## Testing

- `go test ./...`
- `git diff --check`