### PR TITLE
docs: document use_gitignore in schema reference and guide

### DIFF
--- a/website/src/docs/guide.md
+++ b/website/src/docs/guide.md
@@ -898,6 +898,16 @@ of the running the task is considered as a generate.
 
 :::
 
+::: tip
+
+If your globs match files that are ignored by Git (build artifacts, caches,
+etc.), you can set `use_gitignore: true` at the root of your Taskfile to
+exclude anything matched by `.gitignore` rules from `sources` and `generates`
+resolution. The setting can also be enabled or disabled per task, which takes
+precedence over the root value.
+
+:::
+
 ### Using programmatic checks to indicate a task is up to date
 
 Alternatively, you can inform a sequence of tests as `status`. If no error is

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -208,6 +208,17 @@ set: [errexit, nounset, pipefail]
 shopt: [globstar]
 ```
 
+### `use_gitignore`
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Description**: Exclude files matched by `.gitignore` rules when resolving
+  `sources` and `generates` globs for all tasks. Can be overridden per task.
+
+```yaml
+use_gitignore: true
+```
+
 ## Include
 
 Configuration for including external Taskfiles.
@@ -622,6 +633,24 @@ tasks:
       - exclude: '*.debug'
     cmds:
       - go build -o app ./cmd
+```
+
+#### `use_gitignore`
+
+- **Type**: `bool`
+- **Default**: `false`
+- **Description**: Exclude files matched by `.gitignore` rules when resolving
+  this task's `sources` and `generates` globs. Overrides the root-level
+  `use_gitignore` setting.
+
+```yaml
+tasks:
+  build:
+    use_gitignore: true
+    sources:
+      - '**/*.go'
+    cmds:
+      - go build ./...
 ```
 
 #### `status`


### PR DESCRIPTION
The `use_gitignore` setting shipped in v3.52.0 (#2773) and is in the JSON schema and changelog, but the schema reference and guide never picked it up, so the only way to find it right now is reading the schema file itself.

This adds the root-level and per-task entries to the schema reference (same format as the neighbouring settings, descriptions match the schema.json wording and the actual merge behaviour in `taskfile/ast/taskfile.go`) and a short tip in the guide's fingerprinting section, since excluding gitignored build artifacts from `sources`/`generates` globs is the main use case.

Docs only, no code changes.

Disclosure: I used an AI assistant to help draft this change. I've reviewed and verified it against the implementation and I'm happy to revise anything.
