### PR TITLE
SmartJoin incorrectly treats relative paths containing special variable names as special paths

### DIFF
--- a/internal/filepathext/filepathext.go
+++ b/internal/filepathext/filepathext.go
@@ -3,7 +3,7 @@ package filepathext
 import (
 	"os"
 	"path/filepath"
-	"strings"
+	"regexp"
 )
 
 // SmartJoin joins two paths, but only if the second is not already an
@@ -25,29 +25,11 @@ func IsAbs(path string) bool {
 	return filepath.IsAbs(path)
 }
 
-var knownAbsDirs = []string{
-	".ROOT_DIR",
-	".TASKFILE_DIR",
-	".USER_WORKING_DIR",
-}
+// Match special directory variables only within a template action.
+var specialDirRE = regexp.MustCompile(`\{\{[^{}]*\.(?:ROOT_DIR|TASKFILE_DIR|USER_WORKING_DIR)[^{}]*\}\}`)
 
 func isSpecialDir(dir string) bool {
-	for {
-		_, action, ok := strings.Cut(dir, "{{")
-		if !ok {
-			return false
-		}
-		action, dir, ok = strings.Cut(action, "}}")
-		if !ok {
-			return false
-		}
-		// Only inspect template actions, not literal path components.
-		for _, d := range knownAbsDirs {
-			if strings.Contains(action, d) {
-				return true
-			}
-		}
-	}
+	return specialDirRE.MatchString(dir)
 }
 
 // TryAbsToRel tries to convert an absolute path to relative based on the

--- a/internal/filepathext/filepathext.go
+++ b/internal/filepathext/filepathext.go
@@ -32,12 +32,22 @@ var knownAbsDirs = []string{
 }
 
 func isSpecialDir(dir string) bool {
-	for _, d := range knownAbsDirs {
-		if strings.Contains(dir, d) {
-			return true
+	for {
+		_, action, ok := strings.Cut(dir, "{{")
+		if !ok {
+			return false
+		}
+		action, dir, ok = strings.Cut(action, "}}")
+		if !ok {
+			return false
+		}
+		// Only inspect template actions, not literal path components.
+		for _, d := range knownAbsDirs {
+			if strings.Contains(action, d) {
+				return true
+			}
 		}
 	}
-	return false
 }
 
 // TryAbsToRel tries to convert an absolute path to relative based on the

--- a/internal/filepathext/filepathext.go
+++ b/internal/filepathext/filepathext.go
@@ -25,8 +25,9 @@ func IsAbs(path string) bool {
 	return filepath.IsAbs(path)
 }
 
-// Match special directory variables only within a template action.
-var specialDirRE = regexp.MustCompile(`\{\{[^{}]*\.(?:ROOT_DIR|TASKFILE_DIR|USER_WORKING_DIR)[^{}]*\}\}`)
+// Heuristically match special directory names within template actions, without
+// matching prefixes of longer identifiers. This does not parse template syntax.
+var specialDirRE = regexp.MustCompile(`\{\{[^{}]*\.(?:ROOT_DIR|TASKFILE_DIR|USER_WORKING_DIR)(?:[^\p{L}\p{Nd}_{}][^{}]*)?\}\}`)
 
 func isSpecialDir(dir string) bool {
 	return specialDirRE.MatchString(dir)

--- a/internal/filepathext/filepathext_test.go
+++ b/internal/filepathext/filepathext_test.go
@@ -18,6 +18,8 @@ func TestSmartJoinRelativePathContainingSpecialVariableName(t *testing.T) {
 				filepath.Join("project"+variable, "file.txt"),
 				filepath.Join(variable, "file.txt"),
 				filepath.Join("{{.PROJECT}}"+variable, "file.txt"),
+				filepath.Join("{{.PROJECT}}"+variable+"{{.SUFFIX}}", "file.txt"),
+				filepath.Join("{{ "+variable, "file.txt"),
 			} {
 				require.False(t, IsAbs(relative), relative)
 				require.Equal(t, filepath.Join(base, relative), SmartJoin(base, relative))
@@ -38,8 +40,25 @@ func TestSmartJoinAbsoluteAndTemplatePaths(t *testing.T) {
 		"{{- .USER_WORKING_DIR -}}/file.txt",
 		"{{.ROOT_DIR | toSlash}}/file.txt",
 		"{{.PROJECT}}/{{.ROOT_DIR}}/file.txt",
+		"{{\n.TASKFILE_DIR\n}}/file.txt",
+		`{{joinPath .ROOT_DIR "src"}}/file.txt`,
 	} {
 		require.True(t, IsAbs(path), path)
 		require.Equal(t, path, SmartJoin(base, path))
+	}
+}
+
+func TestSmartJoinUnrelatedTemplatePaths(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	for _, path := range []string{
+		"{{.PROJECT}}/file.txt",
+		"{{XROOT_DIR}}/file.txt",
+		"{{XTASKFILE_DIR}}/file.txt",
+		"{{XUSER_WORKING_DIR}}/file.txt",
+	} {
+		require.False(t, IsAbs(path), path)
+		require.Equal(t, filepath.Join(base, path), SmartJoin(base, path))
 	}
 }

--- a/internal/filepathext/filepathext_test.go
+++ b/internal/filepathext/filepathext_test.go
@@ -39,6 +39,8 @@ func TestSmartJoinAbsoluteAndTemplatePaths(t *testing.T) {
 		"{{ .TASKFILE_DIR }}/file.txt",
 		"{{- .USER_WORKING_DIR -}}/file.txt",
 		"{{.ROOT_DIR | toSlash}}/file.txt",
+		"{{.ROOT_DIR|toSlash}}/file.txt",
+		"{{(.ROOT_DIR)}}/file.txt",
 		"{{.PROJECT}}/{{.ROOT_DIR}}/file.txt",
 		"{{\n.TASKFILE_DIR\n}}/file.txt",
 		`{{joinPath .ROOT_DIR "src"}}/file.txt`,
@@ -60,5 +62,22 @@ func TestSmartJoinUnrelatedTemplatePaths(t *testing.T) {
 	} {
 		require.False(t, IsAbs(path), path)
 		require.Equal(t, filepath.Join(base, path), SmartJoin(base, path))
+	}
+}
+
+func TestSmartJoinTemplateVariableNameSuffixes(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	for _, variable := range []string{".ROOT_DIR", ".TASKFILE_DIR", ".USER_WORKING_DIR"} {
+		for _, suffix := range []string{"_SUFFIX", "_EXTRA", "2", "suffix", "变量"} {
+			t.Run(variable+suffix, func(t *testing.T) {
+				t.Parallel()
+
+				path := "{{" + variable + suffix + "}}/file.txt"
+				require.False(t, IsAbs(path), path)
+				require.Equal(t, filepath.Join(base, path), SmartJoin(base, path))
+			})
+		}
 	}
 }

--- a/internal/filepathext/filepathext_test.go
+++ b/internal/filepathext/filepathext_test.go
@@ -1,0 +1,45 @@
+package filepathext
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSmartJoinRelativePathContainingSpecialVariableName(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	for _, variable := range []string{".ROOT_DIR", ".TASKFILE_DIR", ".USER_WORKING_DIR"} {
+		t.Run(variable, func(t *testing.T) {
+			t.Parallel()
+			for _, relative := range []string{
+				filepath.Join("project"+variable, "file.txt"),
+				filepath.Join(variable, "file.txt"),
+				filepath.Join("{{.PROJECT}}"+variable, "file.txt"),
+			} {
+				require.False(t, IsAbs(relative), relative)
+				require.Equal(t, filepath.Join(base, relative), SmartJoin(base, relative))
+			}
+		})
+	}
+}
+
+func TestSmartJoinAbsoluteAndTemplatePaths(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	absolute := filepath.Join(t.TempDir(), "file.txt")
+	for _, path := range []string{
+		absolute,
+		"{{.ROOT_DIR}}/file.txt",
+		"{{ .TASKFILE_DIR }}/file.txt",
+		"{{- .USER_WORKING_DIR -}}/file.txt",
+		"{{.ROOT_DIR | toSlash}}/file.txt",
+		"{{.PROJECT}}/{{.ROOT_DIR}}/file.txt",
+	} {
+		require.True(t, IsAbs(path), path)
+		require.Equal(t, path, SmartJoin(base, path))
+	}
+}

--- a/taskfile/node_file_test.go
+++ b/taskfile/node_file_test.go
@@ -1,0 +1,33 @@
+package taskfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileNodeResolveLiteralSpecialDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	entrypoint := filepath.Join(dir, "Taskfile.yml")
+	require.NoError(t, os.WriteFile(entrypoint, []byte("version: '3'\n"), 0o600))
+	node, err := NewFileNode(entrypoint, "")
+	require.NoError(t, err)
+
+	for _, name := range []string{"project.ROOT_DIR", "project.TASKFILE_DIR", "project.USER_WORKING_DIR"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resolvedDir, err := node.ResolveDir(name)
+			require.NoError(t, err)
+			require.Equal(t, filepath.Join(dir, name), resolvedDir)
+
+			resolvedEntrypoint, err := node.ResolveEntrypoint(filepath.Join(name, "Taskfile.yml"))
+			require.NoError(t, err)
+			require.Equal(t, filepath.Join(dir, name, "Taskfile.yml"), resolvedEntrypoint)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3021

## Description

`SmartJoin` incorrectly treats ordinary relative paths containing special variable names such as `.ROOT_DIR` as absolute/special paths, causing them to bypass the base-directory join.

The path should be treated as a normal relative path and joined with `base`.

From looking at the implementation, this may be caused by `isSpecialDir` using `strings.Contains` to detect special variables. As a result, an ordinary directory name containing one of these strings can be matched even when the variable is not actually part of a `{{ ... }}` template expression.

A small portion of the code and tests was generated with assistance from Codex.

```text
Linux amd64 / Go 1.26.5
go test ./...                                      PASS

golangci-lint 2.13.0
fmt --diff (3 changed files)                       PASS
run --new-from-rev=385e5ad --timeout 5m             0 issues
run --timeout 5m                                  3 pre-existing gci issues:
  errors/error_taskfile_decode.go
  errors/errors.go
  errors/errors_task.go
```

## Checklist

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/).
- [x] I have disclosed the use of any AI-generated content in this pull request per the [AI Usage Policy](https://taskfile.dev/docs/contributing#ai-usage-policy).
- [x] I fully understand the changes and have hand-written the description (No AI) of this pull request.