### PR TITLE
docs: Clarify `internal` and `desc` behaviors

### DIFF
--- a/website/src/next/docs/reference/schema.md
+++ b/website/src/next/docs/reference/schema.md
@@ -278,7 +278,8 @@ includes:
 
 - **Type**: `bool`
 - **Default**: `false`
-- **Description**: Hide included tasks from command line and `--list`
+- **Description**: Makes a task inaccessible from the command line and hidden
+  from `--list`, restricting its execution to other tasks only.
 
 ```yaml
 includes:
@@ -529,7 +530,9 @@ tasks:
 #### `desc`
 
 - **Type**: `string`
-- **Description**: Short description shown in `--list`
+- **Description**: Short description shown in `--list`. If omitted, the task
+  will not be listed in `--list`, but will remain publicly callable from the
+  command line.
 
 ```yaml
 tasks:


### PR DESCRIPTION
<!--
Thanks for your pull request, we really appreciate contributions!
Please understand that it may take some time to be reviewed.
-->

## Description

docs: Clarify `internal` and `desc` behaviors
- Explain that `internal` prevents direct command-line access.
- Clarify that omitting `desc` hides a task from the list while keeping it callable.

## Checklist

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/).
- [x] I have disclosed the use of any AI-generated content in this pull request per the [AI Usage Policy](https://taskfile.dev/docs/contributing#ai-usage-policy).
- [x] I fully understand the changes and have hand-written the description (No AI) of this pull request.
