### PR TITLE
Handle apostrophes in fingerprint glob paths

### DIFF
--- a/internal/execext/exec.go
+++ b/internal/execext/exec.go
@@ -96,6 +96,7 @@ func escape(s string) string {
 	s = strings.ReplaceAll(s, "&", `\&`)
 	s = strings.ReplaceAll(s, "(", `\(`)
 	s = strings.ReplaceAll(s, ")", `\)`)
+	s = strings.ReplaceAll(s, "'", `\'`)
 	return s
 }
 

--- a/internal/fingerprint/glob_test.go
+++ b/internal/fingerprint/glob_test.go
@@ -1,0 +1,24 @@
+package fingerprint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGlobHandlesApostropheInPath(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	dir := filepath.Join(baseDir, "test'd")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+
+	file := filepath.Join(dir, "test.in")
+	require.NoError(t, os.WriteFile(file, []byte("input"), 0o644))
+
+	matches, err := glob(dir, "test.in")
+	require.NoError(t, err)
+	require.Equal(t, []string{filepath.ToSlash(file)}, matches)
+}


### PR DESCRIPTION
- Escape apostrophes when expanding fingerprint globs so quoted paths are parsed correctly.
- Add a regression test for a directory name that contains an apostrophe.
