### PR TITLE
feat: command timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@
 - Added Nushell completions, available via `task --completion nu`. They complete
   task names and aliases, every flag with its description, and the values of
   `--completion`, `--output` and `--sort` (#2966 by @vmaerten).
+- :warning: Added a per-command `timeout` that terminates a command once it
+  exceeds the given duration (Go duration syntax). It covers shell commands,
+  task calls, deferred commands, `deps` and the `if` condition, obeys
+  `ignore_error`, and reports exit code `124`. Callers that join a `run: once`
+  or `when_changed` task already running now honor their own `timeout`, and
+  inherit that task's failure instead of being told it succeeded (#1569, #2898
+  by @vmaerten).
 
 ## v3.52.0 - 2026-07-02
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -39,6 +39,7 @@ const (
 	CodeTaskCancelled
 	CodeTaskMissingRequiredVars
 	CodeTaskNotAllowedVars
+	CodeTaskTimedOut
 )
 
 // TaskError extends the standard error interface with a Code method. This code will

--- a/errors/errors_task.go
+++ b/errors/errors_task.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"mvdan.cc/sh/v3/interp"
 )
@@ -56,6 +57,22 @@ func (err *TaskRunError) TaskExitCode() int {
 
 func (err *TaskRunError) Unwrap() error {
 	return err.Err
+}
+
+// TaskTimeoutError is returned when a command exceeds the timeout it declared.
+// It deliberately does not unwrap to context.DeadlineExceeded, which the watch
+// loop treats as an expected cancellation and swallows.
+type TaskTimeoutError struct {
+	TaskName string
+	Timeout  time.Duration
+}
+
+func (err *TaskTimeoutError) Error() string {
+	return fmt.Sprintf(`task: [%s] command timeout exceeded (%s)`, err.TaskName, err.Timeout)
+}
+
+func (err *TaskTimeoutError) Code() int {
+	return CodeTaskTimedOut
 }
 
 // TaskInternalError when the user attempts to invoke a task that is internal.

--- a/errors/errors_task.go
+++ b/errors/errors_task.go
@@ -63,15 +63,12 @@ func (err *TaskRunError) Unwrap() error {
 	return err.Err
 }
 
-// TimeoutExitCode is the code a command killed by its timeout reports, both
-// through {{.EXIT_CODE}} and through --exit-code. It follows the convention of
-// timeout(1) from coreutils, which the shell has no exit status of its own to
-// offer for a killed command.
+// TimeoutExitCode is what a killed command reports in place of the exit status
+// it never got, following the convention of timeout(1).
 const TimeoutExitCode = 124
 
 // TaskTimeoutError is returned when a command exceeds the timeout it declared.
-// It deliberately does not unwrap to context.DeadlineExceeded, which the watch
-// loop treats as an expected cancellation and swallows.
+// It must not unwrap to context.DeadlineExceeded, which --watch swallows.
 type TaskTimeoutError struct {
 	TaskName string
 	Timeout  time.Duration

--- a/errors/errors_task.go
+++ b/errors/errors_task.go
@@ -52,12 +52,22 @@ func (err *TaskRunError) TaskExitCode() int {
 	if errors.As(err.Err, &exit) {
 		return int(exit)
 	}
+	var timeout *TaskTimeoutError
+	if errors.As(err.Err, &timeout) {
+		return TimeoutExitCode
+	}
 	return err.Code()
 }
 
 func (err *TaskRunError) Unwrap() error {
 	return err.Err
 }
+
+// TimeoutExitCode is the code a command killed by its timeout reports, both
+// through {{.EXIT_CODE}} and through --exit-code. It follows the convention of
+// timeout(1) from coreutils, which the shell has no exit status of its own to
+// offer for a killed command.
+const TimeoutExitCode = 124
 
 // TaskTimeoutError is returned when a command exceeds the timeout it declared.
 // It deliberately does not unwrap to context.DeadlineExceeded, which the watch

--- a/executor.go
+++ b/executor.go
@@ -1,7 +1,6 @@
 package task
 
 import (
-	"context"
 	"io"
 	"os"
 	"sync"
@@ -80,7 +79,7 @@ type (
 		concurrencySemaphore chan struct{}
 		taskCallCount        map[string]*int32
 		mkdirMutexMap        map[string]*sync.Mutex
-		executionHashes      map[string]context.Context
+		executionHashes      map[string]*executionState
 		executionHashesMutex sync.Mutex
 		watchedDirs          *xsync.Map[string, bool]
 	}
@@ -108,7 +107,7 @@ func NewExecutor(opts ...ExecutorOption) *Executor {
 		concurrencySemaphore: nil,
 		taskCallCount:        map[string]*int32{},
 		mkdirMutexMap:        map[string]*sync.Mutex{},
-		executionHashes:      map[string]context.Context{},
+		executionHashes:      map[string]*executionState{},
 		executionHashesMutex: sync.Mutex{},
 	}
 	e.Options(opts...)

--- a/setup.go
+++ b/setup.go
@@ -261,7 +261,7 @@ func (e *Executor) setupDefaults() {
 }
 
 func (e *Executor) setupConcurrencyState() {
-	e.executionHashes = make(map[string]context.Context)
+	e.executionHashes = make(map[string]*executionState)
 
 	e.taskCallCount = make(map[string]*int32, e.Taskfile.Tasks.Len())
 	e.mkdirMutexMap = make(map[string]*sync.Mutex, e.Taskfile.Tasks.Len())

--- a/task.go
+++ b/task.go
@@ -376,12 +376,21 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 		}
 	}
 
+	if cmd.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cmd.Timeout)
+		defer cancel()
+	}
+
 	switch {
 	case cmd.Task != "":
 		reacquire := e.releaseConcurrencyLimit()
 		defer reacquire()
 
 		err := e.RunTask(ctx, &Call{Task: cmd.Task, Vars: cmd.Vars, Silent: cmd.Silent, Indirect: true})
+		if err != nil && ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("task: [%s] command timeout exceeded (%s): %w", t.Name(), cmd.Timeout, err)
+		}
 		var exitCode interp.ExitStatus
 		if errors.As(err, &exitCode) && cmd.IgnoreError {
 			e.Logger.VerboseErrf(logger.Yellow, "task: [%s] task error ignored: %v\n", t.Name(), err)
@@ -425,6 +434,9 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 		})
 		if closeErr := closer(err); closeErr != nil {
 			e.Logger.Errf(logger.Red, "task: unable to close writer: %v\n", closeErr)
+		}
+		if err != nil && ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("task: [%s] command timeout exceeded (%s): %w", t.Name(), cmd.Timeout, err)
 		}
 		var exitCode interp.ExitStatus
 		if errors.As(err, &exitCode) && cmd.IgnoreError {

--- a/task.go
+++ b/task.go
@@ -321,11 +321,20 @@ func (e *Executor) runDeps(ctx context.Context, t *ast.Task) error {
 
 	for _, d := range t.Deps {
 		g.Go(func() error {
-			err := e.RunTask(ctx, &Call{Task: d.Task, Vars: d.Vars, Silent: d.Silent, Indirect: true})
-			if err != nil {
-				return err
+			depCtx := ctx
+			var timeout *errors.TaskTimeoutError
+			if d.Timeout > 0 {
+				timeout = &errors.TaskTimeoutError{TaskName: d.Task, Timeout: d.Timeout}
+				var cancel context.CancelFunc
+				depCtx, cancel = context.WithTimeoutCause(ctx, d.Timeout, timeout)
+				defer cancel()
 			}
-			return nil
+
+			err := e.RunTask(depCtx, &Call{Task: d.Task, Vars: d.Vars, Silent: d.Silent, Indirect: true})
+			if err != nil && timedOut(depCtx, timeout) {
+				return timeout
+			}
+			return err
 		})
 	}
 

--- a/task.go
+++ b/task.go
@@ -332,6 +332,10 @@ func (e *Executor) runDeferred(t *ast.Task, call *Call, i int, vars *ast.Vars, d
 	defer cancel()
 
 	cmd := t.Cmds[i]
+	if cmd.Task != "" && cmd.Timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, cmd.Timeout)
+		defer cancel()
+	}
 	cache := &templater.Cache{Vars: vars}
 	extra := map[string]any{}
 

--- a/task.go
+++ b/task.go
@@ -354,6 +354,16 @@ func (e *Executor) runDeferred(t *ast.Task, call *Call, i int, vars *ast.Vars, d
 func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i int) error {
 	cmd := t.Cmds[i]
 
+	// The timeout bounds the whole step, so it must be in place before the if
+	// condition runs: a condition that hangs would otherwise hang the run.
+	var timeout *errors.TaskTimeoutError
+	if cmd.Timeout > 0 {
+		timeout = &errors.TaskTimeoutError{TaskName: t.Name(), Timeout: cmd.Timeout}
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeoutCause(ctx, cmd.Timeout, timeout)
+		defer cancel()
+	}
+
 	// Check if condition for any command type
 	if strings.TrimSpace(cmd.If) != "" {
 		if err := execext.RunCommand(ctx, &execext.RunCommandOptions{
@@ -361,17 +371,12 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 			Dir:     t.Dir,
 			Env:     env.Get(t),
 		}); err != nil {
+			if timedOut(ctx, timeout) {
+				return timeout
+			}
 			e.Logger.VerboseOutf(logger.Yellow, "task: [%s] if condition not met - skipped\n", t.Name())
 			return nil
 		}
-	}
-
-	var timeout *errors.TaskTimeoutError
-	if cmd.Timeout > 0 {
-		timeout = &errors.TaskTimeoutError{TaskName: t.Name(), Timeout: cmd.Timeout}
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeoutCause(ctx, cmd.Timeout, timeout)
-		defer cancel()
 	}
 
 	switch {

--- a/task.go
+++ b/task.go
@@ -368,8 +368,7 @@ func (e *Executor) runDeferred(t *ast.Task, call *Call, i int, vars *ast.Vars, d
 func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i int) error {
 	cmd := t.Cmds[i]
 
-	// The timeout bounds the whole step, so it must be in place before the if
-	// condition runs: a condition that hangs would otherwise hang the run.
+	// In place before the if condition, which would otherwise run unbounded.
 	var timeout *errors.TaskTimeoutError
 	if cmd.Timeout > 0 {
 		timeout = &errors.TaskTimeoutError{TaskName: t.Name(), Timeout: cmd.Timeout}
@@ -458,26 +457,22 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 	}
 }
 
-// isCommandFailure reports whether err is the command failing on its own terms
-// - a non-zero exit status or its own timeout - as opposed to Task failing to
-// run it at all. Only the former is what ignore_error offers to ignore.
+// isCommandFailure reports whether the command failed on its own terms - a
+// non-zero exit status or its timeout - rather than Task failing to run it.
 func isCommandFailure(err error) bool {
 	var exitCode interp.ExitStatus
 	var timeout *errors.TaskTimeoutError
 	return errors.As(err, &exitCode) || errors.As(err, &timeout)
 }
 
-// timedOut reports whether ctx was cancelled by the given timeout, as opposed
-// to a deadline inherited from an ancestor. ctx.Err() cannot tell them apart:
-// a derived context reports its parent's DeadlineExceeded as its own.
+// timedOut reports whether ctx was cancelled by the given timeout rather than by
+// an inherited deadline, which a derived context reports as its own.
 func timedOut(ctx context.Context, timeout *errors.TaskTimeoutError) bool {
 	return timeout != nil && errors.Is(context.Cause(ctx), timeout)
 }
 
 // executionState is the outcome of a task execution, shared with the callers
-// that join it instead of running the task again under run: once or run:
-// when_changed. done is closed once execute returns; err is written before that
-// and must only be read after done is seen closed, which is what orders them.
+// that join it. err is written before done is closed; read it only once closed.
 type executionState struct {
 	done chan struct{}
 	err  error
@@ -503,9 +498,8 @@ func (e *Executor) startExecution(ctx context.Context, t *ast.Task, execute func
 		reacquire := e.releaseConcurrencyLimit()
 		defer reacquire()
 
-		// Prefer an execution that is already over, even if our own context is
-		// done: there is nothing left to wait for, and select would otherwise
-		// pick between the two branches at random.
+		// A finished execution wins even if our context is done: there is
+		// nothing left to wait for, and select would otherwise pick at random.
 		select {
 		case <-other.done:
 			return other.err
@@ -514,14 +508,12 @@ func (e *Executor) startExecution(ctx context.Context, t *ast.Task, execute func
 
 		select {
 		case <-other.done:
-			// Somebody else ran the task on our behalf, so its outcome is ours.
-			// Reporting success here would hide a shared execution that failed
-			// or that another caller's timeout killed halfway through.
+			// Its outcome is ours. Returning nil would hide an execution that
+			// failed, or that another caller's timeout killed.
 			return other.err
 		case <-ctx.Done():
-			// We did not start the task, so we cannot stop it, only stop waiting
-			// for it. Report the cause rather than ctx.Err() so that our own
-			// timeout surfaces as one instead of a bare context error.
+			// We did not start it, so we can only stop waiting. Report the cause
+			// so that our own timeout surfaces as one.
 			return context.Cause(ctx)
 		}
 	}

--- a/task.go
+++ b/task.go
@@ -332,10 +332,6 @@ func (e *Executor) runDeferred(t *ast.Task, call *Call, i int, vars *ast.Vars, d
 	defer cancel()
 
 	cmd := t.Cmds[i]
-	if cmd.Task != "" && cmd.Timeout > 0 {
-		ctx, cancel = context.WithTimeout(ctx, cmd.Timeout)
-		defer cancel()
-	}
 	cache := &templater.Cache{Vars: vars}
 	extra := map[string]any{}
 
@@ -370,9 +366,11 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 		}
 	}
 
+	var timeout *errors.TaskTimeoutError
 	if cmd.Timeout > 0 {
+		timeout = &errors.TaskTimeoutError{TaskName: t.Name(), Timeout: cmd.Timeout}
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, cmd.Timeout)
+		ctx, cancel = context.WithTimeoutCause(ctx, cmd.Timeout, timeout)
 		defer cancel()
 	}
 
@@ -382,8 +380,8 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 		defer reacquire()
 
 		err := e.RunTask(ctx, &Call{Task: cmd.Task, Vars: cmd.Vars, Silent: cmd.Silent, Indirect: true})
-		if err != nil && ctx.Err() == context.DeadlineExceeded {
-			return fmt.Errorf("task: [%s] command timeout exceeded (%s): %w", t.Name(), cmd.Timeout, err)
+		if err != nil && timedOut(ctx, timeout) {
+			return timeout
 		}
 		var exitCode interp.ExitStatus
 		if errors.As(err, &exitCode) && cmd.IgnoreError {
@@ -429,8 +427,8 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 		if closeErr := closer(err); closeErr != nil {
 			e.Logger.Errf(logger.Red, "task: unable to close writer: %v\n", closeErr)
 		}
-		if err != nil && ctx.Err() == context.DeadlineExceeded {
-			return fmt.Errorf("task: [%s] command timeout exceeded (%s): %w", t.Name(), cmd.Timeout, err)
+		if err != nil && timedOut(ctx, timeout) {
+			return timeout
 		}
 		var exitCode interp.ExitStatus
 		if errors.As(err, &exitCode) && cmd.IgnoreError {
@@ -441,6 +439,13 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 	default:
 		return nil
 	}
+}
+
+// timedOut reports whether ctx was cancelled by the given timeout, as opposed
+// to a deadline inherited from an ancestor. ctx.Err() cannot tell them apart:
+// a derived context reports its parent's DeadlineExceeded as its own.
+func timedOut(ctx context.Context, timeout *errors.TaskTimeoutError) bool {
+	return timeout != nil && errors.Is(context.Cause(ctx), timeout)
 }
 
 func (e *Executor) startExecution(ctx context.Context, t *ast.Task, execute func(ctx context.Context) error) error {

--- a/task.go
+++ b/task.go
@@ -272,9 +272,13 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 				}
 
 				var exitCode interp.ExitStatus
-				if errors.As(err, &exitCode) {
+				var timeout *errors.TaskTimeoutError
+				switch {
+				case errors.As(err, &exitCode):
 					e.Logger.VerboseErrf(logger.Red, "task: %q failed: %v\n", call.Task, err)
 					deferredExitCode = uint8(exitCode)
+				case errors.As(err, &timeout):
+					deferredExitCode = errors.TimeoutExitCode
 				}
 
 				return err

--- a/task.go
+++ b/task.go
@@ -266,12 +266,13 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 					e.Logger.VerboseErrf(logger.Yellow, "task: error cleaning status on error: %v\n", err2)
 				}
 
+				if t.IgnoreError && isCommandFailure(err) {
+					e.Logger.VerboseErrf(logger.Yellow, "task: task error ignored: %v\n", err)
+					continue
+				}
+
 				var exitCode interp.ExitStatus
 				if errors.As(err, &exitCode) {
-					if t.IgnoreError {
-						e.Logger.VerboseErrf(logger.Yellow, "task: task error ignored: %v\n", err)
-						continue
-					}
 					e.Logger.VerboseErrf(logger.Red, "task: %q failed: %v\n", call.Task, err)
 					deferredExitCode = uint8(exitCode)
 				}
@@ -386,10 +387,9 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 
 		err := e.RunTask(ctx, &Call{Task: cmd.Task, Vars: cmd.Vars, Silent: cmd.Silent, Indirect: true})
 		if err != nil && timedOut(ctx, timeout) {
-			return timeout
+			err = timeout
 		}
-		var exitCode interp.ExitStatus
-		if errors.As(err, &exitCode) && cmd.IgnoreError {
+		if cmd.IgnoreError && isCommandFailure(err) {
 			e.Logger.VerboseErrf(logger.Yellow, "task: [%s] task error ignored: %v\n", t.Name(), err)
 			return nil
 		}
@@ -433,10 +433,9 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 			e.Logger.Errf(logger.Red, "task: unable to close writer: %v\n", closeErr)
 		}
 		if err != nil && timedOut(ctx, timeout) {
-			return timeout
+			err = timeout
 		}
-		var exitCode interp.ExitStatus
-		if errors.As(err, &exitCode) && cmd.IgnoreError {
+		if cmd.IgnoreError && isCommandFailure(err) {
 			e.Logger.VerboseErrf(logger.Yellow, "task: [%s] command error ignored: %v\n", t.Name(), err)
 			return nil
 		}
@@ -444,6 +443,15 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 	default:
 		return nil
 	}
+}
+
+// isCommandFailure reports whether err is the command failing on its own terms
+// - a non-zero exit status or its own timeout - as opposed to Task failing to
+// run it at all. Only the former is what ignore_error offers to ignore.
+func isCommandFailure(err error) bool {
+	var exitCode interp.ExitStatus
+	var timeout *errors.TaskTimeoutError
+	return errors.As(err, &exitCode) || errors.As(err, &timeout)
 }
 
 // timedOut reports whether ctx was cancelled by the given timeout, as opposed

--- a/task.go
+++ b/task.go
@@ -465,6 +465,15 @@ func timedOut(ctx context.Context, timeout *errors.TaskTimeoutError) bool {
 	return timeout != nil && errors.Is(context.Cause(ctx), timeout)
 }
 
+// executionState is the outcome of a task execution, shared with the callers
+// that join it instead of running the task again under run: once or run:
+// when_changed. done is closed once execute returns; err is written before that
+// and must only be read after done is seen closed, which is what orders them.
+type executionState struct {
+	done chan struct{}
+	err  error
+}
+
 func (e *Executor) startExecution(ctx context.Context, t *ast.Task, execute func(ctx context.Context) error) error {
 	h, err := e.GetHash(t)
 	if err != nil {
@@ -477,7 +486,7 @@ func (e *Executor) startExecution(ctx context.Context, t *ast.Task, execute func
 
 	e.executionHashesMutex.Lock()
 
-	if otherExecutionCtx, ok := e.executionHashes[h]; ok {
+	if other, ok := e.executionHashes[h]; ok {
 		e.executionHashesMutex.Unlock()
 		e.Logger.VerboseErrf(logger.Magenta, "task: skipping execution of task: %s\n", h)
 
@@ -485,17 +494,36 @@ func (e *Executor) startExecution(ctx context.Context, t *ast.Task, execute func
 		reacquire := e.releaseConcurrencyLimit()
 		defer reacquire()
 
-		<-otherExecutionCtx.Done()
-		return nil
+		// Prefer an execution that is already over, even if our own context is
+		// done: there is nothing left to wait for, and select would otherwise
+		// pick between the two branches at random.
+		select {
+		case <-other.done:
+			return other.err
+		default:
+		}
+
+		select {
+		case <-other.done:
+			// Somebody else ran the task on our behalf, so its outcome is ours.
+			// Reporting success here would hide a shared execution that failed
+			// or that another caller's timeout killed halfway through.
+			return other.err
+		case <-ctx.Done():
+			// We did not start the task, so we cannot stop it, only stop waiting
+			// for it. Report the cause rather than ctx.Err() so that our own
+			// timeout surfaces as one instead of a bare context error.
+			return context.Cause(ctx)
+		}
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	e.executionHashes[h] = ctx
+	state := &executionState{done: make(chan struct{})}
+	e.executionHashes[h] = state
 	e.executionHashesMutex.Unlock()
 
-	return execute(ctx)
+	defer close(state.done)
+	state.err = execute(ctx)
+	return state.err
 }
 
 // FindMatchingTasks returns a list of tasks that match the given call. A task

--- a/task.go
+++ b/task.go
@@ -366,12 +366,21 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 		}
 	}
 
+	if cmd.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cmd.Timeout)
+		defer cancel()
+	}
+
 	switch {
 	case cmd.Task != "":
 		reacquire := e.releaseConcurrencyLimit()
 		defer reacquire()
 
 		err := e.RunTask(ctx, &Call{Task: cmd.Task, Vars: cmd.Vars, Silent: cmd.Silent, Indirect: true})
+		if err != nil && ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("task: [%s] command timeout exceeded (%s): %w", t.Name(), cmd.Timeout, err)
+		}
 		var exitCode interp.ExitStatus
 		if errors.As(err, &exitCode) && cmd.IgnoreError {
 			e.Logger.VerboseErrf(logger.Yellow, "task: [%s] task error ignored: %v\n", t.Name(), err)
@@ -415,6 +424,9 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 		})
 		if closeErr := closer(err); closeErr != nil {
 			e.Logger.Errf(logger.Red, "task: unable to close writer: %v\n", closeErr)
+		}
+		if err != nil && ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("task: [%s] command timeout exceeded (%s): %w", t.Name(), cmd.Timeout, err)
 		}
 		var exitCode interp.ExitStatus
 		if errors.As(err, &exitCode) && cmd.IgnoreError {

--- a/task.go
+++ b/task.go
@@ -271,11 +271,12 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 					continue
 				}
 
+				e.Logger.VerboseErrf(logger.Red, "task: %q failed: %v\n", call.Task, err)
+
 				var exitCode interp.ExitStatus
 				var timeout *errors.TaskTimeoutError
 				switch {
 				case errors.As(err, &exitCode):
-					e.Logger.VerboseErrf(logger.Red, "task: %q failed: %v\n", call.Task, err)
 					deferredExitCode = uint8(exitCode)
 				case errors.As(err, &timeout):
 					deferredExitCode = errors.TimeoutExitCode

--- a/task.go
+++ b/task.go
@@ -342,6 +342,10 @@ func (e *Executor) runDeferred(t *ast.Task, call *Call, i int, vars *ast.Vars, d
 	defer cancel()
 
 	cmd := t.Cmds[i]
+	if cmd.Task != "" && cmd.Timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, cmd.Timeout)
+		defer cancel()
+	}
 	cache := &templater.Cache{Vars: vars}
 	extra := map[string]any{}
 

--- a/task_test.go
+++ b/task_test.go
@@ -2523,6 +2523,63 @@ func TestErrorCode(t *testing.T) {
 	}
 }
 
+func TestCommandTimeout(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/timeout"
+	tests := []struct {
+		name          string
+		task          string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "timeout exceeded",
+			task:          "timeout-exceeded",
+			expectError:   true,
+			errorContains: "timeout exceeded",
+		},
+		{
+			name:        "timeout not exceeded",
+			task:        "timeout-not-exceeded",
+			expectError: false,
+		},
+		{
+			name:        "no timeout",
+			task:        "no-timeout",
+			expectError: false,
+		},
+		{
+			name:          "multiple commands with timeout",
+			task:          "multiple-cmds-timeout",
+			expectError:   true,
+			errorContains: "timeout exceeded",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buff bytes.Buffer
+			e := task.NewExecutor(
+				task.WithDir(dir),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+			)
+			require.NoError(t, e.Setup())
+
+			err := e.Run(t.Context(), &task.Call{Task: test.task})
+			if test.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.errorContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestEvaluateSymlinksInPaths(t *testing.T) { // nolint:paralleltest // cannot run in parallel
 	const dir = "testdata/evaluate_symlinks_in_paths"
 	var buff bytes.Buffer

--- a/task_test.go
+++ b/task_test.go
@@ -2419,8 +2419,8 @@ func TestRunOnceJoinerHonorsItsOwnTimeout(t *testing.T) {
 	start := time.Now()
 	err := e.Run(t.Context(), &task.Call{Task: "default"})
 	require.Error(t, err)
-	// The joiner used to wait on the shared execution alone, outliving its own
-	// timeout by however long that execution took.
+	// The joiner used to wait on the shared execution alone, ignoring its own
+	// timeout for as long as that execution took.
 	assert.Less(t, time.Since(start), 5*time.Second)
 
 	var timeoutErr *errors.TaskTimeoutError
@@ -2923,8 +2923,7 @@ func TestCommandTimeoutAttribution(t *testing.T) {
 			require.ErrorAs(t, err, &timeoutErr)
 			assert.Equal(t, test.task, timeoutErr.TaskName)
 
-			// The watch loop stays silent on context errors, so a timeout must
-			// not look like one.
+			// --watch swallows context errors; a timeout must not look like one.
 			assert.False(t, errors.Is(err, context.DeadlineExceeded))
 		})
 	}

--- a/task_test.go
+++ b/task_test.go
@@ -2487,6 +2487,27 @@ func TestExitCodeOne(t *testing.T) {
 	assert.Equal(t, "FOO=bar - DYNAMIC_FOO=bar - EXIT_CODE=1", strings.TrimSpace(buff.String()))
 }
 
+func TestExitCodeTimeout(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/exit_code"
+	var buff bytes.Buffer
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
+	require.NoError(t, e.Setup())
+
+	err := e.Run(t.Context(), &task.Call{Task: "exit-timeout"})
+	require.Error(t, err)
+	assert.Equal(t, "EXIT_CODE=124", strings.TrimSpace(buff.String()))
+
+	var runErr *errors.TaskRunError
+	require.ErrorAs(t, err, &runErr)
+	assert.Equal(t, errors.TimeoutExitCode, runErr.TaskExitCode())
+}
+
 func TestIgnoreNilElements(t *testing.T) {
 	t.Parallel()
 

--- a/task_test.go
+++ b/task_test.go
@@ -1035,6 +1035,44 @@ func TestTaskIgnoreErrors(t *testing.T) {
 	require.Error(t, e.Run(t.Context(), &task.Call{Task: "cmd-should-fail"}))
 }
 
+func TestIgnoreErrorsOnTimeout(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/ignore_errors"
+	tests := []struct {
+		name        string
+		task        string
+		expectError bool
+	}{
+		{name: "ignored at task level", task: "task-timeout-should-pass"},
+		{name: "ignored at command level", task: "cmd-timeout-should-pass"},
+		{name: "not ignored", task: "cmd-timeout-should-fail", expectError: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buff bytes.Buffer
+			e := task.NewExecutor(
+				task.WithDir(dir),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+			)
+			require.NoError(t, e.Setup())
+
+			err := e.Run(t.Context(), &task.Call{Task: test.task})
+			if test.expectError {
+				require.Error(t, err)
+				assert.NotContains(t, buff.String(), "reached the end")
+				return
+			}
+			require.NoError(t, err)
+			assert.Contains(t, buff.String(), "reached the end")
+		})
+	}
+}
+
 func TestExpand(t *testing.T) {
 	t.Parallel()
 

--- a/task_test.go
+++ b/task_test.go
@@ -2381,6 +2381,54 @@ func TestRunOnceSharedDeps(t *testing.T) {
 	assert.Contains(t, buff.String(), `task: [service-b:build] echo "build b"`)
 }
 
+func TestRunOnceSharedFailurePropagates(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/run_once_failure"
+
+	var buff bytes.Buffer
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
+	require.NoError(t, e.Setup())
+
+	err := e.Run(t.Context(), &task.Call{Task: "default"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `Failed to run task "shared"`)
+	assert.NotContains(t, buff.String(), "should not be reached")
+	// The shared task still ran only once, which is the point of run: once.
+	assert.Equal(t, 1, strings.Count(buff.String(), "shared ran"))
+}
+
+func TestRunOnceJoinerHonorsItsOwnTimeout(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/run_once_timeout"
+
+	// The two deps run concurrently, so they need a buffer they can share.
+	var buff SyncBuffer
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
+	require.NoError(t, e.Setup())
+
+	start := time.Now()
+	err := e.Run(t.Context(), &task.Call{Task: "default"})
+	require.Error(t, err)
+	// The joiner used to wait on the shared execution alone, outliving its own
+	// timeout by however long that execution took.
+	assert.Less(t, time.Since(start), 5*time.Second)
+
+	var timeoutErr *errors.TaskTimeoutError
+	require.ErrorAs(t, err, &timeoutErr)
+	assert.Equal(t, "joiner", timeoutErr.TaskName)
+	assert.NotContains(t, buff.buf.String(), "should not be reached")
+}
+
 func TestRunWhenChanged(t *testing.T) {
 	t.Parallel()
 

--- a/task_test.go
+++ b/task_test.go
@@ -2395,6 +2395,27 @@ task-1 ran successfully
 	assert.Contains(t, buff.String(), "child task deferred value-from-parent")
 }
 
+func TestDeferredTaskTimeout(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/deferred"
+	var buff bytes.Buffer
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithVerbose(true),
+	)
+	require.NoError(t, e.Setup())
+
+	start := time.Now()
+	require.NoError(t, e.Run(t.Context(), &task.Call{Task: "parent-with-timeout"}))
+	assert.Less(t, time.Since(start), 500*time.Millisecond)
+	assert.Contains(t, buff.String(), "parent completed")
+	assert.NotContains(t, buff.String(), "\ncleanup completed\n")
+	assert.Contains(t, buff.String(), "ignored error in deferred cmd")
+}
+
 func TestExitCodeZero(t *testing.T) {
 	t.Parallel()
 

--- a/task_test.go
+++ b/task_test.go
@@ -2817,6 +2817,49 @@ func TestCommandTimeout(t *testing.T) {
 	}
 }
 
+func TestDepTimeout(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/dep_timeout"
+
+	t.Run("timeout exceeded", func(t *testing.T) {
+		t.Parallel()
+
+		var buff SyncBuffer
+		e := task.NewExecutor(
+			task.WithDir(dir),
+			task.WithStdout(&buff),
+			task.WithStderr(&buff),
+		)
+		require.NoError(t, e.Setup())
+
+		start := time.Now()
+		err := e.Run(t.Context(), &task.Call{Task: "timeout-exceeded"})
+		require.Error(t, err)
+		assert.Less(t, time.Since(start), 5*time.Second)
+
+		var timeoutErr *errors.TaskTimeoutError
+		require.ErrorAs(t, err, &timeoutErr)
+		assert.Equal(t, "slow", timeoutErr.TaskName)
+		assert.NotContains(t, buff.buf.String(), "should not be reached")
+	})
+
+	t.Run("timeout not exceeded", func(t *testing.T) {
+		t.Parallel()
+
+		var buff SyncBuffer
+		e := task.NewExecutor(
+			task.WithDir(dir),
+			task.WithStdout(&buff),
+			task.WithStderr(&buff),
+		)
+		require.NoError(t, e.Setup())
+
+		require.NoError(t, e.Run(t.Context(), &task.Call{Task: "timeout-not-exceeded"}))
+		assert.Contains(t, buff.buf.String(), "reached the end")
+	})
+}
+
 func TestCommandTimeoutBoundsIfCondition(t *testing.T) {
 	t.Parallel()
 

--- a/task_test.go
+++ b/task_test.go
@@ -2,6 +2,7 @@ package task_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -2705,6 +2706,54 @@ func TestCommandTimeout(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestCommandTimeoutAttribution(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/timeout"
+	tests := []struct {
+		name        string
+		task        string
+		notContains string
+	}{
+		{
+			name:        "a command declaring no timeout is not blamed for one",
+			task:        "inherited-timeout",
+			notContains: "(0s)",
+		},
+		{
+			name:        "a command is not blamed for a timeout it never reached",
+			task:        "larger-child-timeout",
+			notContains: "10m",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			e := task.NewExecutor(
+				task.WithDir(dir),
+				task.WithStdout(io.Discard),
+				task.WithStderr(io.Discard),
+			)
+			require.NoError(t, e.Setup())
+
+			err := e.Run(t.Context(), &task.Call{Task: test.task})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "command timeout exceeded (500ms)")
+			assert.NotContains(t, err.Error(), test.notContains)
+
+			var timeoutErr *errors.TaskTimeoutError
+			require.ErrorAs(t, err, &timeoutErr)
+			assert.Equal(t, test.task, timeoutErr.TaskName)
+
+			// The watch loop stays silent on context errors, so a timeout must
+			// not look like one.
+			assert.False(t, errors.Is(err, context.DeadlineExceeded))
 		})
 	}
 }

--- a/task_test.go
+++ b/task_test.go
@@ -2631,6 +2631,63 @@ func TestErrorCode(t *testing.T) {
 	}
 }
 
+func TestCommandTimeout(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/timeout"
+	tests := []struct {
+		name          string
+		task          string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "timeout exceeded",
+			task:          "timeout-exceeded",
+			expectError:   true,
+			errorContains: "timeout exceeded",
+		},
+		{
+			name:        "timeout not exceeded",
+			task:        "timeout-not-exceeded",
+			expectError: false,
+		},
+		{
+			name:        "no timeout",
+			task:        "no-timeout",
+			expectError: false,
+		},
+		{
+			name:          "multiple commands with timeout",
+			task:          "multiple-cmds-timeout",
+			expectError:   true,
+			errorContains: "timeout exceeded",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buff bytes.Buffer
+			e := task.NewExecutor(
+				task.WithDir(dir),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+			)
+			require.NoError(t, e.Setup())
+
+			err := e.Run(t.Context(), &task.Call{Task: test.task})
+			if test.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.errorContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestEvaluateSymlinksInPaths(t *testing.T) { // nolint:paralleltest // cannot run in parallel
 	const dir = "testdata/evaluate_symlinks_in_paths"
 	var buff bytes.Buffer

--- a/task_test.go
+++ b/task_test.go
@@ -2710,6 +2710,28 @@ func TestCommandTimeout(t *testing.T) {
 	}
 }
 
+func TestCommandTimeoutBoundsIfCondition(t *testing.T) {
+	t.Parallel()
+
+	var buff bytes.Buffer
+	e := task.NewExecutor(
+		task.WithDir("testdata/timeout"),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
+	require.NoError(t, e.Setup())
+
+	start := time.Now()
+	err := e.Run(t.Context(), &task.Call{Task: "slow-if-condition"})
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 5*time.Second)
+
+	var timeoutErr *errors.TaskTimeoutError
+	require.ErrorAs(t, err, &timeoutErr)
+	// A condition that times out fails the command, it does not skip it.
+	assert.NotContains(t, buff.String(), "condition was met")
+}
+
 func TestCommandTimeoutAttribution(t *testing.T) {
 	t.Parallel()
 

--- a/task_test.go
+++ b/task_test.go
@@ -2287,6 +2287,27 @@ task-1 ran successfully
 	assert.Contains(t, buff.String(), "child task deferred value-from-parent")
 }
 
+func TestDeferredTaskTimeout(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/deferred"
+	var buff bytes.Buffer
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithVerbose(true),
+	)
+	require.NoError(t, e.Setup())
+
+	start := time.Now()
+	require.NoError(t, e.Run(t.Context(), &task.Call{Task: "parent-with-timeout"}))
+	assert.Less(t, time.Since(start), 500*time.Millisecond)
+	assert.Contains(t, buff.String(), "parent completed")
+	assert.NotContains(t, buff.String(), "\ncleanup completed\n")
+	assert.Contains(t, buff.String(), "ignored error in deferred cmd")
+}
+
 func TestExitCodeZero(t *testing.T) {
 	t.Parallel()
 

--- a/taskfile/ast/cmd.go
+++ b/taskfile/ast/cmd.go
@@ -1,6 +1,8 @@
 package ast
 
 import (
+	"time"
+
 	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
@@ -21,6 +23,7 @@ type Cmd struct {
 	IgnoreError bool
 	Defer       bool
 	Platforms   []*Platform
+	Timeout     time.Duration
 }
 
 func (c *Cmd) DeepCopy() *Cmd {
@@ -40,6 +43,7 @@ func (c *Cmd) DeepCopy() *Cmd {
 		IgnoreError: c.IgnoreError,
 		Defer:       c.Defer,
 		Platforms:   deepcopy.Slice(c.Platforms),
+		Timeout:     c.Timeout,
 	}
 }
 
@@ -67,10 +71,20 @@ func (c *Cmd) UnmarshalYAML(node *yaml.Node) error {
 			IgnoreError bool `yaml:"ignore_error"`
 			Defer       *Defer
 			Platforms   []*Platform
+			Timeout     string
 		}
 		if err := node.Decode(&cmdStruct); err != nil {
 			return errors.NewTaskfileDecodeError(err, node)
 		}
+
+		if cmdStruct.Timeout != "" {
+			timeout, err := time.ParseDuration(cmdStruct.Timeout)
+			if err != nil {
+				return errors.NewTaskfileDecodeError(err, node).WithMessage("invalid timeout format")
+			}
+			c.Timeout = timeout
+		}
+
 		if cmdStruct.Defer != nil {
 
 			// A deferred command

--- a/taskfile/ast/cmd.go
+++ b/taskfile/ast/cmd.go
@@ -86,11 +86,13 @@ func (c *Cmd) UnmarshalYAML(node *yaml.Node) error {
 		}
 
 		if cmdStruct.Defer != nil {
-			timeout, err := parseTimeout(cmdStruct.Defer.Timeout, node)
-			if err != nil {
-				return err
+			if cmdStruct.Defer.Timeout != "" {
+				timeout, err := time.ParseDuration(cmdStruct.Defer.Timeout)
+				if err != nil {
+					return errors.NewTaskfileDecodeError(err, node).WithMessage("invalid timeout format")
+				}
+				c.Timeout = timeout
 			}
-			c.Timeout = timeout
 
 			// A deferred command
 			if cmdStruct.Defer.Cmd != "" {
@@ -139,16 +141,4 @@ func (c *Cmd) UnmarshalYAML(node *yaml.Node) error {
 	}
 
 	return errors.NewTaskfileDecodeError(nil, node).WithTypeMessage("command")
-}
-
-func parseTimeout(value string, node *yaml.Node) (time.Duration, error) {
-	if value == "" {
-		return 0, nil
-	}
-
-	timeout, err := time.ParseDuration(value)
-	if err != nil {
-		return 0, errors.NewTaskfileDecodeError(err, node).WithMessage("invalid timeout format")
-	}
-	return timeout, nil
 }

--- a/taskfile/ast/cmd.go
+++ b/taskfile/ast/cmd.go
@@ -86,9 +86,8 @@ func (c *Cmd) UnmarshalYAML(node *yaml.Node) error {
 		}
 
 		if cmdStruct.Defer != nil {
-			// A deferred command declares its timeout where every other command
-			// does, beside the key rather than inside it. Rejecting the nested
-			// form is what keeps yaml from dropping it without a word.
+			// Rejected rather than dropped: without the field, yaml would
+			// swallow the key without a word.
 			if cmdStruct.Defer.Timeout != "" {
 				return errors.NewTaskfileDecodeError(nil, node).WithMessage("timeout must be set next to defer, not inside it")
 			}
@@ -142,9 +141,8 @@ func (c *Cmd) UnmarshalYAML(node *yaml.Node) error {
 	return errors.NewTaskfileDecodeError(nil, node).WithTypeMessage("command")
 }
 
-// parseTimeout rejects non-positive durations rather than letting them through
-// as "no timeout at all", which is exactly the unbounded run the key exists to
-// prevent.
+// parseTimeout rejects non-positive durations, which would otherwise read as no
+// timeout at all - the unbounded run the key exists to prevent.
 func parseTimeout(s string, node *yaml.Node) (time.Duration, error) {
 	timeout, err := time.ParseDuration(s)
 	if err != nil {

--- a/taskfile/ast/cmd.go
+++ b/taskfile/ast/cmd.go
@@ -78,18 +78,18 @@ func (c *Cmd) UnmarshalYAML(node *yaml.Node) error {
 		}
 
 		if cmdStruct.Timeout != "" {
-			timeout, err := time.ParseDuration(cmdStruct.Timeout)
+			timeout, err := parseTimeout(cmdStruct.Timeout, node)
 			if err != nil {
-				return errors.NewTaskfileDecodeError(err, node).WithMessage("invalid timeout format")
+				return err
 			}
 			c.Timeout = timeout
 		}
 
 		if cmdStruct.Defer != nil {
 			if cmdStruct.Defer.Timeout != "" {
-				timeout, err := time.ParseDuration(cmdStruct.Defer.Timeout)
+				timeout, err := parseTimeout(cmdStruct.Defer.Timeout, node)
 				if err != nil {
-					return errors.NewTaskfileDecodeError(err, node).WithMessage("invalid timeout format")
+					return err
 				}
 				c.Timeout = timeout
 			}
@@ -141,4 +141,18 @@ func (c *Cmd) UnmarshalYAML(node *yaml.Node) error {
 	}
 
 	return errors.NewTaskfileDecodeError(nil, node).WithTypeMessage("command")
+}
+
+// parseTimeout rejects non-positive durations rather than letting them through
+// as "no timeout at all", which is exactly the unbounded run the key exists to
+// prevent.
+func parseTimeout(s string, node *yaml.Node) (time.Duration, error) {
+	timeout, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, errors.NewTaskfileDecodeError(err, node).WithMessage("invalid timeout format")
+	}
+	if timeout <= 0 {
+		return 0, errors.NewTaskfileDecodeError(nil, node).WithMessage("timeout must be greater than zero")
+	}
+	return timeout, nil
 }

--- a/taskfile/ast/cmd.go
+++ b/taskfile/ast/cmd.go
@@ -86,12 +86,11 @@ func (c *Cmd) UnmarshalYAML(node *yaml.Node) error {
 		}
 
 		if cmdStruct.Defer != nil {
+			// A deferred command declares its timeout where every other command
+			// does, beside the key rather than inside it. Rejecting the nested
+			// form is what keeps yaml from dropping it without a word.
 			if cmdStruct.Defer.Timeout != "" {
-				timeout, err := parseTimeout(cmdStruct.Defer.Timeout, node)
-				if err != nil {
-					return err
-				}
-				c.Timeout = timeout
+				return errors.NewTaskfileDecodeError(nil, node).WithMessage("timeout must be set next to defer, not inside it")
 			}
 
 			// A deferred command

--- a/taskfile/ast/cmd.go
+++ b/taskfile/ast/cmd.go
@@ -86,6 +86,11 @@ func (c *Cmd) UnmarshalYAML(node *yaml.Node) error {
 		}
 
 		if cmdStruct.Defer != nil {
+			timeout, err := parseTimeout(cmdStruct.Defer.Timeout, node)
+			if err != nil {
+				return err
+			}
+			c.Timeout = timeout
 
 			// A deferred command
 			if cmdStruct.Defer.Cmd != "" {
@@ -134,4 +139,16 @@ func (c *Cmd) UnmarshalYAML(node *yaml.Node) error {
 	}
 
 	return errors.NewTaskfileDecodeError(nil, node).WithTypeMessage("command")
+}
+
+func parseTimeout(value string, node *yaml.Node) (time.Duration, error) {
+	if value == "" {
+		return 0, nil
+	}
+
+	timeout, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, errors.NewTaskfileDecodeError(err, node).WithMessage("invalid timeout format")
+	}
+	return timeout, nil
 }

--- a/taskfile/ast/defer.go
+++ b/taskfile/ast/defer.go
@@ -7,10 +7,11 @@ import (
 )
 
 type Defer struct {
-	Cmd    string
-	Task   string
-	Vars   *Vars
-	Silent bool
+	Cmd     string
+	Task    string
+	Vars    *Vars
+	Silent  bool
+	Timeout string
 }
 
 func (d *Defer) UnmarshalYAML(node *yaml.Node) error {
@@ -26,10 +27,11 @@ func (d *Defer) UnmarshalYAML(node *yaml.Node) error {
 
 	case yaml.MappingNode:
 		var deferStruct struct {
-			Defer  string
-			Task   string
-			Vars   *Vars
-			Silent bool
+			Defer   string
+			Task    string
+			Vars    *Vars
+			Silent  bool
+			Timeout string
 		}
 		if err := node.Decode(&deferStruct); err != nil {
 			return errors.NewTaskfileDecodeError(err, node)
@@ -38,6 +40,7 @@ func (d *Defer) UnmarshalYAML(node *yaml.Node) error {
 		d.Task = deferStruct.Task
 		d.Vars = deferStruct.Vars
 		d.Silent = deferStruct.Silent
+		d.Timeout = deferStruct.Timeout
 		return nil
 	}
 

--- a/taskfile/ast/dep.go
+++ b/taskfile/ast/dep.go
@@ -1,6 +1,8 @@
 package ast
 
 import (
+	"time"
+
 	"go.yaml.in/yaml/v3"
 
 	"github.com/go-task/task/v3/errors"
@@ -8,10 +10,11 @@ import (
 
 // Dep is a task dependency
 type Dep struct {
-	Task   string
-	For    *For
-	Vars   *Vars
-	Silent bool
+	Task    string
+	For     *For
+	Vars    *Vars
+	Silent  bool
+	Timeout time.Duration
 }
 
 func (d *Dep) DeepCopy() *Dep {
@@ -19,10 +22,11 @@ func (d *Dep) DeepCopy() *Dep {
 		return nil
 	}
 	return &Dep{
-		Task:   d.Task,
-		For:    d.For.DeepCopy(),
-		Vars:   d.Vars.DeepCopy(),
-		Silent: d.Silent,
+		Task:    d.Task,
+		For:     d.For.DeepCopy(),
+		Vars:    d.Vars.DeepCopy(),
+		Silent:  d.Silent,
+		Timeout: d.Timeout,
 	}
 }
 
@@ -39,13 +43,21 @@ func (d *Dep) UnmarshalYAML(node *yaml.Node) error {
 
 	case yaml.MappingNode:
 		var taskCall struct {
-			Task   string
-			For    *For
-			Vars   *Vars
-			Silent bool
+			Task    string
+			For     *For
+			Vars    *Vars
+			Silent  bool
+			Timeout string
 		}
 		if err := node.Decode(&taskCall); err != nil {
 			return errors.NewTaskfileDecodeError(err, node)
+		}
+		if taskCall.Timeout != "" {
+			timeout, err := parseTimeout(taskCall.Timeout, node)
+			if err != nil {
+				return err
+			}
+			d.Timeout = timeout
 		}
 		d.Task = taskCall.Task
 		d.For = taskCall.For

--- a/taskfile/ast/taskfile_test.go
+++ b/taskfile/ast/taskfile_test.go
@@ -126,3 +126,45 @@ func TestDeferredTaskTimeoutParseError(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "invalid timeout format")
 }
+
+func TestTimeoutParseError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		message string
+	}{
+		{
+			name:    "unparsable duration",
+			content: `{cmd: echo, timeout: invalid}`,
+			message: "invalid timeout format",
+		},
+		{
+			name:    "zero duration",
+			content: `{cmd: echo, timeout: 0s}`,
+			message: "timeout must be greater than zero",
+		},
+		{
+			name:    "negative duration",
+			content: `{cmd: echo, timeout: -1s}`,
+			message: "timeout must be greater than zero",
+		},
+		{
+			name:    "negative duration on a deferred task",
+			content: `{defer: {task: some_task, timeout: -5m}}`,
+			message: "timeout must be greater than zero",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var cmd ast.Cmd
+			err := yaml.Unmarshal([]byte(test.content), &cmd)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, test.message)
+		})
+	}
+}

--- a/taskfile/ast/taskfile_test.go
+++ b/taskfile/ast/taskfile_test.go
@@ -24,8 +24,9 @@ vars:
   PARAM2: VALUE2
 `
 		yamlDeferredCall            = `defer: { task: some_task, vars: { PARAM1: "var" } }`
-		yamlDeferredCallWithTimeout = `defer: { task: some_task, timeout: 1s }`
+		yamlDeferredCallWithTimeout = `{ defer: { task: some_task }, timeout: 1s }`
 		yamlDeferredCmd             = `defer: echo 'test'`
+		yamlDeferredCmdWithTimeout  = `{ defer: echo 'test', timeout: 1s }`
 	)
 	tests := []struct {
 		content  string
@@ -85,6 +86,11 @@ vars:
 			&ast.Cmd{Task: "some_task", Defer: true, Timeout: time.Second},
 		},
 		{
+			yamlDeferredCmdWithTimeout,
+			&ast.Cmd{},
+			&ast.Cmd{Cmd: `echo 'test'`, Defer: true, Timeout: time.Second},
+		},
+		{
 			yamlDep,
 			&ast.Dep{},
 			&ast.Dep{Task: "task-name"},
@@ -118,15 +124,6 @@ vars:
 	}
 }
 
-func TestDeferredTaskTimeoutParseError(t *testing.T) {
-	t.Parallel()
-
-	var cmd ast.Cmd
-	err := yaml.Unmarshal([]byte(`defer: { task: some_task, timeout: invalid }`), &cmd)
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "invalid timeout format")
-}
-
 func TestTimeoutParseError(t *testing.T) {
 	t.Parallel()
 
@@ -152,8 +149,18 @@ func TestTimeoutParseError(t *testing.T) {
 		},
 		{
 			name:    "negative duration on a deferred task",
-			content: `{defer: {task: some_task, timeout: -5m}}`,
+			content: `{defer: {task: some_task}, timeout: -5m}`,
 			message: "timeout must be greater than zero",
+		},
+		{
+			name:    "unparsable duration on a deferred task",
+			content: `{defer: {task: some_task}, timeout: invalid}`,
+			message: "invalid timeout format",
+		},
+		{
+			name:    "timeout nested inside defer",
+			content: `{defer: {task: some_task, timeout: 1s}}`,
+			message: "timeout must be set next to defer, not inside it",
 		},
 	}
 

--- a/taskfile/ast/taskfile_test.go
+++ b/taskfile/ast/taskfile_test.go
@@ -2,6 +2,7 @@ package ast_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,8 +23,9 @@ vars:
   PARAM1: VALUE1
   PARAM2: VALUE2
 `
-		yamlDeferredCall = `defer: { task: some_task, vars: { PARAM1: "var" } }`
-		yamlDeferredCmd  = `defer: echo 'test'`
+		yamlDeferredCall            = `defer: { task: some_task, vars: { PARAM1: "var" } }`
+		yamlDeferredCallWithTimeout = `defer: { task: some_task, timeout: 1s }`
+		yamlDeferredCmd             = `defer: echo 'test'`
 	)
 	tests := []struct {
 		content  string
@@ -78,6 +80,11 @@ vars:
 			},
 		},
 		{
+			yamlDeferredCallWithTimeout,
+			&ast.Cmd{},
+			&ast.Cmd{Task: "some_task", Defer: true, Timeout: time.Second},
+		},
+		{
 			yamlDep,
 			&ast.Dep{},
 			&ast.Dep{Task: "task-name"},
@@ -109,4 +116,13 @@ vars:
 		require.NoError(t, err)
 		assert.Equal(t, test.expected, test.v)
 	}
+}
+
+func TestDeferredTaskTimeoutParseError(t *testing.T) {
+	t.Parallel()
+
+	var cmd ast.Cmd
+	err := yaml.Unmarshal([]byte(`defer: { task: some_task, timeout: invalid }`), &cmd)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid timeout format")
 }

--- a/testdata/deferred/Taskfile.yml
+++ b/testdata/deferred/Taskfile.yml
@@ -27,3 +27,15 @@ tasks:
   child:
     cmds:
     - cmd: echo "child {{.VAR1}}"
+
+  parent-with-timeout:
+    cmds:
+      - defer:
+          task: slow-cleanup
+          timeout: 100ms
+          silent: true
+      - echo 'parent completed'
+
+  slow-cleanup:
+    cmds:
+      - sleep 1 && echo 'cleanup completed'

--- a/testdata/deferred/Taskfile.yml
+++ b/testdata/deferred/Taskfile.yml
@@ -32,8 +32,8 @@ tasks:
     cmds:
       - defer:
           task: slow-cleanup
-          timeout: 100ms
           silent: true
+        timeout: 100ms
       - echo 'parent completed'
 
   slow-cleanup:

--- a/testdata/dep_timeout/Taskfile.yml
+++ b/testdata/dep_timeout/Taskfile.yml
@@ -1,0 +1,26 @@
+version: '3'
+
+silent: true
+
+tasks:
+  timeout-exceeded:
+    deps:
+      - task: slow
+        timeout: 300ms
+    cmds:
+      - echo "should not be reached"
+
+  timeout-not-exceeded:
+    deps:
+      - task: quick
+        timeout: 5s
+    cmds:
+      - echo "reached the end"
+
+  slow:
+    cmds:
+      - sleep 10
+
+  quick:
+    cmds:
+      - echo "quick"

--- a/testdata/exit_code/Taskfile.yml
+++ b/testdata/exit_code/Taskfile.yml
@@ -23,3 +23,9 @@ tasks:
     cmds:
       - defer: echo FOO={{.FOO}} - DYNAMIC_FOO={{.DYNAMIC_FOO}} - {{.PREFIX}}{{.EXIT_CODE}}
       - exit 1
+
+  exit-timeout:
+    cmds:
+      - defer: echo {{.PREFIX}}{{.EXIT_CODE}}
+      - cmd: sleep 10
+        timeout: 200ms

--- a/testdata/ignore_errors/Taskfile.yml
+++ b/testdata/ignore_errors/Taskfile.yml
@@ -18,3 +18,23 @@ tasks:
   cmd-should-fail:
     cmds:
       - cmd: exit 1
+
+  task-timeout-should-pass:
+    cmds:
+      - cmd: sleep 10
+        timeout: 200ms
+      - echo "reached the end"
+    ignore_error: true
+
+  cmd-timeout-should-pass:
+    cmds:
+      - cmd: sleep 10
+        timeout: 200ms
+        ignore_error: true
+      - echo "reached the end"
+
+  cmd-timeout-should-fail:
+    cmds:
+      - cmd: sleep 10
+        timeout: 200ms
+      - echo "reached the end"

--- a/testdata/run_once_failure/Taskfile.yml
+++ b/testdata/run_once_failure/Taskfile.yml
@@ -5,11 +5,9 @@ silent: true
 tasks:
   default:
     cmds:
-      # The first caller runs the shared task and swallows its failure...
       - task: shared
         ignore_error: true
-      # ...the second one joins the finished execution and must inherit its
-      # error rather than be told it succeeded.
+      # Joins the finished execution, and must inherit its error.
       - task: shared
       - echo "should not be reached"
 

--- a/testdata/run_once_failure/Taskfile.yml
+++ b/testdata/run_once_failure/Taskfile.yml
@@ -1,0 +1,20 @@
+version: '3'
+
+silent: true
+
+tasks:
+  default:
+    cmds:
+      # The first caller runs the shared task and swallows its failure...
+      - task: shared
+        ignore_error: true
+      # ...the second one joins the finished execution and must inherit its
+      # error rather than be told it succeeded.
+      - task: shared
+      - echo "should not be reached"
+
+  shared:
+    run: once
+    cmds:
+      - echo "shared ran"
+      - exit 1

--- a/testdata/run_once_timeout/Taskfile.yml
+++ b/testdata/run_once_timeout/Taskfile.yml
@@ -4,14 +4,12 @@ silent: true
 
 tasks:
   default:
-    # Without failfast the run would wait for `owner` to finish anyway, hiding
-    # the very thing under test: that `joiner` gives up on its own deadline.
+    # Without failfast the run waits for `owner` anyway, hiding what is tested.
     failfast: true
     deps: [owner, joiner]
 
-  # `owner` starts the shared task and holds it for far longer than `joiner` is
-  # willing to wait, so `joiner` reaches the deduplication path while the shared
-  # execution is still running.
+  # Holds the shared task far longer than `joiner` waits, so `joiner` reaches
+  # the deduplication path while it is still running.
   owner:
     cmds:
       - task: shared

--- a/testdata/run_once_timeout/Taskfile.yml
+++ b/testdata/run_once_timeout/Taskfile.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+silent: true
+
+tasks:
+  default:
+    # Without failfast the run would wait for `owner` to finish anyway, hiding
+    # the very thing under test: that `joiner` gives up on its own deadline.
+    failfast: true
+    deps: [owner, joiner]
+
+  # `owner` starts the shared task and holds it for far longer than `joiner` is
+  # willing to wait, so `joiner` reaches the deduplication path while the shared
+  # execution is still running.
+  owner:
+    cmds:
+      - task: shared
+
+  joiner:
+    cmds:
+      - sleep 0.2
+      - task: shared
+        timeout: 500ms
+      - echo "should not be reached"
+
+  shared:
+    run: once
+    cmds:
+      - sleep 10

--- a/testdata/timeout/Taskfile.yml
+++ b/testdata/timeout/Taskfile.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+tasks:
+  timeout-exceeded:
+    desc: Command that should timeout
+    cmds:
+      - cmd: sleep 10
+        timeout: 1s
+
+  timeout-not-exceeded:
+    desc: Command that completes within timeout
+    cmds:
+      - cmd: echo "quick command"
+        timeout: 5s
+
+  no-timeout:
+    desc: Command with no timeout specified
+    cmds:
+      - echo "no timeout"
+
+  multiple-cmds-timeout:
+    desc: Multiple commands where one exceeds its timeout
+    cmds:
+      - cmd: echo "first"
+        timeout: 1s
+      - cmd: sleep 10
+        timeout: 1s
+      - cmd: echo "third"
+        timeout: 1s

--- a/testdata/timeout/Taskfile.yml
+++ b/testdata/timeout/Taskfile.yml
@@ -28,6 +28,13 @@ tasks:
       - cmd: echo "third"
         timeout: 1s
 
+  slow-if-condition:
+    desc: Condition that hangs must be bounded by the command timeout
+    cmds:
+      - cmd: echo "condition was met"
+        if: sleep 10
+        timeout: 500ms
+
   inherited-timeout:
     desc: Calls a task whose command declares no timeout of its own
     cmds:

--- a/testdata/timeout/Taskfile.yml
+++ b/testdata/timeout/Taskfile.yml
@@ -27,3 +27,24 @@ tasks:
         timeout: 1s
       - cmd: echo "third"
         timeout: 1s
+
+  inherited-timeout:
+    desc: Calls a task whose command declares no timeout of its own
+    cmds:
+      - task: slow-without-timeout
+        timeout: 500ms
+
+  slow-without-timeout:
+    cmds:
+      - sleep 10
+
+  larger-child-timeout:
+    desc: Calls a task whose command declares a timeout it never reaches
+    cmds:
+      - task: slow-with-larger-timeout
+        timeout: 500ms
+
+  slow-with-larger-timeout:
+    cmds:
+      - cmd: sleep 10
+        timeout: 10m

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -816,6 +816,7 @@ tasks:
         platforms: [linux, darwin]
         set: [errexit]
         shopt: [globstar]
+        timeout: 5m
 ```
 
 ### Task References
@@ -931,6 +932,24 @@ tasks:
         cmd: echo "processing {{.ITEM}}"
         if: '[ "{{.ITEM}}" != "b" ]'
 ```
+
+### Command Timeouts
+
+Use `timeout` to limit how long a command may run. The value uses Go duration
+syntax (e.g. `30s`, `5m`, `1h30m`).
+
+```yaml
+tasks:
+  deploy:
+    cmds:
+      - cmd: npm run build
+        timeout: 5m
+      - cmd: ./deploy.sh
+        timeout: 30m
+```
+
+When a command exceeds its timeout, it is terminated and the task fails with an
+error, preventing commands from hanging indefinitely in a pipeline.
 
 ## Shell Options
 

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -847,6 +847,7 @@ tasks:
         platforms: [linux, darwin]
         set: [errexit]
         shopt: [globstar]
+        timeout: 5m
 ```
 
 ### Task References
@@ -962,6 +963,24 @@ tasks:
         cmd: echo "processing {{.ITEM}}"
         if: '[ "{{.ITEM}}" != "b" ]'
 ```
+
+### Command Timeouts
+
+Use `timeout` to limit how long a command may run. The value uses Go duration
+syntax (e.g. `30s`, `5m`, `1h30m`).
+
+```yaml
+tasks:
+  deploy:
+    cmds:
+      - cmd: npm run build
+        timeout: 5m
+      - cmd: ./deploy.sh
+        timeout: 30m
+```
+
+When a command exceeds its timeout, it is terminated and the task fails with an
+error, preventing commands from hanging indefinitely in a pipeline.
 
 ## Shell Options
 

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -983,8 +983,8 @@ When a command exceeds its timeout, it is terminated and the task fails with an
 error, preventing commands from hanging indefinitely in a pipeline. The timeout
 bounds the whole step, so an [`if`](#command) condition that hangs is cut short
 too, and [`ignore_error`](#command) covers a timeout like any other failure. A
-timed-out command reports [`EXIT_CODE`](/reference/templating#exit_code) `124`,
-following the convention of `timeout(1)`.
+timed-out command reports [`EXIT_CODE`](/docs/reference/templating#exit_code)
+`124`, following the convention of `timeout(1)`.
 
 A dependency takes the same key:
 

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -982,6 +982,23 @@ tasks:
 When a command exceeds its timeout, it is terminated and the task fails with an
 error, preventing commands from hanging indefinitely in a pipeline.
 
+### Deferred Task Timeouts
+
+Use `timeout` to limit how long a deferred task call may run. The value uses Go
+duration syntax (for example, `30s`, `5m`, or `1h30m`).
+
+```yaml
+tasks:
+  deploy:
+    cmds:
+      - defer:
+          task: cleanup
+          timeout: 30s
+```
+
+A timed-out deferred task is logged and ignored, like other deferred-task
+errors.
+
 ## Shell Options
 
 ### Set Options

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -951,6 +951,23 @@ tasks:
 When a command exceeds its timeout, it is terminated and the task fails with an
 error, preventing commands from hanging indefinitely in a pipeline.
 
+### Deferred Task Timeouts
+
+Use `timeout` to limit how long a deferred task call may run. The value uses Go
+duration syntax (for example, `30s`, `5m`, or `1h30m`).
+
+```yaml
+tasks:
+  deploy:
+    cmds:
+      - defer:
+          task: cleanup
+          timeout: 30s
+```
+
+A timed-out deferred task is logged and ignored, like other deferred-task
+errors.
+
 ## Shell Options
 
 ### Set Options

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -986,6 +986,16 @@ too, and [`ignore_error`](#command) covers a timeout like any other failure. A
 timed-out command reports [`EXIT_CODE`](/reference/templating#exit_code) `124`,
 following the convention of `timeout(1)`.
 
+A dependency takes the same key:
+
+```yaml
+tasks:
+  build:
+    deps:
+      - task: fetch-assets
+        timeout: 2m
+```
+
 The key goes next to the command whatever form it takes, including a `defer`:
 
 ```yaml

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -967,7 +967,7 @@ tasks:
 ### Command Timeouts
 
 Use `timeout` to limit how long a command may run. The value uses Go duration
-syntax (e.g. `30s`, `5m`, `1h30m`).
+syntax (e.g. `30s`, `5m`, `1h30m`) and must be greater than zero.
 
 ```yaml
 tasks:
@@ -980,12 +980,13 @@ tasks:
 ```
 
 When a command exceeds its timeout, it is terminated and the task fails with an
-error, preventing commands from hanging indefinitely in a pipeline.
+error, preventing commands from hanging indefinitely in a pipeline. The timeout
+bounds the whole step, so an [`if`](#command) condition that hangs is cut short
+too, and [`ignore_error`](#command) covers a timeout like any other failure. A
+timed-out command reports [`EXIT_CODE`](/reference/templating#exit_code) `124`,
+following the convention of `timeout(1)`.
 
-### Deferred Task Timeouts
-
-Use `timeout` to limit how long a deferred task call may run. The value uses Go
-duration syntax (for example, `30s`, `5m`, or `1h30m`).
+The key goes next to the command whatever form it takes, including a `defer`:
 
 ```yaml
 tasks:
@@ -993,11 +994,17 @@ tasks:
     cmds:
       - defer:
           task: cleanup
-          timeout: 30s
+        timeout: 30s
+      - defer: ./cleanup.sh
+        timeout: 30s
 ```
 
-A timed-out deferred task is logged and ignored, like other deferred-task
-errors.
+A timed-out deferred command is logged and ignored, like other deferred errors.
+
+Calling a task that is already running under [`run: once`](#task) or
+[`run: when_changed`](#task) joins that execution instead of starting a second
+one. A `timeout` on such a call bounds how long you wait for it, not the shared
+execution itself, which only the caller that started it can bound.
 
 ## Shell Options
 

--- a/website/src/docs/reference/templating.md
+++ b/website/src/docs/reference/templating.md
@@ -334,8 +334,8 @@ tasks:
 
 - **Type**: `int`
 - **Description**: Failed command exit code (only in `defer`, only when
-  non-zero). A command killed by its [`timeout`](/reference/schema#command) is
-  reported as `124`, following the convention of `timeout(1)`.
+  non-zero). A command killed by its [`timeout`](/docs/reference/schema#command)
+  is reported as `124`, following the convention of `timeout(1)`.
 
 ```yaml
 tasks:

--- a/website/src/docs/reference/templating.md
+++ b/website/src/docs/reference/templating.md
@@ -334,7 +334,8 @@ tasks:
 
 - **Type**: `int`
 - **Description**: Failed command exit code (only in `defer`, only when
-  non-zero)
+  non-zero). A command killed by its [`timeout`](/reference/schema#command) is
+  reported as `124`, following the convention of `timeout(1)`.
 
 ```yaml
 tasks:

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -352,6 +352,10 @@
         "if": {
           "description": "A shell command to evaluate. If the exit code is non-zero, the command is skipped.",
           "type": "string"
+        },
+        "timeout": {
+          "description": "Maximum duration the command is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -392,6 +396,10 @@
         },
         "if": {
           "description": "A shell command to evaluate. If the exit code is non-zero, the command is skipped.",
+          "type": "string"
+        },
+        "timeout": {
+          "description": "Maximum duration the command is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
           "type": "string"
         }
       },
@@ -445,6 +453,10 @@
         "platforms": {
           "description": "Specifies which platforms the command should be run on.",
           "$ref": "#/definitions/platforms"
+        },
+        "timeout": {
+          "description": "Maximum duration the command is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -474,6 +486,10 @@
         },
         "if": {
           "description": "A shell command to evaluate. If the exit code is non-zero, the command is skipped.",
+          "type": "string"
+        },
+        "timeout": {
+          "description": "Maximum duration the command is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
           "type": "string"
         }
       },

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -410,29 +410,6 @@
       "additionalProperties": false,
       "required": ["cmd"]
     },
-    "deferred_task_call": {
-      "type": "object",
-      "properties": {
-        "task": {
-          "description": "Name of the task to run",
-          "type": "string"
-        },
-        "vars": {
-          "description": "Values passed to the task called",
-          "$ref": "#/definitions/vars"
-        },
-        "silent": {
-          "description": "Hides task name and command from output. The command's output will still be redirected to `STDOUT` and `STDERR`.",
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Maximum duration the deferred task is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "required": ["task"]
-    },
     "defer_task_call": {
       "type": "object",
       "properties": {
@@ -440,7 +417,7 @@
           "description": "Run a command when the task completes. This command will run even when the task fails",
           "anyOf": [
             {
-              "$ref": "#/definitions/deferred_task_call"
+              "$ref": "#/definitions/task_call"
             }
           ]
         }

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -410,6 +410,29 @@
       "additionalProperties": false,
       "required": ["cmd"]
     },
+    "deferred_task_call": {
+      "type": "object",
+      "properties": {
+        "task": {
+          "description": "Name of the task to run",
+          "type": "string"
+        },
+        "vars": {
+          "description": "Values passed to the task called",
+          "$ref": "#/definitions/vars"
+        },
+        "silent": {
+          "description": "Hides task name and command from output. The command's output will still be redirected to `STDOUT` and `STDERR`.",
+          "type": "boolean"
+        },
+        "if": {
+          "description": "A shell command to evaluate. If the exit code is non-zero, the command is skipped.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["task"]
+    },
     "defer_task_call": {
       "type": "object",
       "properties": {
@@ -417,9 +440,13 @@
           "description": "Run a command when the task completes. This command will run even when the task fails",
           "anyOf": [
             {
-              "$ref": "#/definitions/task_call"
+              "$ref": "#/definitions/deferred_task_call"
             }
           ]
+        },
+        "timeout": {
+          "description": "Maximum duration the command is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -435,6 +462,10 @@
         "silent": {
           "description": "Hides task name and command from output. The command's output will still be redirected to `STDOUT` and `STDERR`.",
           "type": "boolean"
+        },
+        "timeout": {
+          "description": "Maximum duration the command is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -406,6 +406,29 @@
       "additionalProperties": false,
       "required": ["cmd"]
     },
+    "deferred_task_call": {
+      "type": "object",
+      "properties": {
+        "task": {
+          "description": "Name of the task to run",
+          "type": "string"
+        },
+        "vars": {
+          "description": "Values passed to the task called",
+          "$ref": "#/definitions/vars"
+        },
+        "silent": {
+          "description": "Hides task name and command from output. The command's output will still be redirected to `STDOUT` and `STDERR`.",
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Maximum duration the deferred task is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["task"]
+    },
     "defer_task_call": {
       "type": "object",
       "properties": {
@@ -413,7 +436,7 @@
           "description": "Run a command when the task completes. This command will run even when the task fails",
           "anyOf": [
             {
-              "$ref": "#/definitions/task_call"
+              "$ref": "#/definitions/deferred_task_call"
             }
           ]
         }

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -356,6 +356,10 @@
         "if": {
           "description": "A shell command to evaluate. If the exit code is non-zero, the command is skipped.",
           "type": "string"
+        },
+        "timeout": {
+          "description": "Maximum duration the command is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -396,6 +400,10 @@
         },
         "if": {
           "description": "A shell command to evaluate. If the exit code is non-zero, the command is skipped.",
+          "type": "string"
+        },
+        "timeout": {
+          "description": "Maximum duration the command is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
           "type": "string"
         }
       },
@@ -471,6 +479,10 @@
         "if": {
           "description": "A shell command to evaluate. If the exit code is non-zero, the command is skipped.",
           "type": "string"
+        },
+        "timeout": {
+          "description": "Maximum duration the command is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
+          "type": "string"
         }
       },
       "additionalProperties": false,
@@ -504,6 +516,10 @@
         },
         "if": {
           "description": "A shell command to evaluate. If the exit code is non-zero, the command is skipped.",
+          "type": "string"
+        },
+        "timeout": {
+          "description": "Maximum duration the command is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
           "type": "string"
         }
       },

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -410,6 +410,29 @@
       "additionalProperties": false,
       "required": ["cmd"]
     },
+    "deferred_task_call": {
+      "type": "object",
+      "properties": {
+        "task": {
+          "description": "Name of the task to run",
+          "type": "string"
+        },
+        "vars": {
+          "description": "Values passed to the task called",
+          "$ref": "#/definitions/vars"
+        },
+        "silent": {
+          "description": "Hides task name and command from output. The command's output will still be redirected to `STDOUT` and `STDERR`.",
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Maximum duration the deferred task is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["task"]
+    },
     "defer_task_call": {
       "type": "object",
       "properties": {
@@ -417,7 +440,7 @@
           "description": "Run a command when the task completes. This command will run even when the task fails",
           "anyOf": [
             {
-              "$ref": "#/definitions/task_call"
+              "$ref": "#/definitions/deferred_task_call"
             }
           ]
         }

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -574,6 +574,10 @@
         "vars": {
           "description": "Values passed to the task called",
           "$ref": "#/definitions/vars"
+        },
+        "timeout": {
+          "description": "Maximum duration the command is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -406,29 +406,6 @@
       "additionalProperties": false,
       "required": ["cmd"]
     },
-    "deferred_task_call": {
-      "type": "object",
-      "properties": {
-        "task": {
-          "description": "Name of the task to run",
-          "type": "string"
-        },
-        "vars": {
-          "description": "Values passed to the task called",
-          "$ref": "#/definitions/vars"
-        },
-        "silent": {
-          "description": "Hides task name and command from output. The command's output will still be redirected to `STDOUT` and `STDERR`.",
-          "type": "boolean"
-        },
-        "timeout": {
-          "description": "Maximum duration the deferred task is allowed to run before being terminated. Supports Go duration syntax (e.g., '5m', '30s', '1h').",
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "required": ["task"]
-    },
     "defer_task_call": {
       "type": "object",
       "properties": {
@@ -436,7 +413,7 @@
           "description": "Run a command when the task completes. This command will run even when the task fails",
           "anyOf": [
             {
-              "$ref": "#/definitions/deferred_task_call"
+              "$ref": "#/definitions/task_call"
             }
           ]
         }


### PR DESCRIPTION
## Summary

Add command-level `timeout` support to prevent commands from hanging indefinitely in task pipelines.

Closes #1569

This reimplements (and rebases onto current `main`) the work started in #2474, which was abandoned by its original author.

## Usage

```yaml
version: '3'

tasks:
  deploy:
    cmds:
      - cmd: npm run build
        timeout: 5m
      - cmd: ./deploy.sh
        timeout: 30m
```

Commands exceeding their timeout are terminated:

```
task: Failed to run task "deploy": task: [deploy] command timeout exceeded (5m): context deadline exceeded
```




