### PR TITLE
test: support checkout paths containing spaces in fixtures

### DIFF
--- a/testdata/dir/dynamic_var/Taskfile.yml
+++ b/testdata/dir/dynamic_var/Taskfile.yml
@@ -21,7 +21,7 @@ tasks:
     dir: subdirectory
     vars:
       TASK_DIR:
-        sh: basename $(pwd)
+        sh: basename "$(pwd)"
     silent: true
 
   from-interpolated-dir:
@@ -30,4 +30,4 @@ tasks:
     dir: '{{.DIRECTORY}}'
     vars:
       INTERPOLATED_DIR:
-        sh: basename $(pwd)
+        sh: basename "$(pwd)"

--- a/testdata/dir/dynamic_var/subdirectory/Taskfile.yml
+++ b/testdata/dir/dynamic_var/subdirectory/Taskfile.yml
@@ -2,7 +2,7 @@ version: '3'
 
 vars:
   TASKFILE_DIR:
-    sh: basename $(pwd)
+    sh: basename "$(pwd)"
 
 tasks:
   from-included-taskfile:
@@ -16,4 +16,4 @@ tasks:
     silent: true
     vars:
       TASKFILE_TASK_DIR:
-        sh: basename $(pwd)
+        sh: basename "$(pwd)"

--- a/testdata/includes_interpolation/included/Taskfile.yml
+++ b/testdata/includes_interpolation/included/Taskfile.yml
@@ -3,4 +3,4 @@ version: "3"
 tasks:
   default:
     cmds:
-      - basename $(pwd)
+      - basename "$(pwd)"


### PR DESCRIPTION
## Summary

Some test fixtures use `basename $(pwd)`. When the repository is checked out under a path containing spaces, the shell splits the expanded working directory into multiple arguments.

This PR quotes the command substitution in the affected fixtures:

```sh
basename "$(pwd)"
```

## Problem

When the repository is checked out under a path containing spaces, such as:

```text
/Users/ikshantshukla/task os/task
```

the following tests fail:

- `TestIncludesInterpolation`
- `TestDynamicVariablesShouldRunOnTheTaskDir`

The unquoted `$(pwd)` causes `basename` to receive multiple arguments and return an unexpected directory name.

## Changes

Updated five occurrences across these test fixtures:

- `testdata/includes_interpolation/included/Taskfile.yml`
- `testdata/dir/dynamic_var/subdirectory/Taskfile.yml`
- `testdata/dir/dynamic_var/Taskfile.yml`

Changed:

```sh
basename $(pwd)
```

to:

```sh
basename "$(pwd)"
```

## Testing

Verified the fix from the same checkout path containing spaces.

Before the change, the targeted tests failed:

```bash
go test . \
  -run 'TestIncludesInterpolation|TestDynamicVariablesShouldRunOnTheTaskDir' \
  -v
```

After the change:

- The targeted tests pass.
- The complete test suite passes with `go test ./...`.

## AI usage

I used ChatGPT to help investigate the shell-quoting behavior and organize the PR description. I reproduced the issue, reviewed the changes, and ran the tests locally.

- [x] I have read and followed the Contribution Guide.

## Screenshots

### Before the fix

<img width="782" height="837" alt="Targeted tests failing before the fix" src="https://github.com/user-attachments/assets/09eb48ba-a03a-4f22-8541-f4d60c5934c3" />

### After the fix

<img width="1033" height="623" alt="Targeted tests passing after the fix" src="https://github.com/user-attachments/assets/fc0ca32c-e2db-4775-83bf-b9a8a8ca5321" />