### PR TITLE
Handle quotes in fingerprint source paths

### DIFF
--- a/internal/execext/exec.go
+++ b/internal/execext/exec.go
@@ -96,6 +96,7 @@ func escape(s string) string {
 	s = strings.ReplaceAll(s, "&", `\&`)
 	s = strings.ReplaceAll(s, "(", `\(`)
 	s = strings.ReplaceAll(s, ")", `\)`)
+	s = strings.ReplaceAll(s, "'", `\'`)
 	return s
 }
 

--- a/internal/fingerprint/glob_test.go
+++ b/internal/fingerprint/glob_test.go
@@ -1,0 +1,25 @@
+package fingerprint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-task/task/v3/taskfile/ast"
+)
+
+func TestGlobsInDirectoryContainingQuote(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "test'd")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+	file := filepath.Join(dir, "test.in")
+	require.NoError(t, os.WriteFile(file, nil, 0o644))
+
+	files, err := Globs(dir, []*ast.Glob{{Glob: "test.in"}}, false)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{filepath.ToSlash(file)}, files)
+}


### PR DESCRIPTION
## Context

Fingerprint source globs are expanded after Task joins them to the task directory. The existing path escaping handled spaces and several shell metacharacters, but not a single quote, so an absolute directory such as `test'd` was parsed as unterminated shell syntax. The glob error is swallowed by the fingerprint layer, leaving no source matches and causing the task to rebuild every time.

Fixes https://github.com/go-task/task/issues/2874

## Changes

- escape single quotes alongside the other literal path characters before shell expansion
- add a regression that fingerprints a file below a quoted directory name

## User impact

`sources` and `generates` work normally when any directory in their absolute path contains a single quote.

## Verification

- Regression on the base revision: expected the source path, received an empty result
- `go test ./internal/fingerprint -count=1`: passed
- `go vet ./...`: passed
- Committed Go files are unchanged by the configured formatter
- `go test ./... -count=1`: all changed-package tests passed; the root package retains the same 16 Windows-only failures seen on clean `main` from unavailable POSIX commands and symlink behavior

## AI usage

OpenAI Codex assisted with tracing, implementation, and tests. The complete two-file diff was inspected and the issue's reproducer was verified before submission.