### PR TITLE
fix: escape single quotes in source glob paths

### DIFF
--- a/internal/execext/exec.go
+++ b/internal/execext/exec.go
@@ -96,6 +96,7 @@ func escape(s string) string {
 	s = strings.ReplaceAll(s, "&", `\&`)
 	s = strings.ReplaceAll(s, "(", `\(`)
 	s = strings.ReplaceAll(s, ")", `\)`)
+	s = strings.ReplaceAll(s, "'", `\'`)
 	return s
 }
 

--- a/internal/fingerprint/gitignore_test.go
+++ b/internal/fingerprint/gitignore_test.go
@@ -65,6 +65,16 @@ func TestGlobsWithGitignore(t *testing.T) {
 	assert.Equal(t, 2, txtCount, "both .txt files should remain")
 }
 
+func TestGlobsWithSingleQuoteInDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "task's directory")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "input.txt"), []byte("input"), 0o644))
+
+	files, err := Globs(dir, []*ast.Glob{{Glob: "input.txt"}}, false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{filepath.ToSlash(filepath.Join(dir, "input.txt"))}, files)
+}
+
 func TestGlobsWithGitignoreParentDirIgnored(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- escape single quotes before the source-glob fallback passes a resolved path to the shell field expander
- add a regression for source files inside a directory whose name includes a single quote

## Root cause

The fallback glob path parses the joined filesystem path as shell input. A literal single quote in an ancestor directory was not escaped, so parsing failed with an unterminated-quote error before source fingerprinting could run.

## Validation

- `go test ./internal/fingerprint -run TestGlobsWithSingleQuoteInDirectory -count=1`
- `go test ./...` (environment-limited: only existing POSIX-shell and symlink fixture tests fail on Windows because `bash`, `sleep`, and `basename` are unavailable)
- `git diff --check`

Fixes #2874
