### PR TITLE
fix: `$schema` according to schemastore standards

### DIFF
--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Taskfile YAML Schema",
   "description": "Schema for Taskfile files.",
   "definitions": {


### PR DESCRIPTION
This is a petty change, I admit. This should not be a breaking change, by any means.

Since this repository has its schema hosted in [Schemastore/schemastore][schemastore], this change upholds the standards of schema drafting this repository widely follows. Namely, emphasis mine:

> **Valid schemas**: ["https://json-schema.org/draft/2020-12/schema","https://json-schema.org/draft/2019-09/schema",**"http://json-schema.org/draft-07/schema#"**,"http://json-schema.org/draft-06/schema#","http://json-schema.org/draft-04/schema#","http://json-schema.org/draft-03/schema#"]

Apologies for the inconvenience. Thanks for your time.

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/)

[schemastore]: https://github.com/SchemaStore/schemastore/blob/98d27ebb20037b5d5f4afeb0494c03ab70bce6f0/src/schemas/json/taskfile.json
