### PR TITLE
fix: resolved escape key presses not canceling prompt for required vars

### DIFF
--- a/internal/input/input.go
+++ b/internal/input/input.go
@@ -114,7 +114,7 @@ func (m textModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
 		switch msg.Keystroke() {
-		case "ctrl+c", "escape":
+		case "ctrl+c", "esc":
 			m.cancelled = true
 			m.done = true
 			return m, tea.Quit
@@ -164,7 +164,7 @@ func (m selectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
 		switch msg.Keystroke() {
-		case "ctrl+c", "escape":
+		case "ctrl+c", "esc":
 			m.cancelled = true
 			m.done = true
 			return m, tea.Quit


### PR DESCRIPTION
<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->

This PR addresses a fix needed to identify if the escape key is pressed when a user is prompted for a required variable.

The issue existed in `internal/input/input.go` where there were two switch statements that checked if the escape key was pressed using the string `escape`. However, `uv` identifies the escape key using the string `esc`, not `escape`. Because of this discrepancy, task never quit when the escape key was pressed after prompting the user for a required var. After changing `escape` to `esc` and running the following two tests I was able to verify that I could quit (cancel) Task when it prompted me for a required var:

```
go run ./cmd/task --dir ./testdata/interactive_vars deploy
go run ./cmd/task --dir ./testdata/interactive_vars release
```

AI Disclosure: I used Cursor to help me identify where in the code the keypress events were being done when prompting for required vars. I then investigated the `uv` and `bubbletea` documentation and codebases to identify that the escape key string may have been incorrect. Then experimented on my macOS system (v26.5.2), swapping between the strings `escape` and `esc` at the locations identified in the changed files and running the two tests above a number of times.

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/)
