### PR TITLE
ci: fix golangci-lint custom manager and enable OSV alerts in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,14 +6,15 @@
     "schedule:weekly",
     ":semanticCommitTypeAll(chore)"
   ],
-  "mode": "full",
   "addLabels":["area: dependencies"],
+  "osvVulnerabilityAlerts": true,
+  "postUpdateOptions": ["gomodTidy"],
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^\\.github/workflows/.*\\.ya?ml$"],
+      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
       "matchStrings": [
-        "uses:\\s*golangci/golangci-lint-action@\\S+\\s+with:\\s+version:\\s*(?<currentValue>v[\\d.]+)"
+        "uses:\\s*golangci/golangci-lint-action@\\S+(?:\\s*#[^\\n]*)?\\s+with:\\s+version:\\s*(?<currentValue>v[\\d.]+)"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "golangci/golangci-lint"


### PR DESCRIPTION
## Summary

A few fixes to `.github/renovate.json`:

- **Fix the golangci-lint custom manager.** The regex stopped matching once `golangci/golangci-lint-action` was pinned to a SHA with a trailing `# vX.Y.Z` comment (`\S+` can't cross the space before the comment), so the `golangci-lint` binary version in `lint.yml` (`version: v2.12.2`) was silently no longer being updated. The ref pattern now tolerates an optional trailing comment.
- **Enable `osvVulnerabilityAlerts`.** Indirect Go dependencies are disabled by default in Renovate, which is why a vulnerable transitive dep like `golang.org/x/crypto` (see #2899 / CVE-2026-39832) never got an automated update. With OSV alerts on, Renovate raises security PRs for vulnerable indirect deps without the noise of bumping every transitive dependency.
- **Add `postUpdateOptions: ["gomodTidy"]`** so `go.mod`/`go.sum` stay tidy after updates.
- **Migrate deprecated `fileMatch` → `managerFilePatterns`** (deprecated since Renovate 40) and drop the redundant default `"mode": "full"`.

## Test plan

- `npx renovate --platform=local --dry-run=lookup` confirms the custom manager now extracts `golangci/golangci-lint` at `v2.12.2` again, with no deprecation warnings.