### PR TITLE
fix: escape regex metacharacters in WildcardMatch

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -3417,6 +3417,26 @@ func TestWildcard(t *testing.T) {
 			call:           "wildcard-foo-bar",
 			expectedOutput: "Hello foo-bar\n",
 		},
+		{
+			name:           "regex metacharacters are matched literally",
+			call:           "c++",
+			expectedOutput: "Building c++\n",
+		},
+		{
+			name:    "regex metacharacters do not match as a pattern",
+			call:    "cxx",
+			wantErr: true,
+		},
+		{
+			name:           "a dot matches itself",
+			call:           "deploy.prod",
+			expectedOutput: "Deploying prod\n",
+		},
+		{
+			name:    "a dot is not a wildcard",
+			call:    "deploy-prod",
+			wantErr: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/taskfile/ast/task.go
+++ b/taskfile/ast/task.go
@@ -87,7 +87,10 @@ func (t *Task) WildcardMatch(name string) (bool, []string) {
 	names := append([]string{t.Task}, t.Aliases...)
 
 	for _, taskName := range names {
-		regexStr := fmt.Sprintf("^%s$", strings.ReplaceAll(taskName, "*", "(.*)"))
+		// Escape regex metacharacters in the task name so a name like "c++" or
+		// "a.b" is matched literally (and doesn't panic in MustCompile); only
+		// "*" is a wildcard.
+		regexStr := fmt.Sprintf("^%s$", strings.ReplaceAll(regexp.QuoteMeta(taskName), `\*`, "(.*)"))
 		regex := regexp.MustCompile(regexStr)
 		wildcards := regex.FindStringSubmatch(name)
 

--- a/taskfile/ast/task.go
+++ b/taskfile/ast/task.go
@@ -87,7 +87,10 @@ func (t *Task) WildcardMatch(name string) (bool, []string) {
 	names := append([]string{t.Task}, t.Aliases...)
 
 	for _, taskName := range names {
-		regexStr := fmt.Sprintf("^%s$", strings.ReplaceAll(taskName, "*", "(.*)"))
+		// Escape the task name so a name like "c++" or "a.b" is matched literally
+		// and does not panic in MustCompile, then turn the escaped "*" back into
+		// the wildcard group
+		regexStr := fmt.Sprintf("^%s$", strings.ReplaceAll(regexp.QuoteMeta(taskName), `\*`, "(.*)"))
 		regex := regexp.MustCompile(regexStr)
 		wildcards := regex.FindStringSubmatch(name)
 

--- a/taskfile/ast/task_test.go
+++ b/taskfile/ast/task_test.go
@@ -1,0 +1,41 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/go-task/task/v3/taskfile/ast"
+)
+
+func TestTaskWildcardMatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		taskName      string
+		call          string
+		wantMatch     bool
+		wantWildcards []string
+	}{
+		{"build-*", "build-foo", true, []string{"foo"}},
+		{"build-*-*", "build-foo-bar", true, []string{"foo", "bar"}},
+		{"build-*", "test-foo", false, nil},
+		// Regex metacharacters in the task name must be matched literally, not
+		// interpreted as regex (and must not panic in MustCompile).
+		{"c++", "c++", true, []string{}},
+		{"c++", "cxx", false, nil},
+		{"a.b", "axb", false, nil}, // '.' must not act as a wildcard
+		{"a.b", "a.b", true, []string{}},
+		{"deploy.prod", "deploy-prod", false, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.taskName+"/"+tt.call, func(t *testing.T) {
+			t.Parallel()
+			task := &ast.Task{Task: tt.taskName}
+			match, wildcards := task.WildcardMatch(tt.call)
+			assert.Equal(t, tt.wantMatch, match)
+			assert.Equal(t, tt.wantWildcards, wildcards)
+		})
+	}
+}

--- a/testdata/wildcards/Taskfile.yml
+++ b/testdata/wildcards/Taskfile.yml
@@ -25,3 +25,12 @@ tasks:
       SERVICE: "{{index .MATCH 0}}"
     cmds:
       - echo "Starting {{.SERVICE}}"
+
+  # Regex metacharacters in a task name must be matched literally
+  c++:
+    cmds:
+      - echo "Building c++"
+
+  deploy.prod:
+    cmds:
+      - echo "Deploying prod"


### PR DESCRIPTION
## What

A task whose name contains a regex metacharacter breaks task matching for the whole Taskfile — either with a hard panic or a silent mis-match.

`(*Task).WildcardMatch` builds a regex from the task name, translating only `*`, and calls `regexp.MustCompile` on it:

```go
regexStr := fmt.Sprintf("^%s$", strings.ReplaceAll(taskName, "*", "(.*)"))
regex := regexp.MustCompile(regexStr)
```

The raw task name is injected into the pattern, so any other metacharacter is interpreted as regex syntax:

- **Panic / crash** — a task named `c++` yields `^c++$`, and `regexp.MustCompile` panics with `invalid nested repetition operator: ++`.
- **False positive** — a task named `a.b` matches the call `axb` (the `.` acts as a wildcard). A realistic footgun: `deploy.prod` gets run by a mistyped `task deploy-prod`.

`FindMatchingTasks` calls `WildcardMatch(call.Task)` on **every** task whenever the requested name isn't a direct/alias match, so a single task with such a name breaks matching for the entire Taskfile.

## Fix

Escape the task name with `regexp.QuoteMeta` before building the pattern, then turn the (now escaped) `\*` back into the wildcard group:

```go
regexStr := fmt.Sprintf("^%s$", strings.ReplaceAll(regexp.QuoteMeta(taskName), `\*`, "(.*)"))
```

`*` remains the only wildcard; everything else is matched literally.

## Testing

Added `TestTaskWildcardMatch` covering the existing `build-*` wildcard behavior plus the metacharacter cases (`c++`, `a.b`, `deploy.prod`). On the current code the test panics (`invalid nested repetition operator`); with the fix it passes. The full `taskfile/ast` package suite passes and the module builds clean.
