### PR TITLE
feat: support excluding task namespaces

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -1642,6 +1642,16 @@ func TestIncludesWithExclude(t *testing.T) {
 	require.Error(t, err)
 	buff.Reset()
 
+	err = e.Run(t.Context(), &task.Call{Task: "included:foo:child"})
+	require.NoError(t, err)
+	assert.Equal(t, "foo:child\n", buff.String())
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "included:namespace"})
+	require.NoError(t, err)
+	assert.Equal(t, "namespace\n", buff.String())
+	buff.Reset()
+
 	err = e.Run(t.Context(), &task.Call{Task: "included:namespace:one"})
 	require.Error(t, err)
 	buff.Reset()
@@ -1658,6 +1668,11 @@ func TestIncludesWithExclude(t *testing.T) {
 	err = e.Run(t.Context(), &task.Call{Task: "foo"})
 	require.NoError(t, err)
 	assert.Equal(t, "foo\n", buff.String())
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "namespace"})
+	require.NoError(t, err)
+	assert.Equal(t, "namespace\n", buff.String())
 	buff.Reset()
 
 	err = e.Run(t.Context(), &task.Call{Task: "namespace:two"})

--- a/task_test.go
+++ b/task_test.go
@@ -1642,6 +1642,15 @@ func TestIncludesWithExclude(t *testing.T) {
 	require.Error(t, err)
 	buff.Reset()
 
+	err = e.Run(t.Context(), &task.Call{Task: "included:namespace:one"})
+	require.Error(t, err)
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "included:namespace-other:one"})
+	require.NoError(t, err)
+	assert.Equal(t, "namespace-other:one\n", buff.String())
+	buff.Reset()
+
 	err = e.Run(t.Context(), &task.Call{Task: "bar"})
 	require.Error(t, err)
 	buff.Reset()
@@ -1649,6 +1658,15 @@ func TestIncludesWithExclude(t *testing.T) {
 	err = e.Run(t.Context(), &task.Call{Task: "foo"})
 	require.NoError(t, err)
 	assert.Equal(t, "foo\n", buff.String())
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "namespace:two"})
+	require.Error(t, err)
+	buff.Reset()
+
+	err = e.Run(t.Context(), &task.Call{Task: "namespace-other:one"})
+	require.NoError(t, err)
+	assert.Equal(t, "namespace-other:one\n", buff.String())
 }
 
 func TestIncludedTaskfileVarMerging(t *testing.T) {

--- a/taskfile/ast/include.go
+++ b/taskfile/ast/include.go
@@ -37,6 +37,27 @@ type (
 	IncludeElement orderedmap.Element[string, *Include]
 )
 
+func (include *Include) isTaskExcluded(name string) bool {
+	if include == nil {
+		return false
+	}
+
+	for _, exclude := range include.Excludes {
+		namespace, ok := strings.CutSuffix(exclude, NamespaceSeparator+"*")
+		if ok {
+			if namespace != "" && strings.HasPrefix(name, namespace+NamespaceSeparator) {
+				return true
+			}
+			continue
+		}
+
+		if name == exclude {
+			return true
+		}
+	}
+	return false
+}
+
 // NewIncludes creates a new instance of Includes and initializes it with the
 // provided set of elements, if any. The elements are added in the order they
 // are passed.

--- a/taskfile/ast/tasks.go
+++ b/taskfile/ast/tasks.go
@@ -130,9 +130,9 @@ func (t1 *Tasks) Merge(t2 *Tasks, include *Include, includedTaskfileVars *Vars) 
 		task.Internal = task.Internal || (include != nil && include.Internal)
 		taskName := name
 
-		// If the task or one of its parent namespaces is in the exclude list,
-		// don't add it to the merged taskfile.
-		if isTaskExcluded(name, include.Excludes) {
+		// If the task or its namespace is in the exclude list, don't add it to
+		// the merged taskfile.
+		if include.isTaskExcluded(name) {
 			continue
 		}
 
@@ -249,17 +249,4 @@ func taskNameWithNamespace(taskName string, namespace string) string {
 		return after
 	}
 	return fmt.Sprintf("%s%s%s", namespace, NamespaceSeparator, taskName)
-}
-
-func isTaskExcluded(name string, excludes []string) bool {
-	for _, exclude := range excludes {
-		exclude = strings.TrimSuffix(exclude, NamespaceSeparator+"*")
-		if exclude == "" {
-			continue
-		}
-		if name == exclude || strings.HasPrefix(name, exclude+NamespaceSeparator) {
-			return true
-		}
-	}
-	return false
 }

--- a/taskfile/ast/tasks.go
+++ b/taskfile/ast/tasks.go
@@ -130,8 +130,9 @@ func (t1 *Tasks) Merge(t2 *Tasks, include *Include, includedTaskfileVars *Vars) 
 		task.Internal = task.Internal || (include != nil && include.Internal)
 		taskName := name
 
-		// if the task is in the exclude list, don't add it to the merged taskfile
-		if slices.Contains(include.Excludes, name) {
+		// If the task or one of its parent namespaces is in the exclude list,
+		// don't add it to the merged taskfile.
+		if isTaskExcluded(name, include.Excludes) {
 			continue
 		}
 
@@ -248,4 +249,17 @@ func taskNameWithNamespace(taskName string, namespace string) string {
 		return after
 	}
 	return fmt.Sprintf("%s%s%s", namespace, NamespaceSeparator, taskName)
+}
+
+func isTaskExcluded(name string, excludes []string) bool {
+	for _, exclude := range excludes {
+		exclude = strings.TrimSuffix(exclude, NamespaceSeparator+"*")
+		if exclude == "" {
+			continue
+		}
+		if name == exclude || strings.HasPrefix(name, exclude+NamespaceSeparator) {
+			return true
+		}
+	}
+	return false
 }

--- a/testdata/includes_with_excludes/Taskfile.yml
+++ b/testdata/includes_with_excludes/Taskfile.yml
@@ -5,7 +5,7 @@ includes:
     taskfile: ./included/Taskfile.yml
     excludes:
       - foo
-      - namespace
+      - namespace:*
   included_flatten:
     taskfile: ./included/Taskfile.yml
     flatten: true

--- a/testdata/includes_with_excludes/Taskfile.yml
+++ b/testdata/includes_with_excludes/Taskfile.yml
@@ -4,12 +4,14 @@ includes:
   included:
     taskfile: ./included/Taskfile.yml
     excludes:
-        - foo
+      - foo
+      - namespace
   included_flatten:
     taskfile: ./included/Taskfile.yml
     flatten: true
     excludes:
       - bar
+      - namespace:*
 
 tasks:
   default:

--- a/testdata/includes_with_excludes/included/Taskfile.yml
+++ b/testdata/includes_with_excludes/included/Taskfile.yml
@@ -2,7 +2,9 @@ version: '3'
 
 tasks:
   foo: echo foo
+  foo:child: echo foo:child
   bar: echo bar
+  namespace: echo namespace
   namespace:one: echo namespace:one
   namespace:two: echo namespace:two
   namespace-other:one: echo namespace-other:one

--- a/testdata/includes_with_excludes/included/Taskfile.yml
+++ b/testdata/includes_with_excludes/included/Taskfile.yml
@@ -3,3 +3,6 @@ version: '3'
 tasks:
   foo: echo foo
   bar: echo bar
+  namespace:one: echo namespace:one
+  namespace:two: echo namespace:two
+  namespace-other:one: echo namespace-other:one

--- a/website/src/docs/guide.md
+++ b/website/src/docs/guide.md
@@ -412,8 +412,10 @@ You can do this by using the
 
 ### Exclude tasks from being included
 
-You can exclude tasks from being included by using the `excludes` option. This
-option takes the list of tasks to be excluded from this include.
+You can exclude tasks or entire namespaces from being included by using the
+`excludes` option. This option takes the list of tasks or namespaces to be
+excluded from this include. Append `:*` to a namespace if you want to make the
+namespace exclusion explicit.
 
 ::: code-group
 
@@ -423,7 +425,7 @@ version: '3'
 includes:
   included:
     taskfile: ./Included.yml
-    excludes: [foo]
+    excludes: [foo, internal, 'debug:*']
 ```
 
 ```yaml [Included.yml]
@@ -432,11 +434,14 @@ version: '3'
 tasks:
   foo: echo "Foo"
   bar: echo "Bar"
+  internal:setup: echo "Internal setup"
+  debug:status: echo "Debug status"
 ```
 
 :::
 
-`task included:foo` will throw an error because the `foo` task is excluded but
+`task included:foo`, `task included:internal:setup`, and
+`task included:debug:status` will throw errors because they are excluded, but
 `task included:bar` will work and display `Bar`.
 
 It's compatible with the `flatten` option.

--- a/website/src/docs/guide.md
+++ b/website/src/docs/guide.md
@@ -414,8 +414,8 @@ You can do this by using the
 
 You can exclude tasks or entire namespaces from being included by using the
 `excludes` option. This option takes the list of tasks or namespaces to be
-excluded from this include. Append `:*` to a namespace if you want to make the
-namespace exclusion explicit.
+excluded from this include. Task names are matched exactly. To exclude a
+namespace, append `:*` to its name.
 
 ::: code-group
 
@@ -425,7 +425,7 @@ version: '3'
 includes:
   included:
     taskfile: ./Included.yml
-    excludes: [foo, internal, 'debug:*']
+    excludes: [foo, 'internal:*', 'debug:*']
 ```
 
 ```yaml [Included.yml]

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -308,13 +308,14 @@ includes:
 ### `excludes`
 
 - **Type**: `[]string`
-- **Description**: Tasks or namespaces to exclude from inclusion
+- **Description**: Task names or namespace patterns ending in `:*` to exclude
+  from inclusion
 
 ```yaml
 includes:
   shared:
     taskfile: ./shared.yml
-    excludes: [internal-setup, debug, 'experimental:*']
+    excludes: [internal-setup, 'debug:*', 'experimental:*']
 ```
 
 ### `vars`

--- a/website/src/docs/reference/schema.md
+++ b/website/src/docs/reference/schema.md
@@ -308,13 +308,13 @@ includes:
 ### `excludes`
 
 - **Type**: `[]string`
-- **Description**: Tasks to exclude from inclusion
+- **Description**: Tasks or namespaces to exclude from inclusion
 
 ```yaml
 includes:
   shared:
     taskfile: ./shared.yml
-    excludes: [internal-setup, debug-only]
+    excludes: [internal-setup, debug, 'experimental:*']
 ```
 
 ### `vars`

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -746,7 +746,7 @@
                       }
                     },
                     "excludes": {
-                      "description": "A list of tasks to be excluded from inclusion.",
+                      "description": "A list of tasks or namespaces to be excluded from inclusion.",
                       "type": "array",
                       "items": {
                         "type": "string"

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -746,7 +746,7 @@
                       }
                     },
                     "excludes": {
-                      "description": "A list of tasks or namespaces to be excluded from inclusion.",
+                      "description": "A list of task names or namespace patterns ending in `:*` to be excluded from inclusion.",
                       "type": "array",
                       "items": {
                         "type": "string"


### PR DESCRIPTION
## Summary

- Allow `includes.excludes` entries ending in `:*` to exclude entire task namespaces.
- Preserve exact task-name matching for entries without `:*`.
- Scope namespace exclusions to descendants: `foo:*` excludes `foo:child`, but not the standalone `foo` task or tasks in similarly prefixed namespaces such as `foo-other`.
- Add coverage for exact task matching and namespace exclusions with regular and flattened includes.
- Update the guide, schema reference, and public JSON Schema description.

## Testing

- `go test ./... -run '^TestIncludesWithExclude$' -count=1`
- `go test ./taskfile/... -count=1`
- `go vet ./...`

## AI Assistance

AI assistance was used to review the changes. During the review, it identified that the `excludes` description in the public JSON Schema had not been updated to mention namespaces. I reviewed and fixed the inconsistency before submitting this pull request.

Fixes #2300

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/)