### PR TITLE
fix(output): synchronize concurrent writes to the prefixed writer

### DIFF
--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/fatih/color"
@@ -189,4 +191,37 @@ func TestPrefixedWithColor(t *testing.T) {
 			)
 		}
 	})
+}
+
+func TestPrefixedConcurrentWrites(t *testing.T) {
+	t.Parallel()
+
+	var b bytes.Buffer
+	l := &logger.Logger{Color: false}
+	var o output.Output = output.NewPrefixed(l)
+	stdOut, stdErr, cleanup := o.WrapWriter(&b, &b, "prefix", nil)
+
+	const lines = 1000
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := range lines {
+			fmt.Fprintf(stdOut, "stdout-%d\n", i)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := range lines {
+			fmt.Fprintf(stdErr, "stderr-%d\n", i)
+		}
+	}()
+	wg.Wait()
+	require.NoError(t, cleanup(nil))
+
+	out := strings.Split(strings.TrimSuffix(b.String(), "\n"), "\n")
+	require.Len(t, out, lines*2)
+	for _, line := range out {
+		assert.True(t, strings.HasPrefix(line, "[prefix] "))
+	}
 }

--- a/internal/output/prefixed.go
+++ b/internal/output/prefixed.go
@@ -38,9 +38,13 @@ type prefixWriter struct {
 	prefixed *Prefixed
 	prefix   string
 	buff     bytes.Buffer
+	mutex    sync.Mutex
 }
 
 func (pw *prefixWriter) Write(p []byte) (int, error) {
+	pw.mutex.Lock()
+	defer pw.mutex.Unlock()
+
 	n, err := pw.buff.Write(p)
 	if err != nil {
 		return n, err
@@ -50,6 +54,9 @@ func (pw *prefixWriter) Write(p []byte) (int, error) {
 }
 
 func (pw *prefixWriter) close() error {
+	pw.mutex.Lock()
+	defer pw.mutex.Unlock()
+
 	return pw.writeOutputLines(true)
 }
 


### PR DESCRIPTION
## Description #2945

This pr fixes a panic that can happen with `output: prefixed` mode. when a task writes to both stdout and stderr at the same time, the same prefixWriter ends up being used from two goroutines (os/exec copies each stream from its own goroutine) the shared bytes.Buffer is not safe for concurrent use, so this could corrupt its state and crash with a "slice bounds out of range" panic when their is multiple stdout and stderr concurrently.I added a mutex to prefixWriter and lock it in both Write and Close so the buffer is only ever touched by one goroutine at a time.
I also added a regression test that writes 1000 lines to stdout and 1000 to stderr concurrently, then checks that we get exactly 2000 correctly prefixed lines back. I confirmed it panics  without the fix, and passes with it (also clean under -race).


## Notes

- I'm aware #2949 was closed earlier for not following the AI usage policy.
  The mutex approach i used  was suggested in the issue comments by @trulede sir;
  I've reviewed the code and tests myself and can explain any part of it.
- Chatgpt assistance was used.

## Checklist

- [x] I have read and followed the Contribution Guide.
- [x] I have disclosed the use of any AI generated content in this pull
      request per the AI Usage Policy.
- [x] I fully understand the changes and have hand written the description
      (No AI) of this pull request.


and also I have used strings.Split  as i found it is used   across the repo  in (e.g. task_test.go, watch_test.go etc).and it is a completely standard import for test assertions. output_test.go didn't need it before only because the existing tests there used assert. Equal on exact strings rather than splitting or parsing output.

Ready for further discussions. 