### PR TITLE
test: self-manage .git in gitignore fixture tests

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -681,6 +681,12 @@ type gitignoreSeq struct {
 func (s gitignoreSeq) run(t *testing.T) {
 	t.Helper()
 	cleanup := func() {
+		// The fixture manages its own .git marker so that gitignore filtering
+		// resolves a repo root regardless of the build source: an in-tree
+		// checkout would otherwise inherit the go-task .git, but a GitHub
+		// source tarball has none, which would silently disable filtering and
+		// break the golden fixtures.
+		_ = os.RemoveAll(filepathext.SmartJoin(s.dir, ".git"))
 		_ = os.RemoveAll(filepathext.SmartJoin(s.dir, ".task"))
 		for name := range s.create {
 			_ = os.Remove(filepathext.SmartJoin(s.dir, name))
@@ -694,6 +700,7 @@ func (s gitignoreSeq) run(t *testing.T) {
 	}
 	cleanup()
 	t.Cleanup(cleanup)
+	require.NoError(t, os.MkdirAll(filepathext.SmartJoin(s.dir, ".git"), 0o755))
 	for name, content := range s.create {
 		writeFile(t, s.dir, name, content)
 	}


### PR DESCRIPTION
## Summary

fixes #2907 

The `use_gitignore` filtering added in 616433d resolves a repository root by walking up the directory tree to a `.git` entry (`internal/fingerprint/gitignore.go`). When the tests run inside an in-tree checkout, the fixtures under `testdata/gitignore*` inherit go-task's own `.git`, so filtering activates and the golden fixtures match.

## Test plan

- Simulated a tarball build by copying the tree without `.git`:
  - Before: `go test . -run TestGitignore` **fails** on the *ignored file modified* steps.
  - After: **passes**.
- In a normal git checkout: `go test . -run TestGitignore` still passes, no golden files changed, `git status` clean after the run (fixture `.git` is cleaned up).
- Full suite `go test ./...` passes with no regressions.