### PR TITLE
ci(renovate): stop dependency updates from bumping the go directive

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -50,6 +50,11 @@
       "matchManagers": ["gomod"],
       "matchDepTypes": ["golang"],
       "enabled": false
+    },
+    {
+      "description": "Skip releases whose own `go` directive exceeds ours. Without this, `gomodTidy` propagates their requirement into our go.mod and breaks the older Go versions in the CI matrix.",
+      "matchManagers": ["gomod"],
+      "constraintsFiltering": "strict"
     }
   ]
 }

--- a/experiments/errors.go
+++ b/experiments/errors.go
@@ -16,7 +16,7 @@ type InvalidValueError struct {
 
 func (err InvalidValueError) Error() string {
 	return fmt.Sprintf(
-		"task: Experiment %q has an invalid value %q (allowed values: %s)",
+		"task: Experiment %q has an invalid value %d (allowed values: %s)",
 		err.Name,
 		err.Value,
 		strings.Join(slicesext.Convert(err.AllowedValues, strconv.Itoa), ", "),


### PR DESCRIPTION
## Summary

Two independent fixes for the CI failures on #2943.

**`ci(renovate)`** — Renovate never proposed the `go 1.25.10` -> `go 1.26.4` bump in #2943 directly; it is absent from the PR's dependency table, and the existing `matchDepTypes: ["golang"]` rule does block that update. The bump comes from the `gomodTidy` post-update option instead: a digest update to the indirect dep `github.com/planetscale/vtprotobuf` pulled in a revision whose own `go.mod` declares `go 1.26.4`, so `go mod tidy` raises our directive to match. Every 1.25.x job then fails with `go.mod requires go >= 1.26.4 (running go 1.25.12; GOTOOLCHAIN=local)`.

Reproduced locally by resetting the directive on the Renovate branch and re-running `go mod tidy`; confirmed the culprit with `go list -m -f '{{.GoVersion}}' all`. The package is a sixth-level indirect, reached through `hashicorp/go-getter` -> `cloud.google.com/go/storage` -> `grpc/stats/opentelemetry` (a `.test` package) -> `envoyproxy/go-control-plane`.

Rather than pinning offending packages one at a time, this sets [`constraintsFiltering: "strict"`](https://docs.renovatebot.com/modules/manager/gomod/) on the gomod manager, so Renovate filters out candidate releases whose `go` directive exceeds ours.

**`fix(experiments)`** — `InvalidValueError.Value` is an `int` formatted with `%q`, which renders it as a quoted rune literal (`'\x02'`) rather than the number. Go 1.26's stricter vet reports it, failing both the lint job and the `experiments` package build. This is preexisting and red on `main`, independent of #2943.

## Test plan

- [x] `go vet ./...` clean under Go 1.26.5 (previously reported `experiments/errors.go:19:45`)
- [x] `go test ./experiments/...` passes — the table tests compare the struct, not the formatted message, so no golden files are affected
- [x] Verified that holding `vtprotobuf` back keeps `go.mod` at `1.25.10` after `go mod tidy` with every other #2943 update applied

Once merged, #2943 needs a rebase/retry for the filter to take effect.

## Notes

`constraintsFiltering` relies on the datasource exposing each candidate's `go` directive, and it only governs what Renovate proposes — a transitive bump via MVS could still raise the directive. Some dependencies will also now hold back silently until the project moves to 1.26.

Leaving the wider question of dropping 1.25 alone here; #2920 covers that.
