### PR TITLE
fix: dynamic var uses wrong dir

### DIFF
--- a/compiler.go
+++ b/compiler.go
@@ -29,8 +29,13 @@ type Compiler struct {
 
 	Logger *logger.Logger
 
-	dynamicCache   map[string]string
+	dynamicCache   map[dynamicCacheKey]string
 	muDynamicCache sync.Mutex
+}
+
+type dynamicCacheKey struct {
+	dir string
+	sh  string
 }
 
 func (c *Compiler) GetTaskfileVariables() (*ast.Vars, error) {
@@ -156,9 +161,12 @@ func (c *Compiler) HandleDynamicVar(v ast.Var, dir string, e []string) (string, 
 	}
 
 	if c.dynamicCache == nil {
-		c.dynamicCache = make(map[string]string, 30)
+		c.dynamicCache = make(map[dynamicCacheKey]string, 30)
 	}
-	if result, ok := c.dynamicCache[*v.Sh]; ok {
+
+	key := dynamicCacheKey{dir, *v.Sh}
+
+	if result, ok := c.dynamicCache[key]; ok {
 		return result, nil
 	}
 
@@ -184,7 +192,7 @@ func (c *Compiler) HandleDynamicVar(v ast.Var, dir string, e []string) (string, 
 	result := strings.TrimSuffix(stdout.String(), "\r\n")
 	result = strings.TrimSuffix(result, "\n")
 
-	c.dynamicCache[*v.Sh] = result
+	c.dynamicCache[key] = result
 	// Never print the resolved value of a secret variable, even in verbose mode
 	logResult := result
 	if v.Secret {

--- a/task_test.go
+++ b/task_test.go
@@ -1052,8 +1052,8 @@ func TestIncludes(t *testing.T) {
 			"./module2/included_directory_with_dir.txt": "included_directory_with_dir",
 			"./module2/included_taskfile_with_dir.txt":  "included_taskfile_with_dir",
 			"os_include.txt":                            "os",
-			"output1/result.txt":                        "output1",
-			"output2/result.txt":                        "output2",
+			"result.txt":                                "includes",
+			"common/result.txt":                         "common",
 		},
 	}
 	t.Run("", func(t *testing.T) {

--- a/task_test.go
+++ b/task_test.go
@@ -1052,6 +1052,8 @@ func TestIncludes(t *testing.T) {
 			"./module2/included_directory_with_dir.txt": "included_directory_with_dir",
 			"./module2/included_taskfile_with_dir.txt":  "included_taskfile_with_dir",
 			"os_include.txt":                            "os",
+			"output1/result.txt":                        "output1",
+			"output2/result.txt":                        "output2",
 		},
 	}
 	t.Run("", func(t *testing.T) {

--- a/testdata/includes/Taskfile.yml
+++ b/testdata/includes/Taskfile.yml
@@ -16,10 +16,10 @@ includes:
   included_os: ./Taskfile_{{OS}}.yml
   include_common_task1:
     taskfile: ./common/Taskfile.yml
-    dir: ./output1
+    dir: .
   include_common_task2:
     taskfile: ./common/Taskfile.yml
-    dir: ./output2
+    dir: ./common
 
 tasks:
   default:

--- a/testdata/includes/Taskfile.yml
+++ b/testdata/includes/Taskfile.yml
@@ -4,16 +4,22 @@ includes:
   included: ./included
   included_taskfile: ./Taskfile2.yml
   included_without_dir:
-    taskfile:  ./module1
+    taskfile: ./module1
   included_taskfile_without_dir:
-    taskfile:  ./module1/Taskfile.yml
+    taskfile: ./module1/Taskfile.yml
   included_with_dir:
-    taskfile:  ./module2
-    dir:  ./module2
+    taskfile: ./module2
+    dir: ./module2
   included_taskfile_with_dir:
-    taskfile:  ./module2/Taskfile.yml
-    dir:  ./module2
+    taskfile: ./module2/Taskfile.yml
+    dir: ./module2
   included_os: ./Taskfile_{{OS}}.yml
+  include_common_task1:
+    taskfile: ./common/Taskfile.yml
+    dir: ./output1
+  include_common_task2:
+    taskfile: ./common/Taskfile.yml
+    dir: ./output2
 
 tasks:
   default:
@@ -26,6 +32,8 @@ tasks:
       - task: included_with_dir:gen_file
       - task: included_taskfile_with_dir:gen_dir
       - task: included_os:gen
+      - task: include_common_task1:show
+      - task: include_common_task2:show
 
   gen:
     cmds:

--- a/testdata/includes/common/Taskfile.yml
+++ b/testdata/includes/common/Taskfile.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+tasks:
+  show:
+    vars:
+      CURRENT_DIR:
+        sh: basename "$(pwd)"
+
+    cmds:
+      - 'echo "{{.CURRENT_DIR}}" > result.txt'


### PR DESCRIPTION
<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->

The shell command value which stored using the command as a cache key may have collisions with the same command 
but different dir. When the command value is related with dir, it will get a wrong command value.

Close #2928

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/)

I used AI assistant to inspect the repo structure and help with tests.