### PR TITLE
perf: add fast path for simple recursive globs

### DIFF
--- a/internal/fingerprint/glob.go
+++ b/internal/fingerprint/glob.go
@@ -1,19 +1,15 @@
 package fingerprint
 
 import (
-	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
-	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
+	"github.com/go-task/task/v3/internal/fsext"
 	"github.com/go-task/task/v3/taskfile/ast"
 )
-
-var errFastGlobFallback = errors.New("fast glob fallback")
 
 func Globs(dir string, globs []*ast.Glob, useGitignore bool) ([]string, error) {
 	resultMap := make(map[string]bool)
@@ -37,7 +33,7 @@ func Globs(dir string, globs []*ast.Glob, useGitignore bool) ([]string, error) {
 func glob(dir string, g string) ([]string, error) {
 	g = filepathext.SmartJoin(dir, g)
 
-	if results, ok, err := fastRecursiveGlob(g); ok {
+	if results, ok, err := fsext.FastRecursiveGlob(g); ok {
 		return results, err
 	}
 
@@ -59,66 +55,6 @@ func glob(dir string, g string) ([]string, error) {
 		results[f] = true
 	}
 	return collectKeys(results), nil
-}
-
-func fastRecursiveGlob(pattern string) ([]string, bool, error) {
-	pattern = filepath.Clean(pattern)
-	separator := string(os.PathSeparator)
-	marker := separator + "**" + separator
-
-	idx := strings.Index(pattern, marker)
-	if idx == -1 || strings.Contains(pattern[idx+len(marker):], marker) {
-		return nil, false, nil
-	}
-
-	root := pattern[:idx]
-	namePattern := pattern[idx+len(marker):]
-	if root == "" || namePattern == "" || strings.Contains(namePattern, separator) {
-		return nil, false, nil
-	}
-	if strings.Contains(root, "**") || strings.ContainsAny(root, "*?[]{}") {
-		return nil, false, nil
-	}
-	if strings.ContainsAny(namePattern, "{}") {
-		return nil, false, nil
-	}
-
-	results := make(map[string]bool)
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-
-		if d.Type()&fs.ModeSymlink != 0 {
-			info, err := os.Stat(path)
-			if err != nil {
-				return err
-			}
-			if info.IsDir() {
-				return errFastGlobFallback
-			}
-		}
-
-		matched, err := filepath.Match(namePattern, filepath.Base(path))
-		if err != nil {
-			return err
-		}
-		if !matched {
-			return nil
-		}
-		results[path] = true
-		return nil
-	})
-	if errors.Is(err, errFastGlobFallback) {
-		return nil, false, nil
-	}
-	if err != nil {
-		return nil, true, err
-	}
-	return collectKeys(results), true, nil
 }
 
 func collectKeys(m map[string]bool) []string {

--- a/internal/fingerprint/glob.go
+++ b/internal/fingerprint/glob.go
@@ -1,14 +1,19 @@
 package fingerprint
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
+	"github.com/go-task/task/v3/errors"
 	"github.com/go-task/task/v3/internal/execext"
 	"github.com/go-task/task/v3/internal/filepathext"
 	"github.com/go-task/task/v3/taskfile/ast"
 )
+
+var errFastGlobFallback = errors.New("fast glob fallback")
 
 func Globs(dir string, globs []*ast.Glob, useGitignore bool) ([]string, error) {
 	resultMap := make(map[string]bool)
@@ -32,6 +37,10 @@ func Globs(dir string, globs []*ast.Glob, useGitignore bool) ([]string, error) {
 func glob(dir string, g string) ([]string, error) {
 	g = filepathext.SmartJoin(dir, g)
 
+	if results, ok, err := fastRecursiveGlob(g); ok {
+		return results, err
+	}
+
 	fs, err := execext.ExpandFields(g)
 	if err != nil {
 		return nil, err
@@ -50,6 +59,66 @@ func glob(dir string, g string) ([]string, error) {
 		results[f] = true
 	}
 	return collectKeys(results), nil
+}
+
+func fastRecursiveGlob(pattern string) ([]string, bool, error) {
+	pattern = filepath.Clean(pattern)
+	separator := string(os.PathSeparator)
+	marker := separator + "**" + separator
+
+	idx := strings.Index(pattern, marker)
+	if idx == -1 || strings.Contains(pattern[idx+len(marker):], marker) {
+		return nil, false, nil
+	}
+
+	root := pattern[:idx]
+	namePattern := pattern[idx+len(marker):]
+	if root == "" || namePattern == "" || strings.Contains(namePattern, separator) {
+		return nil, false, nil
+	}
+	if strings.Contains(root, "**") || strings.ContainsAny(root, "*?[]{}") {
+		return nil, false, nil
+	}
+	if strings.ContainsAny(namePattern, "{}") {
+		return nil, false, nil
+	}
+
+	results := make(map[string]bool)
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		if d.Type()&fs.ModeSymlink != 0 {
+			info, err := os.Stat(path)
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return errFastGlobFallback
+			}
+		}
+
+		matched, err := filepath.Match(namePattern, filepath.Base(path))
+		if err != nil {
+			return err
+		}
+		if !matched {
+			return nil
+		}
+		results[path] = true
+		return nil
+	})
+	if errors.Is(err, errFastGlobFallback) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, true, err
+	}
+	return collectKeys(results), true, nil
 }
 
 func collectKeys(m map[string]bool) []string {

--- a/internal/fsext/glob.go
+++ b/internal/fsext/glob.go
@@ -37,7 +37,7 @@ func FastRecursiveGlob(pattern string) ([]string, bool, error) {
 		return nil, false, nil
 	}
 
-	results := make(map[string]bool)
+	var results []string
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -59,12 +59,12 @@ func FastRecursiveGlob(pattern string) ([]string, bool, error) {
 			}
 		}
 
-		matched, err := filepath.Match(namePattern, filepath.Base(path))
+		matched, err := filepath.Match(namePattern, d.Name())
 		if err != nil {
 			return err
 		}
 		if matched {
-			results[path] = true
+			results = append(results, filepath.ToSlash(path))
 		}
 		return nil
 	})
@@ -74,14 +74,6 @@ func FastRecursiveGlob(pattern string) ([]string, bool, error) {
 	if err != nil {
 		return nil, true, err
 	}
-	return collectGlobKeys(results), true, nil
-}
-
-func collectGlobKeys(matches map[string]bool) []string {
-	results := make([]string, 0, len(matches))
-	for path := range matches {
-		results = append(results, filepath.ToSlash(path))
-	}
 	sort.Strings(results)
-	return results
+	return results, true, nil
 }

--- a/internal/fsext/glob.go
+++ b/internal/fsext/glob.go
@@ -1,0 +1,87 @@
+package fsext
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/go-task/task/v3/errors"
+)
+
+var errFastGlobFallback = errors.New("fast glob fallback")
+
+// FastRecursiveGlob expands simple literal-root recursive patterns. The
+// boolean reports whether the pattern was handled or requires the full shell
+// glob expander.
+func FastRecursiveGlob(pattern string) ([]string, bool, error) {
+	pattern = filepath.Clean(pattern)
+	separator := string(os.PathSeparator)
+	marker := separator + "**" + separator
+
+	idx := strings.Index(pattern, marker)
+	if idx == -1 || strings.Contains(pattern[idx+len(marker):], marker) {
+		return nil, false, nil
+	}
+
+	root := pattern[:idx]
+	namePattern := pattern[idx+len(marker):]
+	if root == "" || namePattern == "" || strings.Contains(namePattern, separator) {
+		return nil, false, nil
+	}
+	if strings.Contains(root, "**") || strings.ContainsAny(root, "*?[]{}") {
+		return nil, false, nil
+	}
+	if strings.ContainsAny(namePattern, "{}") {
+		return nil, false, nil
+	}
+
+	results := make(map[string]bool)
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if path == root {
+			return errFastGlobFallback
+		}
+
+		if d.Type()&fs.ModeSymlink != 0 {
+			info, err := os.Stat(path)
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return errFastGlobFallback
+			}
+		}
+
+		matched, err := filepath.Match(namePattern, filepath.Base(path))
+		if err != nil {
+			return err
+		}
+		if matched {
+			results[path] = true
+		}
+		return nil
+	})
+	if errors.Is(err, errFastGlobFallback) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, true, err
+	}
+	return collectGlobKeys(results), true, nil
+}
+
+func collectGlobKeys(matches map[string]bool) []string {
+	results := make([]string, 0, len(matches))
+	for path := range matches {
+		results = append(results, filepath.ToSlash(path))
+	}
+	sort.Strings(results)
+	return results
+}

--- a/internal/fsext/glob_test.go
+++ b/internal/fsext/glob_test.go
@@ -1,0 +1,92 @@
+package fsext
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFastRecursiveGlob(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), "root")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "nested", "deeper"), 0o755))
+
+	files := []string{
+		filepath.Join(root, "direct.yaml"),
+		filepath.Join(root, "nested", "alpha.yaml"),
+		filepath.Join(root, "nested", "deeper", "beta.yaml"),
+		filepath.Join(root, "nested", "ignored.txt"),
+	}
+	for _, file := range files {
+		require.NoError(t, os.WriteFile(file, nil, 0o600))
+	}
+
+	got, ok, err := FastRecursiveGlob(filepath.Join(root, "**", "*.yaml"))
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []string{
+		filepath.ToSlash(files[0]),
+		filepath.ToSlash(files[1]),
+		filepath.ToSlash(files[2]),
+	}, got)
+}
+
+func TestFastRecursiveGlobFallback(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), "root")
+	tests := []struct {
+		name    string
+		pattern string
+	}{
+		{name: "no recursive marker", pattern: filepath.Join(root, "*.yaml")},
+		{name: "wildcard root", pattern: filepath.Join(root, "*", "**", "*.yaml")},
+		{name: "nested suffix", pattern: filepath.Join(root, "**", "generated", "*.yaml")},
+		{name: "brace suffix", pattern: filepath.Join(root, "**", "*.{yaml,yml}")},
+		{name: "multiple recursive markers", pattern: filepath.Join(root, "**", "nested", "**", "*.yaml")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok, err := FastRecursiveGlob(tt.pattern)
+			require.NoError(t, err)
+			require.False(t, ok)
+			require.Nil(t, got)
+		})
+	}
+}
+
+func TestFastRecursiveGlobNonDirectoryRoot(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), "root.yaml")
+	require.NoError(t, os.WriteFile(root, nil, 0o600))
+
+	got, ok, err := FastRecursiveGlob(filepath.Join(root, "**", "*.yaml"))
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, got)
+}
+
+func TestFastRecursiveGlobSymlinkDirectoryFallback(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	root := filepath.Join(tempDir, "root")
+	target := filepath.Join(tempDir, "target")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(target, "file.yaml"), nil, 0o600))
+	if err := os.Symlink(target, filepath.Join(root, "linked")); err != nil {
+		t.Skipf("cannot create directory symlink: %v", err)
+	}
+
+	got, ok, err := FastRecursiveGlob(filepath.Join(root, "**", "*.yaml"))
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, got)
+}


### PR DESCRIPTION
This is a **stacked** optimization PR on top of the filesystem benchmark work in #2881. Please review or merge #2881 first; this branch intentionally depends on those benchmarks so the performance impact can be evaluated with the same many-small and few-large fixtures.

This is independent from #2883.

This PR optimizes expansion for simple recursive source globs like `path/to/folder/**/*.yaml`.

The fast path only handles narrow literal-root recursive globs. More complex shell-style patterns continue to use the existing expander, and symlinked directories fall back to the existing path to preserve current behavior.

```text
BenchmarkManySmallFiles/checksum-28                    3         389359224 ns/op           0.26 MB/s             0.09537 source_MiB/op     20000 source_files/op      2004835176 B/op   491402 allocs/op
BenchmarkManySmallFiles/timestamp-28                   3          83254561 ns/op           1.20 MB/s             0.09537 source_MiB/op     20000 source_files/op      42646077 B/op     311394 allocs/op
BenchmarkManySmallFiles/native-mtime-28                3          18549550 ns/op           5.39 MB/s             0.09537 source_MiB/op     20000 source_files/op      11558392 B/op     123036 allocs/op
BenchmarkManySmallFiles/none-28                        3            744356 ns/op         2598650 B/op       3193 allocs/op

BenchmarkFewLargeFiles/checksum-28                     3          60481191 ns/op        8876.66 MB/s           512.0 source_MiB/op            4.000 source_files/op    1064938 B/op       1551 allocs/op
BenchmarkFewLargeFiles/timestamp-28                    3            113883 ns/op        4714246.05 MB/s        512.0 source_MiB/op            4.000 source_files/op     262730 B/op       1525 allocs/op
BenchmarkFewLargeFiles/native-mtime-28                 3             11552 ns/op        46475623.60 MB/s               512.0 source_MiB/op             4.000 source_files/op      4701 B/op         44 allocs/op
BenchmarkFewLargeFiles/none-28                         3           1048155 ns/op         2573429 B/op       3185 allocs/op
```
