### PR TITLE
feat: Add support for grouping all of a task's output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Added versioned Homebrew casks (`go-task@<major>.<minor>`) to install a specific
   minor version of Task (#3023 by @vmaerten).
+- Added opt-in task-level grouping for `output: group`. Set `by_task: true` or
+  use `--output-group-by-task` to combine all shell command output from a task
+  into one group while preserving the existing per-command default.
 
 ### 📦 Package API
 

--- a/completion/fish/task.fish
+++ b/completion/fish/task.fish
@@ -91,6 +91,7 @@ complete -c $GO_TASK_PROGNAME -s o -l output                    -d 'set output s
 complete -c $GO_TASK_PROGNAME      -l output-group-begin        -d 'message template before grouped output'
 complete -c $GO_TASK_PROGNAME      -l output-group-end          -d 'message template after grouped output'
 complete -c $GO_TASK_PROGNAME      -l output-group-error-only   -d 'hide output from successful tasks'
+complete -c $GO_TASK_PROGNAME      -l output-group-by-task      -d 'group all task output together'
 complete -c $GO_TASK_PROGNAME -s p -l parallel                  -d 'execute tasks in parallel'
 complete -c $GO_TASK_PROGNAME -s s -l silent                    -d 'disable echoing'
 complete -c $GO_TASK_PROGNAME      -l sort                      -d 'set task sorting order' -xa "default alphanumeric none"

--- a/completion/nu/task-completions.nu
+++ b/completion/nu/task-completions.nu
@@ -157,6 +157,7 @@ export extern "task" [
   --output-group-begin: string                    # message template printed before a task's grouped output
   --output-group-end: string                      # message template printed after a task's grouped output
   --output-group-error-only                       # swallow the output of successful tasks
+  --output-group-by-task                          # group all task output together
   --color(-c)                                     # colored output, enabled by default
   --silent(-s)                                    # disable echoing
   --verbose(-v)                                   # enable verbose mode

--- a/completion/ps/task.ps1
+++ b/completion/ps/task.ps1
@@ -48,6 +48,7 @@ Register-ArgumentCompleter -CommandName $cmdNames -ScriptBlock {
 			[CompletionResult]::new('--output-group-begin', '--output-group-begin', [CompletionResultType]::ParameterName, 'template before group'),
 			[CompletionResult]::new('--output-group-end', '--output-group-end', [CompletionResultType]::ParameterName, 'template after group'),
 			[CompletionResult]::new('--output-group-error-only', '--output-group-error-only', [CompletionResultType]::ParameterName, 'hide successful output'),
+			[CompletionResult]::new('--output-group-by-task', '--output-group-by-task', [CompletionResultType]::ParameterName, 'group all task output together'),
 			[CompletionResult]::new('-p', '-p', [CompletionResultType]::ParameterName, 'execute in parallel'),
 			[CompletionResult]::new('--parallel', '--parallel', [CompletionResultType]::ParameterName, 'execute in parallel'),
 			[CompletionResult]::new('-s', '-s', [CompletionResultType]::ParameterName, 'silent mode'),

--- a/completion/zsh/_task
+++ b/completion/zsh/_task
@@ -112,6 +112,7 @@ _task() {
         '(--output-group-begin)--output-group-begin[message template before grouped output]:template text: '
         '(--output-group-end)--output-group-end[message template after grouped output]:template text: '
         '(--output-group-error-only)--output-group-error-only[hide output from successful tasks]'
+        '(--output-group-by-task)--output-group-by-task[group all task output together]'
         '(-s --silent)'{-s,--silent}'[disable echoing]'
         '(--sort)--sort[set task sorting order]:order:(default alphanumeric none)'
         '(--status)--status[exit non-zero if supplied tasks not up-to-date]'

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -149,6 +149,7 @@ func init() {
 	pflag.StringVar(&Output.Group.Begin, "output-group-begin", getConfig(config, "OUTPUT_GROUP_BEGIN", func() *string { return nil }, ""), "Message template to print before a task's grouped output.")
 	pflag.StringVar(&Output.Group.End, "output-group-end", getConfig(config, "OUTPUT_GROUP_END", func() *string { return nil }, ""), "Message template to print after a task's grouped output.")
 	pflag.BoolVar(&Output.Group.ErrorOnly, "output-group-error-only", getConfig(config, "OUTPUT_GROUP_ERROR_ONLY", func() *bool { return nil }, false), "Swallow output from successful tasks.")
+	pflag.BoolVar(&Output.Group.ByTask, "output-group-by-task", getOutputGroupByTask(), "Group output by task instead of command.")
 	pflag.BoolVarP(&Color, "color", "c", getConfig(config, "COLOR", func() *bool { return config.Color }, true), "Colored output. Enabled by default. Set flag to false or use NO_COLOR=1 to disable.")
 	pflag.IntVarP(&Concurrency, "concurrency", "C", getConfig(config, "CONCURRENCY", func() *int { return config.Concurrency }, 0), "Limit number of tasks to run concurrently.")
 	pflag.DurationVarP(&Interval, "interval", "I", 0, "Interval to watch for changes.")
@@ -222,6 +223,9 @@ func Validate() error {
 		}
 		if Output.Group.ErrorOnly {
 			return errors.New("task: You can't set --output-group-error-only without --output=group")
+		}
+		if Output.Group.ByTask {
+			return errors.New("task: You can't set --output-group-by-task without --output=group")
 		}
 	}
 
@@ -309,6 +313,13 @@ func (o *flagsOption) ApplyToExecutor(e *task.Executor) {
 		task.WithFailfast(Failfast),
 		task.WithTempDirPath(TempDir),
 	)
+}
+
+func getOutputGroupByTask() bool {
+	if value, ok := getEnvAs[bool]("OUTPUT_GROUP_BY_TASK"); ok {
+		return value
+	}
+	return false
 }
 
 // getConfig extracts a config value with priority: env var > taskrc config > fallback

--- a/task.go
+++ b/task.go
@@ -452,12 +452,12 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 		if err != nil && timedOut(ctx, timeout) {
 			err = timeout
 		}
-		if taskOut != nil && err != nil {
-			taskOut.failed = true
-		}
 		if cmd.IgnoreError && isCommandFailure(err) {
 			e.Logger.VerboseErrf(logger.Yellow, "task: [%s] task error ignored: %v\n", t.Name(), err)
 			return nil
+		}
+		if taskOut != nil && err != nil {
+			taskOut.failed = true
 		}
 		return err
 	case cmd.Cmd != "":
@@ -506,8 +506,6 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 			if closeErr := closer(err); closeErr != nil {
 				e.Logger.Errf(logger.Red, "task: unable to close writer: %v\n", closeErr)
 			}
-		} else if err != nil {
-			taskOut.failed = true
 		}
 		if err != nil && timedOut(ctx, timeout) {
 			err = timeout
@@ -515,6 +513,9 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 		if cmd.IgnoreError && isCommandFailure(err) {
 			e.Logger.VerboseErrf(logger.Yellow, "task: [%s] command error ignored: %v\n", t.Name(), err)
 			return nil
+		}
+		if taskOut != nil && err != nil {
+			taskOut.failed = true
 		}
 		return err
 	default:

--- a/task.go
+++ b/task.go
@@ -3,6 +3,7 @@ package task
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"slices"
@@ -203,7 +204,8 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 	release := e.acquireConcurrencyLimit()
 	defer release()
 
-	if err = e.startExecution(ctx, t, func(ctx context.Context) error {
+	var taskOut *taskOutput
+	err = e.startExecution(ctx, t, func(ctx context.Context) error {
 		e.Logger.VerboseErrf(logger.Magenta, "task: %q started\n", call.Task)
 		if err := e.runDeps(ctx, t); err != nil {
 			return err
@@ -253,15 +255,22 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 			e.Logger.Errf(logger.Red, "task: cannot make directory %q: %v\n", t.Dir, err)
 		}
 
+		if e.OutputStyle.Name == "group" && e.OutputStyle.Group.ByTask && !t.Interactive && !e.Dry {
+			taskOut, err = e.newTaskOutput(t, call)
+			if err != nil {
+				return err
+			}
+		}
+
 		var deferredExitCode uint8
 
 		for i := range t.Cmds {
 			if t.Cmds[i].Defer {
-				defer e.runDeferred(t, call, i, t.Vars, &deferredExitCode)
+				defer e.runDeferred(t, call, i, t.Vars, &deferredExitCode, taskOut)
 				continue
 			}
 
-			if err := e.runCommand(ctx, t, call, i); err != nil {
+			if err := e.runCommand(ctx, t, call, i, taskOut); err != nil {
 				if err2 := e.statusOnError(t); err2 != nil {
 					e.Logger.VerboseErrf(logger.Yellow, "task: error cleaning status on error: %v\n", err2)
 				}
@@ -282,9 +291,21 @@ func (e *Executor) RunTask(ctx context.Context, call *Call) error {
 				return err
 			}
 		}
+
 		e.Logger.VerboseErrf(logger.Magenta, "task: %q finished\n", call.Task)
 		return nil
-	}); err != nil {
+	})
+
+	if taskOut != nil {
+		if closeErr := taskOut.close(err); closeErr != nil {
+			e.Logger.Errf(logger.Red, "task: unable to close writer: %v\n", closeErr)
+			if err == nil {
+				err = closeErr
+			}
+		}
+	}
+
+	if err != nil {
 		return &errors.TaskRunError{TaskName: t.Name(), Err: err}
 	}
 
@@ -339,7 +360,39 @@ func (e *Executor) runDeps(ctx context.Context, t *ast.Task) error {
 	return g.Wait()
 }
 
-func (e *Executor) runDeferred(t *ast.Task, call *Call, i int, vars *ast.Vars, deferredExitCode *uint8) {
+type taskOutput struct {
+	stdOut, stdErr io.Writer
+	closer         output.CloseFunc
+	failed         bool
+}
+
+func (e *Executor) newTaskOutput(t *ast.Task, call *Call) (*taskOutput, error) {
+	vars, err := e.Compiler.FastGetVariables(t, call)
+	if err != nil {
+		return nil, fmt.Errorf("task: failed to get variables: %w", err)
+	}
+
+	stdOut, stdErr, closer := e.Output.WrapWriter(
+		e.Stdout,
+		e.Stderr,
+		t.Prefix,
+		&templater.Cache{Vars: vars},
+	)
+	return &taskOutput{
+		stdOut: stdOut,
+		stdErr: stdErr,
+		closer: closer,
+	}, nil
+}
+
+func (o *taskOutput) close(err error) error {
+	if err == nil && o.failed {
+		err = fmt.Errorf("one or more task commands failed")
+	}
+	return o.closer(err)
+}
+
+func (e *Executor) runDeferred(t *ast.Task, call *Call, i int, vars *ast.Vars, deferredExitCode *uint8, taskOut *taskOutput) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -358,12 +411,12 @@ func (e *Executor) runDeferred(t *ast.Task, call *Call, i int, vars *ast.Vars, d
 	cmd.If = templater.ReplaceWithExtra(cmd.If, cache, extra)
 	cmd.Vars = templater.ReplaceVarsWithExtra(cmd.Vars, cache, extra)
 
-	if err := e.runCommand(ctx, t, call, i); err != nil {
+	if err := e.runCommand(ctx, t, call, i, taskOut); err != nil {
 		e.Logger.VerboseErrf(logger.Yellow, "task: ignored error in deferred cmd: %s\n", err.Error())
 	}
 }
 
-func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i int) error {
+func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i int, taskOut *taskOutput) error {
 	cmd := t.Cmds[i]
 
 	// In place before the if condition, which would otherwise run unbounded.
@@ -399,6 +452,9 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 		if err != nil && timedOut(ctx, timeout) {
 			err = timeout
 		}
+		if taskOut != nil && err != nil {
+			taskOut.failed = true
+		}
 		if cmd.IgnoreError && isCommandFailure(err) {
 			e.Logger.VerboseErrf(logger.Yellow, "task: [%s] task error ignored: %v\n", t.Name(), err)
 			return nil
@@ -418,16 +474,23 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 			return nil
 		}
 
-		outputWrapper := e.Output
-		if t.Interactive {
-			outputWrapper = output.Interleaved{}
+		var stdOut, stdErr io.Writer
+		var closer output.CloseFunc
+		var err error
+		if taskOut != nil {
+			stdOut, stdErr = taskOut.stdOut, taskOut.stdErr
+		} else {
+			outputWrapper := e.Output
+			if t.Interactive {
+				outputWrapper = output.Interleaved{}
+			}
+			vars, err := e.Compiler.FastGetVariables(t, call)
+			outputTemplater := &templater.Cache{Vars: vars}
+			if err != nil {
+				return fmt.Errorf("task: failed to get variables: %w", err)
+			}
+			stdOut, stdErr, closer = outputWrapper.WrapWriter(e.Stdout, e.Stderr, t.Prefix, outputTemplater)
 		}
-		vars, err := e.Compiler.FastGetVariables(t, call)
-		outputTemplater := &templater.Cache{Vars: vars}
-		if err != nil {
-			return fmt.Errorf("task: failed to get variables: %w", err)
-		}
-		stdOut, stdErr, closer := outputWrapper.WrapWriter(e.Stdout, e.Stderr, t.Prefix, outputTemplater)
 
 		err = execext.RunCommand(ctx, &execext.RunCommandOptions{
 			Command:   cmd.Cmd,
@@ -439,8 +502,12 @@ func (e *Executor) runCommand(ctx context.Context, t *ast.Task, call *Call, i in
 			Stdout:    stdOut,
 			Stderr:    stdErr,
 		})
-		if closeErr := closer(err); closeErr != nil {
-			e.Logger.Errf(logger.Red, "task: unable to close writer: %v\n", closeErr)
+		if taskOut == nil {
+			if closeErr := closer(err); closeErr != nil {
+				e.Logger.Errf(logger.Red, "task: unable to close writer: %v\n", closeErr)
+			}
+		} else if err != nil {
+			taskOut.failed = true
 		}
 		if err != nil && timedOut(ctx, timeout) {
 			err = timeout

--- a/task_test.go
+++ b/task_test.go
@@ -2610,6 +2610,116 @@ Bye!
 	assert.Equal(t, strings.TrimSpace(buff.String()), expectedOutputOrder)
 }
 
+func TestOutputGroupRemainsPerCommandByDefault(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/output_group"
+	var buff bytes.Buffer
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+		task.WithSilent(true),
+	)
+	require.NoError(t, e.Setup())
+
+	require.NoError(t, e.Run(t.Context(), &task.Call{Task: "multi"}))
+	expectedOutput := strings.TrimSpace(`
+::group::multi
+first
+::endgroup::
+::group::multi
+second
+::endgroup::
+`)
+	assert.Equal(t, expectedOutput, strings.TrimSpace(buff.String()))
+}
+
+func TestOutputGroupByTask(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/output_group_by_task"
+	var buff bytes.Buffer
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
+	require.NoError(t, e.Setup())
+
+	require.NoError(t, e.Run(t.Context(), &task.Call{Task: "multi"}))
+	expectedMulti := strings.TrimSpace(`
+::group::multi
+first
+second
+::endgroup::
+`)
+	assert.Equal(t, expectedMulti, strings.TrimSpace(buff.String()))
+
+	buff.Reset()
+	require.NoError(t, e.Run(t.Context(), &task.Call{Task: "deferred"}))
+	expectedDeferred := strings.TrimSpace(`
+::group::deferred
+first
+second
+deferred
+::endgroup::
+`)
+	assert.Equal(t, expectedDeferred, strings.TrimSpace(buff.String()))
+
+	buff.Reset()
+	require.NoError(t, e.Run(t.Context(), &task.Call{Task: "parent"}))
+	expectedParent := strings.TrimSpace(`
+::group::child
+child
+::endgroup::
+::group::parent
+parent-before
+parent-after
+::endgroup::
+`)
+	assert.Equal(t, expectedParent, strings.TrimSpace(buff.String()))
+
+	var parallelBuff SyncBuffer
+	parallelExecutor := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&parallelBuff),
+		task.WithStderr(&parallelBuff),
+	)
+	require.NoError(t, parallelExecutor.Setup())
+	require.NoError(t, parallelExecutor.Run(t.Context(), &task.Call{Task: "parallel"}))
+
+	parallelOutput := parallelBuff.buf.String()
+	blocks := strings.Split(strings.TrimSpace(parallelOutput), "::group::")
+	require.Len(t, blocks, 3)
+	for _, block := range blocks[1:] {
+		assert.Equal(t, 1, strings.Count(block, "::endgroup::"))
+		assert.False(t, strings.Contains(block, "dep-one-first") && strings.Contains(block, "dep-two-first"))
+	}
+	assert.Contains(t, parallelOutput, "dep-one-first\ndep-one-second")
+	assert.Contains(t, parallelOutput, "dep-two-first\ndep-two-second")
+}
+
+func TestOutputGroupByTaskErrorOnly(t *testing.T) {
+	t.Parallel()
+
+	const dir = "testdata/output_group_by_task_error_only"
+	var buff bytes.Buffer
+	e := task.NewExecutor(
+		task.WithDir(dir),
+		task.WithStdout(&buff),
+		task.WithStderr(&buff),
+	)
+	require.NoError(t, e.Setup())
+
+	require.NoError(t, e.Run(t.Context(), &task.Call{Task: "passing"}))
+	assert.Empty(t, buff.String())
+
+	buff.Reset()
+	require.Error(t, e.Run(t.Context(), &task.Call{Task: "failing"}))
+	assert.Equal(t, "failing-first\nfailing-second\n", buff.String())
+}
+
 func TestOutputGroupErrorOnlySwallowsOutputOnSuccess(t *testing.T) {
 	t.Parallel()
 

--- a/task_test.go
+++ b/task_test.go
@@ -2718,6 +2718,14 @@ func TestOutputGroupByTaskErrorOnly(t *testing.T) {
 	buff.Reset()
 	require.Error(t, e.Run(t.Context(), &task.Call{Task: "failing"}))
 	assert.Equal(t, "failing-first\nfailing-second\n", buff.String())
+
+	buff.Reset()
+	require.NoError(t, e.Run(t.Context(), &task.Call{Task: "ignored-command"}))
+	assert.Empty(t, buff.String())
+
+	buff.Reset()
+	require.NoError(t, e.Run(t.Context(), &task.Call{Task: "ignored-task"}))
+	assert.Equal(t, "child-failing-first\nchild-failing-second\n", buff.String())
 }
 
 func TestOutputGroupErrorOnlySwallowsOutputOnSuccess(t *testing.T) {

--- a/taskfile/ast/output.go
+++ b/taskfile/ast/output.go
@@ -54,6 +54,7 @@ func (s *Output) UnmarshalYAML(node *yaml.Node) error {
 type OutputGroup struct {
 	Begin, End string
 	ErrorOnly  bool `yaml:"error_only"`
+	ByTask     bool `yaml:"by_task"`
 }
 
 // IsSet returns true if and only if a custom output style is set.

--- a/taskfile/ast/output_test.go
+++ b/taskfile/ast/output_test.go
@@ -1,0 +1,60 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+
+	"github.com/go-task/task/v3/taskfile/ast"
+)
+
+func TestOutputParse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		expect  ast.Output
+	}{
+		{
+			name:    "scalar group output",
+			content: "group",
+			expect:  ast.Output{Name: "group"},
+		},
+		{
+			name: "group output options",
+			content: `group:
+  begin: '::group::{{.TASK}}'
+  end: '::endgroup::'
+  error_only: true
+  by_task: true
+`,
+			expect: ast.Output{
+				Name: "group",
+				Group: ast.OutputGroup{
+					Begin:     "::group::{{.TASK}}",
+					End:       "::endgroup::",
+					ErrorOnly: true,
+					ByTask:    true,
+				},
+			},
+		},
+		{
+			name:    "group output defaults",
+			content: "group: {}\n",
+			expect:  ast.Output{Name: "group"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var actual ast.Output
+			require.NoError(t, yaml.Unmarshal([]byte(test.content), &actual))
+			assert.Equal(t, test.expect, actual)
+		})
+	}
+}

--- a/testdata/output_group/Taskfile.yml
+++ b/testdata/output_group/Taskfile.yml
@@ -9,6 +9,12 @@ tasks:
   hello:
     cmds:
       - echo 'Hello!'
+
+  multi:
+    cmds:
+      - echo 'first'
+      - echo 'second'
+
   bye:
     deps:
       - hello

--- a/testdata/output_group_by_task/Taskfile.yml
+++ b/testdata/output_group_by_task/Taskfile.yml
@@ -1,0 +1,44 @@
+version: '3'
+
+silent: true
+
+output:
+  group:
+    begin: '::group::{{ .TASK }}'
+    end: '::endgroup::'
+    by_task: true
+
+tasks:
+  multi:
+    cmds:
+      - echo 'first'
+      - echo 'second'
+
+  deferred:
+    cmds:
+      - defer: echo 'deferred'
+      - echo 'first'
+      - echo 'second'
+
+  child:
+    cmds:
+      - echo 'child'
+
+  parent:
+    cmds:
+      - echo 'parent-before'
+      - task: child
+      - echo 'parent-after'
+
+  parallel:
+    deps: [dep-one, dep-two]
+
+  dep-one:
+    cmds:
+      - echo 'dep-one-first'
+      - echo 'dep-one-second'
+
+  dep-two:
+    cmds:
+      - echo 'dep-two-first'
+      - echo 'dep-two-second'

--- a/testdata/output_group_by_task_error_only/Taskfile.yml
+++ b/testdata/output_group_by_task_error_only/Taskfile.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+silent: true
+
+output:
+  group:
+    error_only: true
+    by_task: true
+
+tasks:
+  passing:
+    cmds:
+      - echo 'passing-first'
+      - echo 'passing-second'
+
+  failing:
+    cmds:
+      - echo 'failing-first'
+      - echo 'failing-second' && exit 1

--- a/testdata/output_group_by_task_error_only/Taskfile.yml
+++ b/testdata/output_group_by_task_error_only/Taskfile.yml
@@ -17,3 +17,21 @@ tasks:
     cmds:
       - echo 'failing-first'
       - echo 'failing-second' && exit 1
+
+  ignored-command:
+    cmds:
+      - echo 'ignored-command-first'
+      - cmd: echo 'ignored-command-failure' && exit 1
+        ignore_error: true
+      - echo 'ignored-command-last'
+
+  child-failing:
+    cmds:
+      - echo 'child-failing-first'
+      - echo 'child-failing-second' && exit 1
+
+  ignored-task:
+    cmds:
+      - task: child-failing
+        ignore_error: true
+      - echo 'ignored-task-parent'

--- a/website/src/latest/docs/guide.md
+++ b/website/src/latest/docs/guide.md
@@ -2710,7 +2710,27 @@ tasks:
 
 The `group` output will print the entire output of a command once after it
 finishes, so you will not have live feedback for commands that take a long time
-to run.
+to run. By default, each command in a task is placed in its own group.
+
+To place all of a task's commands in one group, set `by_task: true` under the
+`group` output options:
+
+```yaml
+version: '3'
+
+output:
+  group:
+    by_task: true
+
+tasks:
+  # ...
+```
+
+Task-level grouping combines the output of the task's shell commands, including
+deferred commands, and prints it as one block when the task finishes. Dependencies
+and tasks called from a command remain separate task groups. The option is
+intended for non-interactive commands; tasks with `interactive: true` continue
+to use real-time interleaved output.
 
 When using the `group` output, you can optionally provide a templated message to
 print at the start and end of the group. This can be useful for instructing CI

--- a/website/src/latest/docs/reference/cli.md
+++ b/website/src/latest/docs/reference/cli.md
@@ -268,6 +268,18 @@ Message template to print after grouped output.
 task test --output group --output-group-end "::endgroup::"
 ```
 
+#### `--output-group-by-task`
+
+Group all shell command output from each task into one block instead of creating
+one group per command. This option only applies to `--output group`; dependencies
+and tasks called from a command remain separate groups.
+
+- **Environment variable**: [`TASK_OUTPUT_GROUP_BY_TASK`](./environment.md#task-output-group-by-task)
+
+```bash
+task test --output group --output-group-by-task
+```
+
 #### `--output-group-error-only`
 
 Only show command output on non-zero exit codes.

--- a/website/src/latest/docs/reference/environment.md
+++ b/website/src/latest/docs/reference/environment.md
@@ -114,6 +114,15 @@ files > defaults.
 - **CLI equivalent**:
   [`--output-group-error-only`](./cli.md#--output-group-error-only)
 
+### `TASK_OUTPUT_GROUP_BY_TASK`
+
+- **Type**: `boolean` (`true`, `false`, `1`, `0`)
+- **Default**: `false`
+- **Description**: Group all shell command output from each task into one block
+  instead of one group per command. Only applies when the output style is
+  `group`.
+- **CLI equivalent**: [`--output-group-by-task`](./cli.md#--output-group-by-task)
+
 ### `TASK_TEMP_DIR`
 
 Defines the location of Task's temporary directory which is used for storing

--- a/website/src/latest/docs/reference/schema.md
+++ b/website/src/latest/docs/reference/schema.md
@@ -42,6 +42,7 @@ output:
     begin: "::group::{{.TASK}}"
     end: "::endgroup::"
     error_only: false
+    by_task: true
 ```
 
 ### `method`

--- a/website/src/next/docs/guide.md
+++ b/website/src/next/docs/guide.md
@@ -2712,7 +2712,27 @@ tasks:
 
 The `group` output will print the entire output of a command once after it
 finishes, so you will not have live feedback for commands that take a long time
-to run.
+to run. By default, each command in a task is placed in its own group.
+
+To place all of a task's commands in one group, set `by_task: true` under the
+`group` output options:
+
+```yaml
+version: '3'
+
+output:
+  group:
+    by_task: true
+
+tasks:
+  # ...
+```
+
+Task-level grouping combines the output of the task's shell commands, including
+deferred commands, and prints it as one block when the task finishes. Dependencies
+and tasks called from a command remain separate task groups. The option is
+intended for non-interactive commands; tasks with `interactive: true` continue
+to use real-time interleaved output.
 
 When using the `group` output, you can optionally provide a templated message to
 print at the start and end of the group. This can be useful for instructing CI

--- a/website/src/next/docs/reference/cli.md
+++ b/website/src/next/docs/reference/cli.md
@@ -268,6 +268,19 @@ Message template to print after grouped output.
 task test --output group --output-group-end "::endgroup::"
 ```
 
+#### `--output-group-by-task`
+
+Group all shell command output from each task into one block instead of creating
+one group per command. This option only applies to `--output group`; dependencies
+and tasks called from a command remain separate groups.
+
+- **Environment variable**:
+  [`TASK_OUTPUT_GROUP_BY_TASK`](./environment.md#task-output-group-by-task)
+
+```bash
+task test --output group --output-group-by-task
+```
+
 #### `--output-group-error-only`
 
 Only show command output on non-zero exit codes.

--- a/website/src/next/docs/reference/environment.md
+++ b/website/src/next/docs/reference/environment.md
@@ -114,6 +114,16 @@ files > defaults.
 - **CLI equivalent**:
   [`--output-group-error-only`](./cli.md#output-group-error-only)
 
+### `TASK_OUTPUT_GROUP_BY_TASK`
+
+- **Type**: `boolean` (`true`, `false`, `1`, `0`)
+- **Default**: `false`
+- **Description**: Group all shell command output from each task into one block
+  instead of one group per command. Only applies when the output style is
+  `group`.
+- **CLI equivalent**:
+  [`--output-group-by-task`](./cli.md#--output-group-by-task)
+
 ### `TASK_TEMP_DIR`
 
 Defines the location of Task's temporary directory which is used for storing

--- a/website/src/next/docs/reference/schema.md
+++ b/website/src/next/docs/reference/schema.md
@@ -42,6 +42,7 @@ output:
     begin: "::group::{{.TASK}}"
     end: "::endgroup::"
     error_only: false
+    by_task: true
 ```
 
 ### `method`

--- a/website/src/public/next-schema.json
+++ b/website/src/public/next-schema.json
@@ -707,6 +707,11 @@
               "description": "Swallows command output on zero exit code",
               "type": "boolean",
               "default": false
+            },
+            "by_task": {
+              "description": "Groups all shell command output from each task into one block instead of one group per command",
+              "type": "boolean",
+              "default": false
             }
           }
         }
@@ -768,7 +773,7 @@
           ]
         },
         "output": {
-          "description": "Defines how the STDOUT and STDERR are printed when running tasks in parallel. The interleaved output prints lines in real time (default). The group output will print the entire output of a command once, after it finishes, so you won't have live feedback for commands that take a long time to run. The prefix output will prefix every line printed by a command with [task-name] as the prefix, but you can customize the prefix for a command with the prefix: attribute.",
+          "description": "Defines how the STDOUT and STDERR are printed when running tasks in parallel. The interleaved output prints lines in real time (default). The group output prints the entire output of each command once after it finishes, so you won't have live feedback for commands that take a long time to run. By default, each command in a task gets its own group; set group.by_task to group all shell command output from a task into one block. The prefix output will prefix every line printed by a command with [task-name] as the prefix, but you can customize the prefix for a command with the prefix: attribute.",
           "anyOf": [
             { "$ref": "#/definitions/outputString" },
             { "$ref": "#/definitions/outputObject" }

--- a/website/src/public/schema.json
+++ b/website/src/public/schema.json
@@ -707,6 +707,11 @@
               "description": "Swallows command output on zero exit code",
               "type": "boolean",
               "default": false
+            },
+            "by_task": {
+              "description": "Groups all shell command output from each task into one block instead of one group per command",
+              "type": "boolean",
+              "default": false
             }
           }
         }
@@ -768,7 +773,7 @@
           ]
         },
         "output": {
-          "description": "Defines how the STDOUT and STDERR are printed when running tasks in parallel. The interleaved output prints lines in real time (default). The group output will print the entire output of a command once, after it finishes, so you won't have live feedback for commands that take a long time to run. The prefix output will prefix every line printed by a command with [task-name] as the prefix, but you can customize the prefix for a command with the prefix: attribute.",
+          "description": "Defines how the STDOUT and STDERR are printed when running tasks in parallel. The interleaved output prints lines in real time (default). The group output prints the entire output of each command once after it finishes, so you won't have live feedback for commands that take a long time to run. By default, each command in a task gets its own group; set group.by_task to group all shell command output from a task into one block. The prefix output will prefix every line printed by a command with [task-name] as the prefix, but you can customize the prefix for a command with the prefix: attribute.",
           "anyOf": [
             { "$ref": "#/definitions/outputString" },
             { "$ref": "#/definitions/outputObject" }


### PR DESCRIPTION
## Description

Add support for extending the grouping in tasks from just the grouping of each individual cmd output to a single grouping across the entire `task` output for all `cmds`. This nonetheless only applies to all `cmd` entries called within a `task`. If a `task` calls another `task`, that `task`'s output will be grouped under that `task`'s grouping.

This should make the output much easier to read under tools such as GitHub Workflows and GitLab pipelines.

Closes #2941

> [!NOTE]
> I noticed that #2979 splits the site into `next` and `latest` folders, but `CONTRIBUTING.md` doesn't say which version to update; therefore, I updated both folders to keep them in sync. Please let me know if this is incorrect. 

## AI Declaration

Much of the code and documentation was written using Kiro through ChatGPT 5.6 Luna and reviewed with Qwen3 Coder Next. I fully reviewed all code and documentation changes and made any final necessary updates as needed before committing.

## Checklist

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/).
- [x] I have disclosed the use of any AI-generated content in this pull request per the [AI Usage Policy](https://taskfile.dev/docs/contributing#ai-usage-policy).
- [x] I fully understand the changes and have hand-written the description (No AI) of this pull request.