### PR TITLE
fix: sanitize all invalid characters in checksum filenames

### DIFF
--- a/internal/fingerprint/sources_checksum.go
+++ b/internal/fingerprint/sources_checksum.go
@@ -119,7 +119,7 @@ func (checker *ChecksumChecker) checksumFilePath(t *ast.Task) string {
 	return filepath.Join(checker.tempDir, "checksum", normalizeFilename(t.Name()))
 }
 
-var checksumFilenameRegexp = regexp.MustCompile("[^A-z0-9]")
+var checksumFilenameRegexp = regexp.MustCompile("[^[:alnum:]]")
 
 // replaces invalid characters on filenames with "-"
 func normalizeFilename(f string) string {

--- a/internal/fingerprint/sources_checksum_test.go
+++ b/internal/fingerprint/sources_checksum_test.go
@@ -16,6 +16,10 @@ func TestNormalizeFilename(t *testing.T) {
 		{"foo/bar/baz", "foo-bar-baz"},
 		{"foo@bar/baz", "foo-bar-baz"},
 		{"foo1bar2baz3", "foo1bar2baz3"},
+		{"foo\\bar", "foo-bar"},
+		{"foo_bar", "foo-bar"},
+		{"foo[bar]baz", "foo-bar-baz"},
+		{"foo^bar`baz", "foo-bar-baz"},
 	}
 	for _, test := range tests {
 		assert.Equal(t, test.Out, normalizeFilename(test.In))


### PR DESCRIPTION
## Description

`normalizeFilename` (in `internal/fingerprint`) turns a task name into the on-disk checksum/timestamp filename, replacing invalid characters with `-`. It uses:

```go
var checksumFilenameRegexp = regexp.MustCompile("[^A-z0-9]")
```

`A-z` is the classic range bug: it spans ASCII 65 (`A`) to 122 (`z`), which **includes the six characters between `Z` and `a`** — `[ \\ ] ^ _ \``. Those are not sanitized. The intent (per the comment) was clearly `[A-Za-z0-9]`.

Concrete impact: a task name containing one of these characters (notably `\\`, a path separator on Windows) leaks into the checksum/timestamp file path, which can corrupt the file location and break `sources:`/`generates:` up-to-date detection for that task.

## Fix

`[^A-z0-9]` → `[^A-Za-z0-9]`.

## Test

Extended `TestNormalizeFilename` with cases for the leaked characters (`\\`, `_`, `[`, `]`, `^`, `\``). Fails before, passes after.

Note: for any existing task whose name contains one of these characters, the normalized filename changes once, so the first run after upgrade recomputes the checksum (treated as not-up-to-date) — expected and harmless.

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/)