### PR TITLE
fix: joinUrl no longer collapses the URL scheme

### DIFF
--- a/internal/templater/funcs.go
+++ b/internal/templater/funcs.go
@@ -3,8 +3,8 @@ package templater
 import (
 	"maps"
 	"math/rand/v2"
+	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -103,8 +103,13 @@ func joinEnv(elem ...string) string {
 	return strings.Join(elem, string(os.PathListSeparator))
 }
 
-func joinUrl(elem ...string) string {
-	return path.Join(elem...)
+func joinUrl(elem ...string) (string, error) {
+	if len(elem) == 0 {
+		return "", nil
+	}
+	// Use net/url.JoinPath rather than path.Join: the latter runs path.Clean,
+	// which collapses the "//" in a URL scheme (e.g. "http://" -> "http:/").
+	return url.JoinPath(elem[0], elem[1:]...)
 }
 
 func merge(base map[string]any, v ...map[string]any) map[string]any {

--- a/internal/templater/funcs_test.go
+++ b/internal/templater/funcs_test.go
@@ -1,0 +1,27 @@
+package templater
+
+import "testing"
+
+func TestJoinUrl(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		elem []string
+		want string
+	}{
+		// The URL scheme's "//" must be preserved, not collapsed by path.Clean.
+		{"scheme preserved", []string{"http://localhost", "path1", "path2"}, "http://localhost/path1/path2"},
+		{"https with base path", []string{"https://example.com/api", "v1", "users"}, "https://example.com/api/v1/users"},
+		{"trailing slash on base", []string{"http://localhost/", "path"}, "http://localhost/path"},
+		{"single element", []string{"http://localhost"}, "http://localhost/"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := joinUrl(tt.elem...)
+			if err != nil {
+				t.Fatalf("joinUrl(%q) unexpected error: %v", tt.elem, err)
+			}
+			if got != tt.want {
+				t.Errorf("joinUrl(%q) = %q; want %q", tt.elem, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/templater/funcs_test.go
+++ b/internal/templater/funcs_test.go
@@ -3,6 +3,8 @@ package templater
 import "testing"
 
 func TestJoinUrl(t *testing.T) {
+	t.Parallel()
+
 	for _, tt := range []struct {
 		name string
 		elem []string
@@ -15,6 +17,8 @@ func TestJoinUrl(t *testing.T) {
 		{"single element", []string{"http://localhost"}, "http://localhost/"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := joinUrl(tt.elem...)
 			if err != nil {
 				t.Fatalf("joinUrl(%q) unexpected error: %v", tt.elem, err)


### PR DESCRIPTION
## What
`joinUrl` collapses the `//` in a URL scheme, so it produces an invalid URL:

```yaml
vars:
  SERVER: "http://localhost"
tasks:
  default:
    cmds:
      - echo "{{joinUrl .SERVER "path1" "path2"}}"
      # got:  http:/localhost/path1/path2
      # want: http://localhost/path1/path2
```

The documented behavior (docs/reference/templating.md, "URLs" section) shows `http://localhost/path1/path2`, so this is a clear bug — and it's the whole reason `joinUrl` exists separately from `joinPath`.

## Why
`joinUrl` was implemented as `path.Join(elem...)`. `path.Join` runs `path.Clean`, which collapses consecutive slashes and destroys the `//` after the scheme.

## Fix
Use `net/url.JoinPath`, which is purpose-built for joining URL path segments and preserves the scheme. The signature becomes `(string, error)`, consistent with the sibling `relPath`/`absPath` funcs (`filepath.Rel`/`filepath.Abs`), and the template engine already supports funcs that return an error.

## Tests
Added `TestJoinUrl` in `internal/templater/funcs_test.go` covering scheme preservation, a base with an existing path, and trailing-slash handling. `joinUrl` shipped without a test in #2408, which is how this slipped through.
