### PR TITLE
fix: fall back to the include dir when no taskfile is specified

### DIFF
--- a/taskfile/reader.go
+++ b/taskfile/reader.go
@@ -339,7 +339,12 @@ func (r *Reader) include(ctx context.Context, node Node) error {
 				return err
 			}
 
-			entrypoint, err := node.ResolveEntrypoint(include.Taskfile)
+			// If no taskfile is specified, look for one in the include's dir
+			taskfile := include.Taskfile
+			if taskfile == "" {
+				taskfile = include.Dir
+			}
+			entrypoint, err := node.ResolveEntrypoint(taskfile)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description

This change fixes task-file discovery when task files are included from the includes directory.

The reader now falls back to the appropriate include-directory path when resolving an included task file that is not found through the existing lookup path.

The change was verified with the repository test suite in the pipeline environment, and the resulting patch contains only the intended reader.go change. No unrelated files or test scaffolding are included in the final commit.

This PR addresses the behavior reported in #2878.

The code change in this PR was generated with the assistance of an engineering system I created, which I reviewed, understood, and validated.

## Checklist

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/).
- [x] I have disclosed the use of any AI-generated content in this pull request per the [AI Usage Policy](https://taskfile.dev/docs/contributing#ai-usage-policy).
- [x] I fully understand the changes and have hand-written the description (No AI) of this pull request.
