### PR TITLE
test: verify --force and --force-all bypass task preconditions

### DIFF
--- a/task_test.go
+++ b/task_test.go
@@ -3373,6 +3373,64 @@ func TestForce(t *testing.T) {
 	}
 }
 
+func TestForceBypassesPreconditions(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/force-precondition"
+
+	tests := []struct {
+		name     string
+		task     string
+		force    bool
+		forceAll bool
+		wantErr  bool
+	}{
+		{
+			name:    "without force, failing precondition blocks the task",
+			task:    "with-precondition",
+			wantErr: true,
+		},
+		{
+			name:  "force bypasses preconditions",
+			task:  "with-precondition",
+			force: true,
+		},
+		{
+			name:    "force does not bypass dependency preconditions",
+			task:    "calls-dep",
+			force:   true,
+			wantErr: true,
+		},
+		{
+			name:     "force-all bypasses preconditions including dependencies",
+			task:     "calls-dep",
+			forceAll: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buff bytes.Buffer
+			e := task.NewExecutor(
+				task.WithDir(dir),
+				task.WithStdout(&buff),
+				task.WithStderr(&buff),
+				task.WithForce(tt.force),
+				task.WithForceAll(tt.forceAll),
+			)
+			require.NoError(t, e.Setup())
+			err := e.Run(t.Context(), &task.Call{Task: tt.task})
+			if tt.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, task.ErrPreconditionFailed)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestWildcard(t *testing.T) {
 	t.Parallel()
 

--- a/testdata/force-precondition/Taskfile.yml
+++ b/testdata/force-precondition/Taskfile.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+tasks:
+  with-precondition:
+    preconditions:
+      - sh: "test -f nonexistent.txt"
+        msg: "file missing"
+    cmds:
+      - echo "ran with force"
+
+  dep-with-precondition:
+    preconditions:
+      - sh: "test -f nonexistent.txt"
+        msg: "dep file missing"
+    cmds:
+      - echo "dep ran with force-all"
+
+  calls-dep:
+    deps:
+      - dep-with-precondition
+    cmds:
+      - echo "parent ran"


### PR DESCRIPTION

## Summary

Adds a table-driven regression test (`TestForceBypassesPreconditions`) covering how the
`--force` and `--force-all` flags interact with task preconditions:

- **negative control**: without flags, a failing precondition blocks the task with
  `task.ErrPreconditionFailed`;
- `--force` bypasses the task's own precondition;
- `--force` does **not** bypass the preconditions of task dependencies;
- `--force-all` bypasses preconditions of the task and its dependencies.

The pinned behavior matches `skipFingerprinting := e.ForceAll || (!call.Indirect && e.Force)`
in `task.go`. The negative control proves the fixture precondition genuinely fails without the
flags, so the test is not vacuous.

Includes a new fixture `testdata/force-precondition/Taskfile.yml`.

## Type

- [x] Test addition (no production code, no dependency changes, no refactor)

## Testing

```bash
$ go test -v -run TestForceBypassesPreconditions .
--- PASS: TestForceBypassesPreconditions (0.00s)
    --- PASS: TestForceBypassesPreconditions/without_force,_failing_precondition_blocks_the_task (0.00s)
    --- PASS: TestForceBypassesPreconditions/force_does_not_bypass_dependency_preconditions (0.00s)
    --- PASS: TestForceBypassesPreconditions/force_bypasses_preconditions (0.00s)
    --- PASS: TestForceBypassesPreconditions/force-all_bypasses_preconditions_including_dependencies (0.00s)
PASS
ok  github.com/go-task/task/v3   (cached)

$ go test -run 'TestForce|TestPrecondition' .
ok  github.com/go-task/task/v3   (cached)

$ go build ./...
BUILD_OK

$ go test ./...
ok  github.com/go-task/task/v3   1.603s
ok  github.com/go-task/task/v3/args   (cached)
ok  github.com/go-task/task/v3/experiments   (cached)
ok  github.com/go-task/task/v3/internal/fingerprint   (cached)
ok  github.com/go-task/task/v3/internal/fsext   (cached)
ok  github.com/go-task/task/v3/internal/gitignore   (cached)
ok  github.com/go-task/task/v3/internal/output   (cached)
ok  github.com/go-task/task/v3/internal/slicesext   (cached)
ok  github.com/go-task/task/v3/internal/sort   (cached)
ok  github.com/go-task/task/v3/internal/summary   (cached)
ok  github.com/go-task/task/v3/internal/templater   (cached)
ok  github.com/go-task/task/v3/taskfile   (cached)
ok  github.com/go-task/task/v3/taskfile/ast   (cached)
ok  github.com/go-task/task/v3/taskrc   (cached)
(19 packages: no test files)
```

14 packages ok, 0 failures; `git diff upstream/main...HEAD --check` clean; `gofmt -l` clean.

**AI disclosure:** This contribution was prepared with the assistance of AI tools and was human-reviewed before submission. The author understands and can explain the change.

