### PR TITLE
This change normalizes filesystem event paths before comparing them with the configured watch sources

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -101,7 +101,7 @@ func (e *Executor) watchTasks(calls ...*Call) error {
 							return
 						}
 
-						if !event.Has(fsnotify.Remove) && !slices.Contains(files, event.Name) {
+						if !event.Has(fsnotify.Remove) && !slices.Contains(files, filepath.ToSlash(event.Name)) {
 							relPath, _ := filepath.Rel(baseDir, event.Name)
 							e.Logger.VerboseErrf(logger.Magenta, "task: skipped for file not in sources: %s\n", relPath)
 							return


### PR DESCRIPTION
## Description

This change normalizes filesystem event paths before comparing them with the configured watch sources.

On Windows, filesystem event paths can use path separators that differ from the slash-separated paths used by the configured sources. The change applies filepath.ToSlash to the event path so the comparison uses a consistent representation.

The package tests pass in the pipeline environment.

The relevant verification environment was macOS, so this PR does not independently reproduce the reported Windows behavior. In particular, the implementation assumes the collected source paths are already represented with slash separators on Windows.

This PR addresses the path-normalization behavior described in #2862.

The code change in this PR was generated with the assistance of an engineering system I created, which I reviewed, understood, and validated.

## Checklist

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/).
- [x] I have disclosed the use of any AI-generated content in this pull request per the [AI Usage Policy](https://taskfile.dev/docs/contributing#ai-usage-policy).
- [x] I fully understand the changes and have hand-written the description (No AI) of this pull request.
