### PR TITLE
fix: preserve stdin taskfile bytes

### DIFF
--- a/taskfile/node_stdin.go
+++ b/taskfile/node_stdin.go
@@ -1,8 +1,7 @@
 package taskfile
 
 import (
-	"bufio"
-	"fmt"
+	"io"
 	"os"
 
 	"github.com/go-task/task/v3/internal/execext"
@@ -29,15 +28,7 @@ func (node *StdinNode) Remote() bool {
 }
 
 func (node *StdinNode) Read() ([]byte, error) {
-	var stdin []byte
-	scanner := bufio.NewScanner(os.Stdin)
-	for scanner.Scan() {
-		stdin = fmt.Appendln(stdin, scanner.Text())
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-	return stdin, nil
+	return io.ReadAll(os.Stdin)
 }
 
 func (node *StdinNode) ResolveEntrypoint(entrypoint string) (string, error) {

--- a/taskfile/node_stdin_test.go
+++ b/taskfile/node_stdin_test.go
@@ -1,0 +1,65 @@
+package taskfile
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStdinNodeReadPreservesInput(t *testing.T) { //nolint:paralleltest // replaces process-wide stdin
+	node, err := NewStdinNode("")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			name:  "line longer than 64 KiB",
+			input: []byte(strings.Repeat("a", 64*1024+1)),
+		},
+		{
+			name:  "no trailing newline",
+			input: []byte("version: '3'"),
+		},
+		{
+			name:  "CRLF line endings",
+			input: []byte("version: '3'\r\ntasks:\r\n"),
+		},
+		{
+			name:  "empty input",
+			input: []byte{},
+		},
+	}
+
+	for _, tt := range tests { //nolint:paralleltest // subtests replace process-wide stdin
+		t.Run(tt.name, func(t *testing.T) {
+			replaceStdin(t, tt.input)
+
+			got, err := node.Read()
+			require.NoError(t, err)
+			assert.Equal(t, tt.input, got)
+		})
+	}
+}
+
+func replaceStdin(t *testing.T, input []byte) {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "stdin")
+	require.NoError(t, os.WriteFile(path, input, 0o600))
+
+	stdin, err := os.Open(path)
+	require.NoError(t, err)
+
+	original := os.Stdin
+	os.Stdin = stdin
+	t.Cleanup(func() {
+		os.Stdin = original
+		require.NoError(t, stdin.Close())
+	})
+}


### PR DESCRIPTION
<!--

Thanks for your pull request, we really appreciate contributions!

Please understand that it may take some time to be reviewed.

Also, make sure to follow the [Contribution Guide](https://taskfile.dev/contributing/).

-->

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/)



`StdinNode.Read` used `bufio.Scanner` to read a Taskfile line by line.

`Scanner` has a default maximum token size of 64 KiB, so a Taskfile containing a longer line failed with:

```text
bufio.Scanner: token too long
```


The previous implementation also removed the original line endings and added `\n` after every scanned line. This converted CRLF input to LF and added a trailing newline when the input did not contain one.

This differed from regular Taskfile reads, which use `io.ReadAll ` and preserve the input bytes.
