### PR TITLE
fix: deterministic ordering of required var prompts

### DIFF
--- a/requires.go
+++ b/requires.go
@@ -3,6 +3,8 @@ package task
 import (
 	"slices"
 
+	"github.com/elliotchance/orderedmap/v3"
+
 	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/input"
 	"github.com/go-task/task/v3/internal/term"
@@ -32,7 +34,7 @@ func (e *Executor) promptDepsVars(calls []*Call) error {
 
 	// Collect all missing vars from the dependency tree
 	visited := make(map[string]bool)
-	varsMap := make(map[string]*ast.VarsWithValidation)
+	varsMap := orderedmap.NewOrderedMap[string, *ast.VarsWithValidation]()
 
 	var collect func(call *Call) error
 	collect = func(call *Call) error {
@@ -42,8 +44,8 @@ func (e *Executor) promptDepsVars(calls []*Call) error {
 		}
 
 		for _, v := range getMissingRequiredVars(compiledTask) {
-			if _, exists := varsMap[v.Name]; !exists {
-				varsMap[v.Name] = v
+			if !varsMap.Has(v.Name) {
+				varsMap.Set(v.Name, v)
 			}
 		}
 
@@ -73,14 +75,14 @@ func (e *Executor) promptDepsVars(calls []*Call) error {
 		}
 	}
 
-	if len(varsMap) == 0 {
+	if varsMap.Len() == 0 {
 		return nil
 	}
 
 	prompter := e.newPrompter()
 	e.promptedVars = ast.NewVars()
 
-	for _, v := range varsMap {
+	for v := range varsMap.Values() {
 		value, err := prompter.Prompt(v.Name, getEnumValues(v.Enum))
 		if err != nil {
 			if errors.Is(err, input.ErrCancelled) {


### PR DESCRIPTION
Hello! Huge fan of task and while snooping through release notes found the relatively new feature of interactive prompting for required vars courtesy of https://github.com/go-task/task/pull/2579. The first run I used it for, with 2 required vars, it prompted for the vars backwards based on `Taskfile.yml` definition order.

I could only reproduce this some of the time, suggesting something like Go map traversal. Here's my Taskfile used for local testing before/after this change:

```yaml
version: '3'

tasks:
  deps:
    desc: Resolve required vars through dep traversal
    requires:
      vars: [A, B, C, D, E, F]
    cmd: echo "Hello world"

  cmds:
    desc: Resolve required vars through "just-in-time" prompting
    cmds:
      - task: example
```

Based on https://github.com/go-task/task/pull/2579 there are 2 effective codepaths for interactive variable prompting to concern ourselves with, aligning with the tasks defined above:

1. Deps
2. Cmds

When running `task deps --interactive`, there was about a 50% chance on my end that the ordering was completely jumbled. The "cmds" path uses slices internally and I observed no behavioral sequencing issues (`task cmds --interactive`).

### Ordering

The solution presented in this PR is to preserve discovery order of required vars in the "deps" path. This felt the most intuitive to me but I'm open to suggestions. The present non-deterministic order threw me off so I figured it was unintentional.

Regardless of exact ordering, predictability helps with muscle memory (perhaps folks are quickly typing out the same vars in common tasks). I'd say more importantly it preserves semantics intended by the task developer. Take for instance
- `[HOST, PORT]`
- `[IMAGE, TAG]`
- Credentials (user/pass)

In each of these cases, being prompted in reverse order would feel off.

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/)
