### PR TITLE
docs: clarify join argument order in templating reference

### DIFF
--- a/website/src/docs/reference/templating.md
+++ b/website/src/docs/reference/templating.md
@@ -565,6 +565,9 @@ tasks:
       - echo "{{.MULTILINE | catLines}}"          # Replace newlines with spaces
 ```
 
+In pipeline form, `join` receives the list from the left-hand side. The
+equivalent non-pipeline form is `{{join " " .WORDS}}`.
+
 #### Shell Argument Parsing
 
 ```yaml


### PR DESCRIPTION
Summary
Clarify that `join` receives the list from the left-hand side in pipeline form, and show the equivalent non-pipeline call.

Fixes #2224

Validation
- Ran `git diff --check`
- Ran `pnpm build` in `website/` (currently fails on a pre-existing parsing error in `website/src/docs/reference/templating.md:419`, outside this diff)
