### PR TITLE
test: add benchmarks for glob cache performance

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -152,6 +152,12 @@ tasks:
     cmds:
       - gotestsum -f '{{.GOTESTSUM_FORMAT}}' -tags 'signals watch' ./...
 
+  bench:checksum:
+    desc: Runs checksum benchmarks
+    aliases: [bench]
+    cmds:
+      - go test -bench=. -benchmem -tags=fsbench -run=^$ ./...
+
   goreleaser:test:
     desc: Tests release process without publishing
     cmds:

--- a/checksum_benchmark_test.go
+++ b/checksum_benchmark_test.go
@@ -7,9 +7,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -44,12 +46,18 @@ func benchmarkIssue2853Modes(b *testing.B, dir string, fileCount int, fileSize i
 		name        string
 		task        string
 		expectCache bool
+		nativeMTime bool
 	}{
 		{name: "checksum", task: "checksum-yaml", expectCache: true},
 		{name: "timestamp", task: "timestamp-yaml", expectCache: true},
+		{name: "native-mtime", nativeMTime: true},
 		{name: "none", task: "uncached-yaml"},
 	} {
 		b.Run(mode.name, func(b *testing.B) {
+			if mode.nativeMTime {
+				benchmarkIssue2853NativeMTime(b, dir, fileCount, fileSize)
+				return
+			}
 			benchmarkIssue2853Task(b, dir, mode.task, mode.expectCache, fileCount, fileSize)
 		})
 	}
@@ -105,6 +113,54 @@ func benchmarkIssue2853Task(
 		b.ReportMetric(float64(fileCount), "source_files/op")
 		b.ReportMetric(float64(sourceBytes)/(1024*1024), "source_MiB/op")
 	}
+}
+
+func benchmarkIssue2853NativeMTime(b *testing.B, dir string, fileCount int, fileSize int64) {
+	b.Helper()
+
+	output := filepath.Join(dir, "out", "native-mtime.txt")
+	require.NoError(b, os.WriteFile(output, []byte("ok"), 0o644))
+	outputTime := time.Now().Add(time.Second)
+	require.NoError(b, os.Chtimes(output, outputTime, outputTime))
+
+	sourceRoot := filepath.Join(dir, "path", "to", "folder")
+	sourceBytes := int64(fileCount) * fileSize
+
+	b.ReportAllocs()
+	b.SetBytes(sourceBytes)
+	b.ResetTimer()
+	for range b.N {
+		outputInfo, err := os.Stat(output)
+		require.NoError(b, err)
+
+		upToDate, err := nativeMTimeUpToDate(sourceRoot, outputInfo.ModTime())
+		require.NoError(b, err)
+		require.True(b, upToDate)
+	}
+	b.ReportMetric(float64(fileCount), "source_files/op")
+	b.ReportMetric(float64(sourceBytes)/(1024*1024), "source_MiB/op")
+}
+
+func nativeMTimeUpToDate(sourceRoot string, outputTime time.Time) (bool, error) {
+	upToDate := true
+	err := filepath.WalkDir(sourceRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".yaml" {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if info.ModTime().After(outputTime) {
+			upToDate = false
+			return fs.SkipAll
+		}
+		return nil
+	})
+	return upToDate, err
 }
 
 func createIssue2853Fixture(tb testing.TB, dir string, fileCount int, fileSize int64) {

--- a/checksum_benchmark_test.go
+++ b/checksum_benchmark_test.go
@@ -1,0 +1,155 @@
+package task_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-task/task/v3"
+)
+
+const (
+	issue2853ManySmallYAMLFileCount = 20_000
+	issue2853SmallYAMLFileSize      = 5
+	issue2853FewLargeYAMLFileCount  = 4
+	issue2853LargeYAMLFileSize      = 128 * 1024 * 1024
+)
+
+func BenchmarkIssue2853ManySmallSparseYAMLFiles(b *testing.B) {
+	dir := b.TempDir()
+	createIssue2853Fixture(b, dir, issue2853ManySmallYAMLFileCount, issue2853SmallYAMLFileSize)
+
+	benchmarkIssue2853Modes(b, dir, issue2853ManySmallYAMLFileCount, issue2853SmallYAMLFileSize)
+}
+
+func BenchmarkIssue2853FewLargeSparseYAMLFiles(b *testing.B) {
+	dir := b.TempDir()
+	createIssue2853Fixture(b, dir, issue2853FewLargeYAMLFileCount, issue2853LargeYAMLFileSize)
+
+	benchmarkIssue2853Modes(b, dir, issue2853FewLargeYAMLFileCount, issue2853LargeYAMLFileSize)
+}
+
+func benchmarkIssue2853Modes(b *testing.B, dir string, fileCount int, fileSize int64) {
+	b.Helper()
+
+	for _, mode := range []struct {
+		name        string
+		task        string
+		expectCache bool
+	}{
+		{name: "checksum", task: "checksum-yaml", expectCache: true},
+		{name: "timestamp", task: "timestamp-yaml", expectCache: true},
+		{name: "none", task: "uncached-yaml"},
+	} {
+		b.Run(mode.name, func(b *testing.B) {
+			benchmarkIssue2853Task(b, dir, mode.task, mode.expectCache, fileCount, fileSize)
+		})
+	}
+}
+
+func benchmarkIssue2853Task(
+	b *testing.B,
+	dir string,
+	taskName string,
+	expectCache bool,
+	fileCount int,
+	fileSize int64,
+) {
+	b.Helper()
+
+	tempDir := task.TempDir{
+		Remote:      filepath.Join(dir, ".task"),
+		Fingerprint: filepath.Join(dir, ".task"),
+	}
+
+	if expectCache {
+		e := task.NewExecutor(
+			task.WithDir(dir),
+			task.WithStdout(io.Discard),
+			task.WithStderr(io.Discard),
+			task.WithTempDir(tempDir),
+		)
+		require.NoError(b, e.Setup())
+		require.NoError(b, e.Run(b.Context(), &task.Call{Task: taskName}))
+	}
+
+	b.ReportAllocs()
+	sourceBytes := int64(fileCount) * fileSize
+	if expectCache {
+		b.SetBytes(sourceBytes)
+	}
+	b.ResetTimer()
+	for range b.N {
+		var buff bytes.Buffer
+		e := task.NewExecutor(
+			task.WithDir(dir),
+			task.WithStdout(&buff),
+			task.WithStderr(&buff),
+			task.WithTempDir(tempDir),
+		)
+		require.NoError(b, e.Setup())
+		require.NoError(b, e.Run(b.Context(), &task.Call{Task: taskName}))
+		if expectCache {
+			require.Contains(b, buff.String(), fmt.Sprintf(`Task "%s" is up to date`, taskName))
+		}
+	}
+	if expectCache {
+		b.ReportMetric(float64(fileCount), "source_files/op")
+		b.ReportMetric(float64(sourceBytes)/(1024*1024), "source_MiB/op")
+	}
+}
+
+func createIssue2853Fixture(tb testing.TB, dir string, fileCount int, fileSize int64) {
+	tb.Helper()
+
+	taskfile := `version: '3'
+
+tasks:
+  checksum-yaml:
+    sources:
+      - path/to/folder/**/*.yaml
+    generates:
+      - out/checksum.txt
+    cmds:
+      - printf ok > out/checksum.txt
+
+  timestamp-yaml:
+    method: timestamp
+    sources:
+      - path/to/folder/**/*.yaml
+    generates:
+      - out/timestamp.txt
+    cmds:
+      - printf ok > out/timestamp.txt
+
+  uncached-yaml:
+    method: none
+    cmds:
+      - printf ok > out/uncached.txt
+`
+	require.NoError(tb, os.WriteFile(filepath.Join(dir, "Taskfile.yml"), []byte(taskfile), 0o644))
+	require.NoError(tb, os.MkdirAll(filepath.Join(dir, "out"), 0o755))
+
+	for i := 1; i <= fileCount; i++ {
+		subdir := filepath.Join(dir, "path", "to", "folder", fmt.Sprintf("%04d", i/100))
+		require.NoError(tb, os.MkdirAll(subdir, 0o755))
+		name := filepath.Join(subdir, fmt.Sprintf("file-%05d.yaml", i))
+		createSparseFile(tb, name, fileSize)
+	}
+}
+
+func createSparseFile(tb testing.TB, name string, size int64) {
+	tb.Helper()
+
+	file, err := os.OpenFile(name, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	require.NoError(tb, err)
+	defer func() {
+		require.NoError(tb, file.Close())
+	}()
+	require.NoError(tb, file.Truncate(size))
+}

--- a/checksum_benchmark_test.go
+++ b/checksum_benchmark_test.go
@@ -19,27 +19,27 @@ import (
 )
 
 const (
-	issue2853ManySmallYAMLFileCount = 20_000
-	issue2853SmallYAMLFileSize      = 5
-	issue2853FewLargeYAMLFileCount  = 4
-	issue2853LargeYAMLFileSize      = 128 * 1024 * 1024
+	manySmallFileCount = 20_000
+	smallFileSize      = 5
+	fewLargeFileCount  = 4
+	largeFileSize      = 128 * 1024 * 1024
 )
 
-func BenchmarkIssue2853ManySmallSparseYAMLFiles(b *testing.B) {
+func BenchmarkManySmallFiles(b *testing.B) {
 	dir := b.TempDir()
-	createIssue2853Fixture(b, dir, issue2853ManySmallYAMLFileCount, issue2853SmallYAMLFileSize)
+	createBenchmarkFixture(b, dir, manySmallFileCount, smallFileSize)
 
-	benchmarkIssue2853Modes(b, dir, issue2853ManySmallYAMLFileCount, issue2853SmallYAMLFileSize)
+	benchmarkModes(b, dir, manySmallFileCount, smallFileSize)
 }
 
-func BenchmarkIssue2853FewLargeSparseYAMLFiles(b *testing.B) {
+func BenchmarkFewLargeFiles(b *testing.B) {
 	dir := b.TempDir()
-	createIssue2853Fixture(b, dir, issue2853FewLargeYAMLFileCount, issue2853LargeYAMLFileSize)
+	createBenchmarkFixture(b, dir, fewLargeFileCount, largeFileSize)
 
-	benchmarkIssue2853Modes(b, dir, issue2853FewLargeYAMLFileCount, issue2853LargeYAMLFileSize)
+	benchmarkModes(b, dir, fewLargeFileCount, largeFileSize)
 }
 
-func benchmarkIssue2853Modes(b *testing.B, dir string, fileCount int, fileSize int64) {
+func benchmarkModes(b *testing.B, dir string, fileCount int, fileSize int64) {
 	b.Helper()
 
 	for _, mode := range []struct {
@@ -55,15 +55,15 @@ func benchmarkIssue2853Modes(b *testing.B, dir string, fileCount int, fileSize i
 	} {
 		b.Run(mode.name, func(b *testing.B) {
 			if mode.nativeMTime {
-				benchmarkIssue2853NativeMTime(b, dir, fileCount, fileSize)
+				benchmarkNativeMTime(b, dir, fileCount, fileSize)
 				return
 			}
-			benchmarkIssue2853Task(b, dir, mode.task, mode.expectCache, fileCount, fileSize)
+			benchmarkTask(b, dir, mode.task, mode.expectCache, fileCount, fileSize)
 		})
 	}
 }
 
-func benchmarkIssue2853Task(
+func benchmarkTask(
 	b *testing.B,
 	dir string,
 	taskName string,
@@ -115,7 +115,7 @@ func benchmarkIssue2853Task(
 	}
 }
 
-func benchmarkIssue2853NativeMTime(b *testing.B, dir string, fileCount int, fileSize int64) {
+func benchmarkNativeMTime(b *testing.B, dir string, fileCount int, fileSize int64) {
 	b.Helper()
 
 	output := filepath.Join(dir, "out", "native-mtime.txt")
@@ -163,7 +163,7 @@ func nativeMTimeUpToDate(sourceRoot string, outputTime time.Time) (bool, error) 
 	return upToDate, err
 }
 
-func createIssue2853Fixture(tb testing.TB, dir string, fileCount int, fileSize int64) {
+func createBenchmarkFixture(tb testing.TB, dir string, fileCount int, fileSize int64) {
 	tb.Helper()
 
 	taskfile := `version: '3'

--- a/checksum_benchmark_test.go
+++ b/checksum_benchmark_test.go
@@ -1,3 +1,6 @@
+//go:build fsbench
+// +build fsbench
+
 package task_test
 
 import (


### PR DESCRIPTION
Add Issue #2853 benchmarks comparing checksum, timestamp, and uncached tasks across many-small and few-large sparse source sets.

In my opinion, it looks like there are too many allocations and there must be inefficiencies in the many-small sources scenario.

```
  many small / checksum    419 ms   0.24 MB/s      0.095 MiB, 20000 files
  many small / timestamp   144 ms   0.69 MB/s      0.095 MiB, 20000 files
  many small / none        0.71 ms

  few large / checksum    60.4 ms   8883 MB/s      512 MiB, 4 files
  few large / timestamp   0.23 ms   2330118 MB/s   512 MiB, 4 files
  few large / none        0.56 ms
```

The MB/s is not a IO rate (timestamp doesn't do IO). More like, a throughput comparison.

<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/)
