### PR TITLE
fix: synchronize prefixed output writer to fix concurrent-write panic

### DIFF
--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/fatih/color"
@@ -151,6 +152,43 @@ func TestPrefixed(t *testing.T) { //nolint:paralleltest // cannot run in paralle
 		require.NoError(t, cleanup(nil))
 		assert.Equal(t, "[prefix] Test!\n", b.String())
 	})
+}
+
+// TestPrefixedConcurrentStdoutStderr is a regression test for
+// https://github.com/go-task/task/issues/2945: WrapWriter returns the same
+// *prefixWriter for both stdout and stderr, and os/exec copies command
+// output to each of them from its own goroutine, so Write can legitimately
+// be called concurrently from two goroutines for a single task. Since
+// bytes.Buffer isn't safe for concurrent use, unsynchronized access to the
+// shared buffer could corrupt its internal state and panic (observed as
+// "slice bounds out of range"). Run with -race for a reliable signal; this
+// also reproduces the panic reliably on an unfixed prefixWriter even
+// without -race, given enough concurrent lines.
+func TestPrefixedConcurrentStdoutStderr(t *testing.T) {
+	t.Parallel()
+
+	l := &logger.Logger{Color: false}
+	var o output.Output = output.NewPrefixed(l)
+	stdOut, stdErr, cleanup := o.WrapWriter(io.Discard, io.Discard, "prefix", nil)
+
+	const lines = 5000
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := range lines {
+			fmt.Fprintf(stdOut, "stdout line %d\n", i)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := range lines {
+			fmt.Fprintf(stdErr, "stderr line %d\n", i)
+		}
+	}()
+	wg.Wait()
+
+	require.NoError(t, cleanup(nil))
 }
 
 func TestPrefixedWithColor(t *testing.T) {

--- a/internal/output/prefixed.go
+++ b/internal/output/prefixed.go
@@ -38,9 +38,18 @@ type prefixWriter struct {
 	prefixed *Prefixed
 	prefix   string
 	buff     bytes.Buffer
+	mutex    sync.Mutex
 }
 
+// Write and close both run under pw.mutex because WrapWriter hands out the
+// same *prefixWriter for both stdout and stderr, and os/exec copies each of
+// them to its Write method from its own goroutine. bytes.Buffer isn't safe
+// for concurrent use, so without this lock, concurrent stdout/stderr output
+// races on pw.buff and can panic (e.g. "slice bounds out of range").
 func (pw *prefixWriter) Write(p []byte) (int, error) {
+	pw.mutex.Lock()
+	defer pw.mutex.Unlock()
+
 	n, err := pw.buff.Write(p)
 	if err != nil {
 		return n, err
@@ -50,6 +59,9 @@ func (pw *prefixWriter) Write(p []byte) (int, error) {
 }
 
 func (pw *prefixWriter) close() error {
+	pw.mutex.Lock()
+	defer pw.mutex.Unlock()
+
 	return pw.writeOutputLines(true)
 }
 


### PR DESCRIPTION
## What's the bug

With `output: prefixed` enabled, Task can panic while a command writes to stdout and stderr concurrently:

```
panic: runtime error: slice bounds out of range [2687:2453]

goroutine 178 [running]:
bytes.(*Buffer).readSlice(...)
        bytes/buffer.go:440
bytes.(*Buffer).ReadString(...)
        bytes/buffer.go:459
github.com/go-task/task/v3/internal/output.(*prefixWriter).writeOutputLines(0xc0001bab90, 0x0)
        github.com/go-task/task/v3@v3.43.3/internal/output/prefixed.go:58 +0x3a
github.com/go-task/task/v3/internal/output.(*prefixWriter).Write(...)
        github.com/go-task/task/v3@v3.43.3/internal/output/prefixed.go:49 +0x45
io.copyBuffer(...)
        io/io.go:431
os/exec.(*Cmd).writerDescriptor.func1()
        os/exec/exec.go:580
```

Reproduces with:

```yaml
version: "3"
output: prefixed
tasks:
  default:
    cmds:
      - |
        for i in $(seq 1 10000); do
          echo "stdout line ${i}" &
          echo "stderr line ${i}" >&2 &
        done
        wait
```

## Root cause

`WrapWriter` in `internal/output/prefixed.go` returns the **same** `*prefixWriter` instance for both stdout and stderr:

```go
pw := &prefixWriter{writer: stdOut, prefix: prefix, prefixed: p}
return pw, pw, func(error) error { return pw.close() }
```

`os/exec` copies a running command's stdout and stderr to their respective writers from two separate goroutines (`io.copyBuffer` in `Cmd.writerDescriptor`), so for prefixed output, `Write` can legitimately be called concurrently on the same `prefixWriter` by both the stdout- and stderr-copying goroutines of a single task. `prefixWriter.Write` and `writeOutputLines` read and write `pw.buff` (a `bytes.Buffer`) without any synchronization, and `bytes.Buffer` is explicitly documented as not safe for concurrent use - concurrent access corrupts its internal length/offset bookkeeping, which is exactly what produces a "slice bounds out of range" panic.

Note that `Prefixed.mutex` already exists and is held in `writeLine`, but it only protects the struct shared across *all* prefixes (the `seen` map and `counter`) - it does nothing to protect an individual `prefixWriter`'s own buffer from its two concurrent callers.

## The fix

Add a `sync.Mutex` to `prefixWriter` and hold it for the full duration of both `Write` and `close` (both of which read/mutate `pw.buff`). This is a distinct, narrower lock than `Prefixed.mutex`, so there's no risk of the two interacting or deadlocking - `writeOutputLines` (called while holding `prefixWriter.mutex`) calls `writeLine`, which acquires the *separate* `Prefixed.mutex`.

## Testing

- Added `TestPrefixedConcurrentStdoutStderr` (`internal/output/output_test.go`): spawns two goroutines writing 5000 lines each to stdout and stderr concurrently through the same prefixed writer, then calls `cleanup`.
- Verified with `go test -race`: **without** the fix, this reliably reproduces both the underlying data race and the exact reported panic (`slice bounds out of range`) within a handful of runs. **With** the fix, it passes cleanly (no race, no panic) across repeated runs (`-count=5`, and again in isolation with `-race`).
- Ran the full test suite (`go build ./... && go vet ./... && go test ./...`) - clean aside from `TestEvaluateSymlinksInPaths`, which I confirmed is unrelated: it fails the same way with a filesystem/symlink error on an unmodified checkout too, due to how real NTFS symlinks don't survive a Windows→Linux Docker bind mount (I don't have a native Go toolchain on this machine, so I built/tested via Docker).

Fixes #2945
