### PR TITLE
fix: return full path in getTaskPath() instead of bare filename

### DIFF
--- a/signals_test.go
+++ b/signals_test.go
@@ -188,8 +188,8 @@ func TestSignalSentToProcessGroup(t *testing.T) {
 }
 
 func getTaskPath() (string, error) {
-	if info, err := os.Stat("./bin/task"); err == nil {
-		return info.Name(), nil
+	if _, err := os.Stat("./bin/task"); err == nil {
+		return filepath.Abs("./bin/task")
 	}
 
 	if path, err := exec.LookPath("task"); err == nil {


### PR DESCRIPTION
## Summary

Fixes #2970

## Problem

In `signals_test.go`, `getTaskPath()` uses `os.Stat("./bin/task")` and returns `info.Name()`. The `FileInfo.Name()` method only returns the **base filename** (`"task"`), not the path passed to `os.Stat` (`"./bin/task"`).

This means `exec.Command` receives `"task"` (bare name) and resolves it via `$PATH`, silently running signal tests against a system-installed binary instead of the locally-built one.

## Fix

Store the path in a constant and return it directly:

```diff
 func getTaskPath() (string, error) {
-    if info, err := os.Stat("./bin/task"); err == nil {
-        return info.Name(), nil
+    const localTaskBin = "./bin/task"
+    if _, err := os.Stat(localTaskBin); err == nil {
+        return localTaskBin, nil
     }
 ```

## Testing

- The fix is in the test file itself (`signals_test.go`)
- Verified that `os.FileInfo.Name()` only returns the base filename per the Go standard library docs