### PR TITLE
fix: escape apostrophes in fingerprint globs

### DIFF
--- a/internal/execext/exec.go
+++ b/internal/execext/exec.go
@@ -93,6 +93,7 @@ func RunCommand(ctx context.Context, opts *RunCommandOptions) error {
 func escape(s string) string {
 	s = filepath.ToSlash(s)
 	s = strings.ReplaceAll(s, " ", `\ `)
+	s = strings.ReplaceAll(s, "'", `\'`)
 	s = strings.ReplaceAll(s, "&", `\&`)
 	s = strings.ReplaceAll(s, "(", `\(`)
 	s = strings.ReplaceAll(s, ")", `\)`)

--- a/task_test.go
+++ b/task_test.go
@@ -653,6 +653,45 @@ func TestStatusChecksumMissingGenerated(t *testing.T) { // nolint:paralleltest /
 	require.NoError(t, err, "generated.txt should be recreated after third run")
 }
 
+func TestStatusChecksumAllowsApostropheInWorkingDirectory(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "test'd")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Taskfile.yml"), []byte(`version: '3'
+
+tasks:
+  default:
+    generates:
+      - test.out
+    sources:
+      - test.in
+    cmds:
+      - cp test.in test.out
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.in"), []byte("hello\n"), 0o644))
+
+	var buff bytes.Buffer
+	tempDir := task.TempDir{
+		Remote:      filepath.Join(dir, ".task"),
+		Fingerprint: filepath.Join(dir, ".task"),
+	}
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithTempDir(tempDir),
+	)
+	require.NoError(t, e.Setup())
+
+	require.NoError(t, e.Run(t.Context(), &task.Call{Task: "default"}))
+	assert.FileExists(t, filepath.Join(dir, "test.out"))
+	buff.Reset()
+
+	require.NoError(t, e.Run(t.Context(), &task.Call{Task: "default"}))
+	assert.Equal(t, `task: Task "default" is up to date`+"\n", buff.String())
+}
+
 func TestStatusVariables(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Treat apostrophes in fingerprint glob paths as literal path characters before shell-style field expansion.
- Add a regression test that runs a Taskfile from a temporary directory whose name contains an apostrophe, with both `sources` and `generates` configured.

Fixes #2874.

## Tests

- `go test . -run TestStatusChecksumAllowsApostropheInWorkingDirectory -count=1`
- `go test ./internal/fingerprint ./internal/execext . -count=1`
- `go test ./...`
- `git diff --check`

AI assistance was used to help investigate and prepare this patch; I reviewed and tested the changes.

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/)
