### PR TITLE
feat: support excluding task namespaces

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -1648,6 +1648,15 @@ func TestIncludesWithExclude(t *testing.T) {
 	assert.Equal(t, "toolshed\n", buff.String())
 	buff.Reset()
 
+	err = e.Run(t.Context(), &task.Call{Task: "included:deploy:*"})
+	require.Error(t, err)
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "included:deploy:one"})
+	require.NoError(t, err)
+	assert.Equal(t, "deploy-one\n", buff.String())
+	buff.Reset()
+
 	err = e.Run(t.Context(), &task.Call{Task: "bar"})
 	require.Error(t, err)
 	buff.Reset()

--- a/task_test.go
+++ b/task_test.go
@@ -1635,6 +1635,19 @@ func TestIncludesWithExclude(t *testing.T) {
 	require.Error(t, err)
 	buff.Reset()
 
+	err = e.Run(t.Context(), &task.Call{Task: "included:tools:lint"})
+	require.Error(t, err)
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "included:tools:test"})
+	require.Error(t, err)
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "included:toolshed"})
+	require.NoError(t, err)
+	assert.Equal(t, "toolshed\n", buff.String())
+	buff.Reset()
+
 	err = e.Run(t.Context(), &task.Call{Task: "bar"})
 	require.Error(t, err)
 	buff.Reset()

--- a/taskfile/ast/tasks.go
+++ b/taskfile/ast/tasks.go
@@ -130,8 +130,11 @@ func (t1 *Tasks) Merge(t2 *Tasks, include *Include, includedTaskfileVars *Vars) 
 		task.Internal = task.Internal || (include != nil && include.Internal)
 		taskName := name
 
-		// if the task is in the exclude list, don't add it to the merged taskfile
-		if slices.Contains(include.Excludes, name) {
+		// If the task or one of its namespaces is in the exclude list, don't add
+		// it to the merged taskfile.
+		if slices.ContainsFunc(include.Excludes, func(exclude string) bool {
+			return name == exclude || strings.HasPrefix(name, exclude+":")
+		}) {
 			continue
 		}
 

--- a/testdata/includes_with_excludes/Taskfile.yml
+++ b/testdata/includes_with_excludes/Taskfile.yml
@@ -4,7 +4,8 @@ includes:
   included:
     taskfile: ./included/Taskfile.yml
     excludes:
-        - foo
+      - foo
+      - tools
   included_flatten:
     taskfile: ./included/Taskfile.yml
     flatten: true

--- a/testdata/includes_with_excludes/Taskfile.yml
+++ b/testdata/includes_with_excludes/Taskfile.yml
@@ -6,6 +6,7 @@ includes:
     excludes:
       - foo
       - tools
+      - deploy:*
   included_flatten:
     taskfile: ./included/Taskfile.yml
     flatten: true

--- a/testdata/includes_with_excludes/included/Taskfile.yml
+++ b/testdata/includes_with_excludes/included/Taskfile.yml
@@ -6,3 +6,5 @@ tasks:
   tools:lint: echo lint
   tools:test: echo test
   toolshed: echo toolshed
+  deploy:*: echo wildcard
+  deploy:one: echo deploy-one

--- a/testdata/includes_with_excludes/included/Taskfile.yml
+++ b/testdata/includes_with_excludes/included/Taskfile.yml
@@ -3,3 +3,6 @@ version: '3'
 tasks:
   foo: echo foo
   bar: echo bar
+  tools:lint: echo lint
+  tools:test: echo test
+  toolshed: echo toolshed

--- a/website/src/docs/guide.md
+++ b/website/src/docs/guide.md
@@ -414,7 +414,8 @@ You can do this by using the
 
 You can exclude tasks from being included by using the `excludes` option. This
 option takes a list of task names or namespaces to be excluded from this
-include. Excluding a namespace also excludes all tasks below it.
+include. Excluding a namespace also excludes all tasks below it. Entries are
+matched literally and are not treated as glob patterns.
 
 ::: code-group
 

--- a/website/src/docs/guide.md
+++ b/website/src/docs/guide.md
@@ -413,7 +413,8 @@ You can do this by using the
 ### Exclude tasks from being included
 
 You can exclude tasks from being included by using the `excludes` option. This
-option takes the list of tasks to be excluded from this include.
+option takes a list of task names or namespaces to be excluded from this
+include. Excluding a namespace also excludes all tasks below it.
 
 ::: code-group
 
@@ -423,7 +424,7 @@ version: '3'
 includes:
   included:
     taskfile: ./Included.yml
-    excludes: [foo]
+    excludes: [foo, tools]
 ```
 
 ```yaml [Included.yml]
@@ -432,6 +433,8 @@ version: '3'
 tasks:
   foo: echo "Foo"
   bar: echo "Bar"
+  tools:lint: echo "Lint"
+  tools:test: echo "Test"
 ```
 
 :::

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -297,13 +297,13 @@ includes:
 ### `excludes`
 
 - **Type**: `[]string`
-- **Description**: Tasks to exclude from inclusion
+- **Description**: Tasks or namespaces to exclude from inclusion
 
 ```yaml
 includes:
   shared:
     taskfile: ./shared.yml
-    excludes: [internal-setup, debug-only]
+    excludes: [internal-setup, debug]
 ```
 
 ### `vars`

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -297,7 +297,7 @@ includes:
 ### `excludes`
 
 - **Type**: `[]string`
-- **Description**: Tasks or namespaces to exclude from inclusion
+- **Description**: Literal task names or namespaces to exclude from inclusion
 
 ```yaml
 includes:


### PR DESCRIPTION
## Summary

- treat an excluded task name as a namespace for tasks below it
- preserve exact task exclusions and avoid matching similarly prefixed names
- document namespace exclusions in the guide and schema reference

Addresses #2300 by supporting literal namespace names; wildcard-style entries remain literal pending maintainer guidance.

## Validation

- `go test ./... -run TestIncludesWithExclude -count=1`
- `git diff --check`

I also ran `go test ./...`. The affected tests pass, while unrelated tests that
require Unix commands or symlink behavior fail on my Windows environment.

## AI usage

I used an AI coding assistant to help inspect the repository, implement the
change, and run the checks. I reviewed the diff and verified the exact-task,
namespace-task, and similarly-prefixed-task cases locally.

- [x] I have read and followed the Contribution Guide

