### PR TITLE
fix: accept []string and []int in matrix refs

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -929,6 +929,7 @@ func TestForCmds(t *testing.T) {
 		{name: "loop-explicit"},
 		{name: "loop-matrix"},
 		{name: "loop-matrix-ref"},
+		{name: "loop-matrix-ref-computed"},
 		{
 			name:    "loop-matrix-ref-error",
 			wantErr: true,

--- a/testdata/for/cmds/Taskfile.yml
+++ b/testdata/for/cmds/Taskfile.yml
@@ -4,6 +4,7 @@ vars:
   OS_VAR: ["windows", "linux", "darwin"]
   ARCH_VAR: ["amd64", "arm64"]
   NOT_A_LIST: "not a list"
+  OS_CSV: "windows,linux,darwin"
 
 tasks:
   # Loop over a list of values
@@ -26,6 +27,16 @@ tasks:
           matrix:
             OS:
               ref: .OS_VAR
+            ARCH:
+              ref: .ARCH_VAR
+        cmd: echo "{{.ITEM.OS}}/{{.ITEM.ARCH}}"
+
+  loop-matrix-ref-computed:
+    cmds:
+      - for:
+          matrix:
+            OS:
+              ref: 'splitList "," .OS_CSV'
             ARCH:
               ref: .ARCH_VAR
         cmd: echo "{{.ITEM.OS}}/{{.ITEM.ARCH}}"

--- a/testdata/for/cmds/testdata/TestForCmds-loop-matrix-ref-computed.golden
+++ b/testdata/for/cmds/testdata/TestForCmds-loop-matrix-ref-computed.golden
@@ -1,0 +1,6 @@
+windows/amd64
+windows/arm64
+linux/amd64
+linux/arm64
+darwin/amd64
+darwin/arm64

--- a/variables.go
+++ b/variables.go
@@ -356,6 +356,22 @@ func asAnySlice[T any](slice []T) []any {
 	return ret
 }
 
+// resolvedAsAnySlice converts a value resolved from a reference into a []any.
+// A reference does not always resolve to a []any: lists declared in a Taskfile
+// do, but template functions such as `keys` and `splitList` return a []string.
+// The accepted types mirror the list types itemsFromFor already supports.
+func resolvedAsAnySlice(v any) ([]any, bool) {
+	switch value := v.(type) {
+	case []any:
+		return value, true
+	case []string:
+		return asAnySlice(value), true
+	case []int:
+		return asAnySlice(value), true
+	}
+	return nil, false
+}
+
 func itemsFromFor(
 	f *ast.For,
 	dir string,
@@ -477,12 +493,11 @@ func resolveMatrixRefs(matrix *ast.Matrix, cache *templater.Cache) (*ast.Matrix,
 			if cache.Err() != nil {
 				return nil, cache.Err()
 			}
-			switch value := v.(type) {
-			case []any:
-				row.Value = value
-			default:
+			value, ok := resolvedAsAnySlice(v)
+			if !ok {
 				return nil, fmt.Errorf("matrix reference %q must resolve to a list", row.Ref)
 			}
+			row.Value = value
 		}
 	}
 	return resolved, nil
@@ -500,7 +515,7 @@ func resolveEnumRefs(requires *ast.Requires, cache *templater.Cache) error {
 		if cache.Err() != nil {
 			return cache.Err()
 		}
-		arr, ok := resolved.([]any)
+		arr, ok := resolvedAsAnySlice(resolved)
 		if !ok {
 			return fmt.Errorf("enum reference %q must resolve to a list", v.Enum.Ref)
 		}

--- a/variables_test.go
+++ b/variables_test.go
@@ -43,3 +43,52 @@ func TestResolveMatrixRefsDoesNotMutateInput(t *testing.T) {
 	require.Nil(t, orig.Value, "input matrix was mutated: Ref rows must be resolved into a copy")
 	require.Equal(t, ".ARCH_VAR", orig.Ref, "input matrix Ref was altered")
 }
+
+// TestResolveMatrixRefsListTypes is a regression test for #2544. A `ref:` is
+// evaluated as a template expression, so it does not always resolve to a
+// []any: a list declared in a Taskfile does, but template functions such as
+// `keys` and `splitList` return a []string. Resolving a ref used to type
+// assert []any, so those references failed with "must resolve to a list" even
+// though the value was a list. The accepted types mirror the ones
+// itemsFromFor supports for `for: var:`.
+func TestResolveMatrixRefsListTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   any
+		want    []any
+		wantErr bool
+	}{
+		{name: "any slice", value: []any{"amd64", "arm64"}, want: []any{"amd64", "arm64"}},
+		{name: "string slice", value: []string{"amd64", "arm64"}, want: []any{"amd64", "arm64"}},
+		{name: "int slice", value: []int{1, 2}, want: []any{1, 2}},
+		{name: "string", value: "not a list", wantErr: true},
+		{name: "map", value: map[string]any{"key": "value"}, wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			matrix := ast.NewMatrix(
+				&ast.MatrixElement{Key: "ARCH", Value: &ast.MatrixRow{Ref: ".ARCH_VAR"}},
+			)
+
+			vars := ast.NewVars()
+			vars.Set("ARCH_VAR", ast.Var{Value: test.value})
+			cache := &templater.Cache{Vars: vars}
+
+			resolved, err := resolveMatrixRefs(matrix, cache)
+			if test.wantErr {
+				require.ErrorContains(t, err, `matrix reference ".ARCH_VAR" must resolve to a list`)
+				return
+			}
+			require.NoError(t, err)
+
+			row, ok := resolved.Get("ARCH")
+			require.True(t, ok, "ARCH row missing from resolved matrix")
+			require.Equal(t, test.want, row.Value)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2544.

Matrix `ref:` only accepted a literal `[]any`, so a ref computed with a template function like `splitList` came back as `[]string` and failed with "must resolve to a list" even though its a perfectly good list. trulede already pinned this down on the issue, the type switch just never matched.

The fix adds a small helper (`resolvedAsAnySlice`) that accepts `[]any`, `[]string` and `[]int`. that set deliberately mirrors what `itemsFromFor` already takes for literal lists, so nothing that worked before behaves differently, no reflect involved. Enum refs shared the same `[]any` assertion so they get the same widening.

Tests: a table test for the conversion (any/string/int slices plus two error cases) and an end-to-end fixture task `loop-matrix-ref-computed` that loops over a `splitList` ref, with a golden file. `go test ./...` is green locally.

Disclosure: I used an AI assistant to help implement and test this change. I've reviewed and verified it and I'm happy to explain or revise anything here.
