### PR TITLE
docs: add zed extension to community integrations

### DIFF
--- a/website/src/docs/integrations.md
+++ b/website/src/docs/integrations.md
@@ -115,6 +115,8 @@ developers who have created their own integrations for Task:
   [[source](https://github.com/biozz/sublime-taskfile)] by @biozz
 - [IntelliJ Plugin](https://plugins.jetbrains.com/plugin/17058-taskfile)
   [[source](https://github.com/lechuckroh/task-intellij-plugin)] by @lechuckroh
+- [Zed Extension](https://zed.dev/extensions?query=taskfile)
+  [[source](https://github.com/nickalie/zed-taskfile)] by @nickalie
 - [mk](https://github.com/pycontribs/mk) command line tool recognizes Taskfiles
   natively.
 - [fzf-make](https://github.com/kyu08/fzf-make) fuzzy finder with preview window

--- a/website/src/docs/integrations.md
+++ b/website/src/docs/integrations.md
@@ -115,7 +115,7 @@ developers who have created their own integrations for Task:
   [[source](https://github.com/biozz/sublime-taskfile)] by @biozz
 - [IntelliJ Plugin](https://plugins.jetbrains.com/plugin/17058-taskfile)
   [[source](https://github.com/lechuckroh/task-intellij-plugin)] by @lechuckroh
-- [Zed Extension](https://zed.dev/extensions?query=taskfile)
+- [Zed Extension](https://zed.dev/extensions/taskfile)
   [[source](https://github.com/nickalie/zed-taskfile)] by @nickalie
 - [mk](https://github.com/pycontribs/mk) command line tool recognizes Taskfiles
   natively.


### PR DESCRIPTION
Adds the [Zed](https://zed.dev/) Taskfile extension to the Community Integrations list.

The extension provides Taskfile syntax highlighting, task outline navigation, and running tasks directly from the editor. It is published in the Zed extension registry (~500 downloads).

- Registry: https://zed.dev/extensions?query=taskfile
- Source: https://github.com/nickalie/zed-taskfile