### PR TITLE
docs: close two unterminated code fences and fix --trust flag name

### DIFF
--- a/website/src/docs/experiments/remote-taskfiles.md
+++ b/website/src/docs/experiments/remote-taskfiles.md
@@ -229,7 +229,8 @@ remote Taskfiles:
 Sometimes you need to run Task in an environment that does not have an
 interactive terminal, so you are not able to accept a prompt. In these cases you
 are able to tell task to accept these prompts automatically by using the `--yes`
-flag or the `--trust` flag. The `--trust` flag allows you to specify trusted
+flag or the `--trusted-hosts` flag. The `--trusted-hosts` flag allows you to
+specify trusted
 hosts for remote Taskfiles, while `--yes` applies to all prompts in Task. You
 can also configure trusted hosts in your [taskrc configuration](#trusted-hosts) using
 `remote.trusted-hosts`. Before enabling automatic trust, you should:

--- a/website/src/docs/reference/config.md
+++ b/website/src/docs/reference/config.md
@@ -194,3 +194,4 @@ temp-dir: .task
 # Enable experimental features
 experiments:
   REMOTE_TASKFILES: 1
+```

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -735,6 +735,7 @@ tasks:
             ref: .ALLOWED_ENVS
     cmds:
       - ./deploy.sh
+```
 
 #### [`vars`](#variable)
 


### PR DESCRIPTION
Three small documentation fixes:

- **`reference/schema.md`**: the YAML example under `requires` is never closed, so the following `#### vars` heading and its description get rendered inside the code block (the next ````yaml```` is consumed as the closer).
- **`reference/config.md`**: the example under "Example Configuration" is left open at the end of the file.
- **`experiments/remote-taskfiles.md`**: refers to a `--trust` flag, but the registered flag is `--trusted-hosts` (`internal/flags/flags.go`). The same page already uses `--trusted-hosts` in its configuration section.

Docs only.