### PR TITLE
feat: readd example hosted remote taskfile

### DIFF
--- a/website/src/public/Taskfile.yml
+++ b/website/src/public/Taskfile.yml
@@ -1,0 +1,30 @@
+version: "3"
+
+tasks:
+  default:
+    cmds:
+      - task: hello
+
+  hello:
+    cmds:
+      - echo "Hello Task!"
+
+  special-variables:
+    silent: true
+    cmds:
+      - 'echo "CLI_ARGS:         {{.CLI_ARGS}}"'
+      - 'echo "CLI_ARGS_LIST:    {{.CLI_ARGS_LIST}}"'
+      - 'echo "CLI_ARGS_FORCE:   {{.CLI_ARGS_FORCE}}"'
+      - 'echo "CLI_ARGS_SILENT:  {{.CLI_ARGS_SILENT}}"'
+      - 'echo "CLI_ARGS_VERBOSE: {{.CLI_ARGS_VERBOSE}}"'
+      - 'echo "CLI_ARGS_OFFLINE: {{.CLI_ARGS_OFFLINE}}"'
+      - 'echo "TASK:             {{.TASK}}"'
+      - 'echo "ALIAS:            {{.ALIAS}}"'
+      - 'echo "TASK_EXE:         {{.TASK_EXE}}"'
+      - 'echo "ROOT_TASKFILE:    {{.ROOT_TASKFILE}}"'
+      - 'echo "ROOT_DIR:         {{.ROOT_DIR}}"'
+      - 'echo "TASKFILE:         {{.TASKFILE}}"'
+      - 'echo "TASKFILE_DIR:     {{.TASKFILE_DIR}}"'
+      - 'echo "TASK_DIR:         {{.TASK_DIR}}"'
+      - 'echo "USER_WORKING_DIR: {{.USER_WORKING_DIR}}"'
+      - 'echo "TASK_VERSION:     {{.TASK_VERSION}}"'


### PR DESCRIPTION
Some of the remote taskfile docs reference an example file that we host on our website. When we moved the website to vitepress, this was accidentally removed. This PR re-adds it so the examples in the docs work again.