### PR TITLE
feat(release): announce releases on discord

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
           GH_GORELEASER_TOKEN: ${{secrets.GH_GORELEASER_TOKEN}}
           GORELEASER_KEY: ${{secrets.GORELEASER_KEY}}
           CLOUDSMITH_TOKEN: ${{secrets.CLOUDSMITH_TOKEN}}
+          DISCORD_WEBHOOK_ID: ${{secrets.DISCORD_WEBHOOK_ID}}
+          DISCORD_WEBHOOK_TOKEN: ${{secrets.DISCORD_WEBHOOK_TOKEN}}
 
       - name: Deploy Website
         shell: bash

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -184,3 +184,12 @@ cloudsmiths:
         - "alpine/any-version"
     component: main
     republish: true
+
+announce:
+  skip: '{{ .IsNightly }}'
+  discord:
+    author: Task
+    icon_url: https://taskfile.dev/img/logo.png
+    # #43aba2, the primary color of the website.
+    color: '4434850'
+    message_template: '[Task {{ .Tag }}]({{ .ReleaseURL }}) — A new release is available! Check the changelog for details.'

--- a/website/src/next/docs/releasing.md
+++ b/website/src/next/docs/releasing.md
@@ -56,6 +56,10 @@ A single package manager still require manual steps:
   * Trigger a new build on [Snapcraft -> Builds][snapcraftbuilds]
   * Once finished, move the new build to "stable" on [Snapcraft -> Releases][snapcraftreleases]
 
+Once the release is published, GoReleaser announces it on the
+[Discord server](https://discord.gg/6TY36E39UK). Nightly releases are not
+announced.
+
 These package managers are updated automatically by the community:
 
 * [Scoop](https://github.com/ScoopInstaller/Main/blob/master/bucket/task.json)


### PR DESCRIPTION
## Description

The release are now annonced in a Discord channel. We use goreleaser for this.

Example : 

<img width="620" height="144" alt="CleanShot 2026-08-19 at 13 02 20" src="https://github.com/user-attachments/assets/8850c8b1-0811-4533-a82e-0d42e739641b" />


## Checklist

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/).
- [x] I have disclosed the use of any AI-generated content in this pull request per the [AI Usage Policy](https://taskfile.dev/docs/contributing#ai-usage-policy).
- [x] I fully understand the changes and have hand-written the description (No AI) of this pull request.