### PR TITLE
ci: enable indirect Go deps and group action digest updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,11 @@
   ],
   "packageRules": [
     {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": true
+    },
+    {
       "matchUpdateTypes": ["digest", "pinDigest"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,11 @@
   ],
   "packageRules": [
     {
+      "matchUpdateTypes": ["digest", "pinDigest"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch"
+    },
+    {
       "matchManagers": ["github-actions"],
       "addLabels": ["area: github actions"]
     },


### PR DESCRIPTION
## Summary

Two related tweaks to `.github/renovate.json`:

### 1. Enable indirect Go dependency updates
Indirect `gomod` dependencies are disabled by default, so vulnerable transitive deps such as `golang.org/x/crypto` (see #2899 — multiple GO-2026-xxxx CVEs) never get an automated PR, **even with `osvVulnerabilityAlerts` enabled**. The debug log confirms it: OSV detects the vulnerability (`Setting allowed version >= 0.52.0 to fix ... golang.org/x/crypto`) but the dep is still emitted with `skipReason: "disabled"` and `updates: []` — the disabled state is applied at extraction, before the vulnerability fix can attach an update. Renovate has no "indirect only if vulnerable" scope, so this enables indirect `gomod` updates. They fold into the weekly grouped non-major PR via `group:allNonMajor`, keeping noise low, and `postUpdateOptions: ["gomodTidy"]` keeps `go.mod`/`go.sum` clean.

### 2. Group action digest updates with non-major deps
`digest`/`pinDigest` updates aren't covered by `group:allNonMajor` (minor/patch only), so SHA-pinned actions like `goreleaser/goreleaser-action` produced standalone PRs (e.g. #2900). Since those actions are pinned to floating major tags (`# v7`), a digest update is always within-major and safe to group. This reuses the preset's `groupName`/`groupSlug` so they merge into the same grouped PR.

## Test plan

- `npx renovate --platform=local --dry-run=lookup` — `golang.org/x/crypto` now resolves an update to a fixed version instead of `skipReason: disabled`; digest updates resolve into the `all-minor-patch` group.