### PR TITLE
fix: remote taskfiles from ADO git path

### DIFF
--- a/taskfile/node.go
+++ b/taskfile/node.go
@@ -2,6 +2,7 @@ package taskfile
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"time"
 
@@ -89,7 +90,10 @@ func getScheme(uri string) (string, error) {
 		return "", err
 	}
 
-	if strings.HasSuffix(strings.Split(u.Path, "//")[0], ".git") && (u.Scheme == "git" || u.Scheme == "ssh" || u.Scheme == "https" || u.Scheme == "http") {
+	isDotGit := strings.HasSuffix(strings.Split(u.Path, "//")[0], ".git")
+	isUnderscoreGit := strings.Contains(strings.Split(u.Path, "//")[0], "/_git/")
+	schemeIsGitCompatible := slices.Contains([]string{"git", "ssh", "https", "http"}, u.Scheme)
+	if (isDotGit || isUnderscoreGit) && schemeIsGitCompatible {
 		return "git", nil
 	}
 

--- a/taskfile/node_test.go
+++ b/taskfile/node_test.go
@@ -21,4 +21,7 @@ func TestScheme(t *testing.T) {
 	scheme, err = getScheme("https://github.com/foo/common.yml")
 	assert.NoError(t, err)
 	assert.Equal(t, "https", scheme)
+	scheme, err = getScheme("https://some-azure-host.com/org/project/_git/repo")
+	assert.NoError(t, err)
+	assert.Equal(t, "git", scheme)
 }


### PR DESCRIPTION
Fixes https://github.com/go-task/task/issues/1317#issuecomment-4847494248.

Adds a condition to the `getScheme` function so that Azure Devops git paths are detected correctly.

Thanks for always being different Microsoft 🙄 

FYI @YoungOak