### PR TITLE
fix: reject include without taskfile or dir

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -1082,6 +1082,25 @@ func TestIncludesIncorrect(t *testing.T) {
 	assert.Contains(t, err.Error(), "Failed to parse testdata/includes_incorrect/incomplete.yml:", err.Error())
 }
 
+func TestIncludesMissingTaskfile(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/includes_missing_taskfile"
+
+	var buff bytes.Buffer
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSilent(true),
+	)
+
+	err := e.Setup()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "include must specify taskfile or dir")
+	assert.NotContains(t, err.Error(), "include cycle detected")
+}
+
 func TestIncludesEmptyMain(t *testing.T) {
 	t.Parallel()
 

--- a/taskfile/ast/include.go
+++ b/taskfile/ast/include.go
@@ -2,6 +2,7 @@ package ast
 
 import (
 	"iter"
+	"strings"
 	"sync"
 
 	"github.com/elliotchance/orderedmap/v3"
@@ -170,6 +171,9 @@ func (include *Include) UnmarshalYAML(node *yaml.Node) error {
 		}
 		if err := node.Decode(&includedTaskfile); err != nil {
 			return errors.NewTaskfileDecodeError(err, node)
+		}
+		if strings.TrimSpace(includedTaskfile.Taskfile) == "" && strings.TrimSpace(includedTaskfile.Dir) == "" {
+			return errors.NewTaskfileDecodeError(nil, node).WithMessage("include must specify taskfile or dir")
 		}
 		include.Taskfile = includedTaskfile.Taskfile
 		include.Dir = includedTaskfile.Dir

--- a/testdata/includes_missing_taskfile/Taskfile.yml
+++ b/testdata/includes_missing_taskfile/Taskfile.yml
@@ -1,0 +1,5 @@
+version: '3'
+
+includes:
+  GOBIN:
+    sh: echo $(go env GOPATH)/bin

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -701,11 +701,13 @@
                   "properties": {
                     "taskfile": {
                       "description": "The path for the Taskfile or directory to be included. If a directory, Task will look for files named `Taskfile.yml` or `Taskfile.yaml` inside that directory. If a relative path, resolved relative to the directory containing the including Taskfile.",
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     },
                     "dir": {
                       "description": "The working directory of the included tasks when run.",
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     },
                     "optional": {
                       "description": "If `true`, no errors will be thrown if the specified file does not exist.",
@@ -741,7 +743,15 @@
                       "description": "The checksum of the file you expect to include. If the checksum does not match, the file will not be included.",
                       "type": "string"
                     }
-                  }
+                  },
+                  "anyOf": [
+                    {
+                      "required": ["taskfile"]
+                    },
+                    {
+                      "required": ["dir"]
+                    }
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
Fixes #1881.

## What changed

- Reject advanced include mappings that specify neither `taskfile` nor `dir`.
- Add a regression test for the malformed include case from the issue.
- Assert the old misleading include-cycle error is no longer returned.

## Why

A mapping under `includes:` without a Taskfile path currently falls through to default Taskfile discovery. In the issue example, that makes a simple configuration mistake look like an include cycle. Failing during Taskfile decoding gives the user a direct configuration error instead.

## Validation

- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run`
