### PR TITLE
fix: align command schema definitions with the parser

### DIFF
--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -350,7 +350,7 @@
           "type": "boolean"
         },
         "ignore_error": {
-          "description": "Prevent command from aborting the execution of task even after receiving a status code of 1",
+          "description": "Prevent the command from aborting the execution of the task when it exits with a non-zero status code",
           "type": "boolean"
         },
         "if": {
@@ -387,7 +387,7 @@
           }
         },
         "ignore_error": {
-          "description": "Prevent command from aborting the execution of task even after receiving a status code of 1",
+          "description": "Prevent the command from aborting the execution of the task when it exits with a non-zero status code",
           "type": "boolean"
         },
         "platforms": {
@@ -461,7 +461,7 @@
           }
         },
         "ignore_error": {
-          "description": "Prevent command from aborting the execution of task even after receiving a status code of 1",
+          "description": "Prevent the command from aborting the execution of the task when it exits with a non-zero status code",
           "type": "boolean"
         },
         "platforms": {
@@ -495,7 +495,7 @@
           "type": "boolean"
         },
         "ignore_error": {
-          "description": "Prevent command from aborting the execution of task even after receiving a status code of 1",
+          "description": "Prevent the command from aborting the execution of the task when it exits with a non-zero status code",
           "type": "boolean"
         },
         "platforms": {

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -349,6 +349,10 @@
           "description": "Hides task name and command from output. The command's output will still be redirected to `STDOUT` and `STDERR`.",
           "type": "boolean"
         },
+        "ignore_error": {
+          "description": "Prevent command from aborting the execution of task even after receiving a status code of 1",
+          "type": "boolean"
+        },
         "if": {
           "description": "A shell command to evaluate. If the exit code is non-zero, the command is skipped.",
           "type": "string"
@@ -442,6 +446,20 @@
           "description": "Silent mode disables echoing of command before Task runs it",
           "type": "boolean"
         },
+        "set": {
+          "description": "Enables POSIX shell options for this command. See https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/set"
+          }
+        },
+        "shopt": {
+          "description": "Enables Bash shell options for this command. See https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/shopt"
+          }
+        },
         "ignore_error": {
           "description": "Prevent command from aborting the execution of task even after receiving a status code of 1",
           "type": "boolean"
@@ -449,6 +467,10 @@
         "platforms": {
           "description": "Specifies which platforms the command should be run on.",
           "$ref": "#/definitions/platforms"
+        },
+        "if": {
+          "description": "A shell command to evaluate. If the exit code is non-zero, the command is skipped.",
+          "type": "string"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Summary

`Cmd.UnmarshalYAML` accepts `ignore_error` on a task call and `set`, `shopt` and `if` on a looped command, but the schema rejects all four, so working Taskfiles are flagged as invalid by editors and by `check-jsonschema` in CI. This adds the missing properties to `task_call` and `for_cmd_call`, and fixes the `ignore_error` description, which claimed only a status code of 1 is ignored while `runCommand` swallows any non-zero exit.

One thing to decide separately: `platforms` on `for_task_call` validates but is dead — the task-call branch of `Cmd.UnmarshalYAML` never assigns `Platforms` and `runCommand` only calls `shouldRunOnCurrentPlatform` on the cmd branch. Left as is here, since removing it would fail Taskfiles that pass today.

## Test plan

- `check-jsonschema --check-metaschema website/src/public/schema.json` passes, same as CI.
- A Taskfile covering all four forms (`for` + `cmd`, `for` + `cmd` with `if`/`set`/`shopt`, `for` + `task`, plain `- task:` — each with `ignore_error`) validates against the new schema and is rejected by the one on `main`.
- An unknown key on a looped command is still rejected, so `additionalProperties: false` keeps biting.
- The same Taskfile runs correctly with a `task` binary built from `main`: every form executes and `ignore_error` swallows an `exit 3`.
