### PR TITLE
docs: add missing exit codes 108-111 and 208 to CLI reference

### DIFF
--- a/website/src/next/docs/reference/cli.md
+++ b/website/src/next/docs/reference/cli.md
@@ -457,6 +457,10 @@ Task uses specific exit codes to indicate different types of errors:
 - **105** - Remote Taskfile fetch not secure
 - **106** - No cache for remote Taskfile in offline mode
 - **107** - No schema version defined in Taskfile
+- **108** - Remote Taskfile network timeout
+- **109** - Invalid Taskfile
+- **110** - Taskfile cycle detected
+- **111** - Taskfile does not match checksum
 
 ### Task Errors (200-255)
 
@@ -468,6 +472,7 @@ Task uses specific exit codes to indicate different types of errors:
 - **205** - Task cancelled by user
 - **206** - Missing required variables
 - **207** - Variable has incorrect value
+- **208** - Task timed out
 
 ::: info
 


### PR DESCRIPTION
## Description

Documents exit codes 108–111 and 208 in the CLI reference. They already exist in `errors/errors.go` (`CodeTaskfileNetworkTimeout` through `CodeTaskfileDoesNotMatchChecksum`, plus `CodeTaskTimedOut`) but were missing from `website/src/next/docs/reference/cli.md`.

## Checklist

- [x] Code compiles and passes existing tests (`go test ./...`)
- [x] Docs-only change; no behavior change
- [ ] Tests added/updated (N/A — docs)

Disclosure: I used an AI assistant to help find the drift and draft this change. I've checked the codes against `errors/errors.go` and I'm happy to revise anything.
