### PR TITLE
fix: path normalisation in watcher

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -101,7 +101,7 @@ func (e *Executor) watchTasks(calls ...*Call) error {
 							return
 						}
 
-						if !event.Has(fsnotify.Remove) && !slices.Contains(files, event.Name) {
+						if !event.Has(fsnotify.Remove) && !slices.Contains(files, filepath.ToSlash(event.Name)) {
 							relPath, _ := filepath.Rel(baseDir, event.Name)
 							e.Logger.VerboseErrf(logger.Magenta, "task: skipped for file not in sources: %s\n", relPath)
 							return


### PR DESCRIPTION
## Description

Fixes #2862 by normalising the path strings that come from fsnotify before comparison.

## Checklist

- [x] I have read and followed the [Contribution Guide](https://taskfile.dev/contributing/).
- [x] I have disclosed the use of any AI-generated content in this pull request per the [AI Usage Policy](https://taskfile.dev/docs/contributing#ai-usage-policy).
- [x] I fully understand the changes and have hand-written the description (No AI) of this pull request.
