### PR TITLE
test: fix flaky TestDeps by using group output

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -517,6 +517,12 @@ func TestDeps(t *testing.T) {
 		WithExecutorOptions(
 			task.WithDir("testdata/deps"),
 			task.WithSilent(true),
+			// Deps run in parallel and, with the default interleaved output,
+			// their sub-line writes (echo writes the content and the newline
+			// separately) can interleave into a garbled buffer. Group output
+			// flushes each command atomically, keeping every line intact. The
+			// set of lines asserted (via PPSortedLines) is unchanged.
+			task.WithOutputStyle(ast.Output{Name: "group"}),
 		),
 		WithPostProcessFn(PPSortedLines),
 	)


### PR DESCRIPTION
## Summary

`TestDeps` was intermittently failing in CI.

**Root cause:** `TestDeps` runs its dependencies in parallel (via `errgroup` in `runDeps`), and they all write to the same buffer. With the default `interleaved` output style nothing is serialized, and the mvdan/sh `echo` builtin writes the content and the trailing newline as **two separate `Write` calls**. The test's `SyncBuffer` locks each individual `Write` but not the content+newline pair, so two concurrent commands can interleave at the sub-line level, corrupting the captured output.

**Fix:** capture `TestDeps` output with the `group` style, which buffers each command separately and flushes it atomically. Every line stays intact, ordering remains irrelevant (the test already sorts via `PPSortedLines`), and the golden fixture is unchanged. This matches the existing pattern already used elsewhere in `executor_test.go`.

No production code changes; the sub-line interleaving is expected behavior of the interleaved output style, for which `output: group` is the documented clean-output answer.

## Test plan

- `go test -run '^TestDeps$' -count=500 -race .` → 0 failures (was ~17/300 before)
- `git diff` on `testdata/deps/` is empty (golden unchanged)
- `go test ./...` → no failures